### PR TITLE
Fix issue when combining datacards that have very low yields

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -55,12 +55,12 @@ for ich,fname in enumerate(args):
         for (p,e) in DC.exp[b].items(): # so that we get only self.DC.processes contributing to this bin
             if DC.isSignal[p] == False: continue
             #print "in DC.exp.items:b,p", b,p
-            expline.append("%.4f" % e)
+            expline.append("%.4f" % e) if (e == 0 or e > 1e-3) else expline.append("%.4g" % e)
             keyline.append((bout, p, DC.isSignal[p]))
         for (p,e) in DC.exp[b].items(): # so that we get only self.DC.processes contributing to this bin
             if DC.isSignal[p]: continue
             #print "in DC.exp.items:b,p", b,p
-            expline.append("%.4f" % e)
+            expline.append("%.4f" % e) if (e == 0 or e > 1e-3) else expline.append("%.4g" % e)
             keyline.append((bout, p, DC.isSignal[p]))
     # systematics
     for (lsyst,nofloat,pdf,pdfargs,errline) in DC.systs:


### PR DESCRIPTION
Currently combineCards truncate yields to 4 decimals, which can be a problem for some non-Higgs fits where the signal is normalized differently.
This patch fixes it
