### PR TITLE
- added a variable 'absNLL' to the output tree of MultiDimFit

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -37,6 +37,10 @@ protected:
   static unsigned int              nOtherFloatingPoi_; // keep a count of other POIs that we're ignoring, for proper chisquare normalization
   static float                     deltaNLL_;
 
+  /** the absolute negative log likelihood (not the difference to the 
+      best fit as deltaNLL_) */
+  static double                    absNLL_;
+
   // options    
   static unsigned int points_, firstPoint_, lastPoint_;
   static bool floatOtherPOIs_;


### PR DESCRIPTION
to contain the absolute negative log likelihood ratio
  (not sure though it is filled for all methods, we used
  it with --algo=grid).

  We (Xiaohang and me) have used this for the width studies
  to compare different sets of parameters (scaling the sigmas of the
  Voigtians) to the SAME dataset and used it to detect overfitting
  of the data (due to mass peaks in the signal model which are
  too narrow and lead to a high local s/b ratio)

  Originally based on HiggsAnalysis-CombinedLimit-V03-01-09 but
  rebased on the latest head.
