### PR TITLE
fixed include guard

### DIFF
--- a/interface/HGGRooPdfs.h
+++ b/interface/HGGRooPdfs.h
@@ -13,8 +13,8 @@
  * with or without modification, are permitted according to the terms        *
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
-#ifndef ROO_EXPONENTIAL
-#define ROO_EXPONENTIAL
+#ifndef HiggsAnalysis_CombinedLimit_HGGRooPdfs_h
+#define HiggsAnalysis_CombinedLimit_HGGRooPdfs_h
 
 #include "RooAbsPdf.h"
 #include "RooRealProxy.h"


### PR DESCRIPTION
was conflicting with RooFits RooExponential.h (see cms-analysis/HiggsAnalysis-CombinedLimit#5 )
