### PR TITLE
fix crash on workspaces that didn't have discrete nuisances

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -649,6 +649,9 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
     //}
  
     CascadeMinimizerGlobalConfigs::O().pdfCategories = RooArgList();
-    TIterator *dp = discreteParameters->createIterator();
-    while (RooAbsArg *arg = (RooAbsArg*)dp->Next()) (CascadeMinimizerGlobalConfigs::O().pdfCategories).add(*arg);
+
+    if (discreteParameters != 0) {
+        TIterator *dp = discreteParameters->createIterator();
+        while (RooAbsArg *arg = (RooAbsArg*)dp->Next()) (CascadeMinimizerGlobalConfigs::O().pdfCategories).add(*arg);
+    }
 }

--- a/test/validation/reference.json
+++ b/test/validation/reference.json
@@ -1027,258 +1027,6 @@
         }, 
         "status": "done"
     },
-    "Asymm_Asymptotic": {
-        "comment": "all 12 jobs done", 
-        "results": {
-            "counting-B5p5-Obs6-Syst1040B.txt E025": { "comment": "", "limit": 3.3885947705780333, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst1040B.txt E159": { "comment": "", "limit": 4.5073589303488184, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst1040B.txt E500": { "comment": "", "limit": 6.2456880020000511, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst1040B.txt E839": { "comment": "", "limit": 8.6752678398673275, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst1040B.txt E975": { "comment": "", "limit": 11.526247867782963, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst1040B.txt Obs": { "comment": "", "limit": 6.5829289767554098, "limitErr": 0.029676078217295565, "status": "done", "t_real": 0.0053653162904083729 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt E025": { "comment": "", "limit": 3.8814744138864996, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt E159": { "comment": "", "limit": 5.1629656382215918, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt E500": { "comment": "", "limit": 7.1541390511990208, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt E839": { "comment": "", "limit": 9.9371073952030748, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt E975": { "comment": "", "limit": 13.202769648163555, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst4010B.txt Obs": { "comment": "", "limit": 7.6392065073201731, "limitErr": 0.021658043379001679, "status": "done", "t_real": 0.0052495477721095085 }
-        }, 
-        "status": "done"
-    }, 
-    "Counting_Asymptotic": {
-        "comment": "all 90 jobs done", 
-        "results": {
-            "counting-B5p5-Obs1-StatOnly.txt E025": { "comment": "", "limit": 3.2318540008053223, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-StatOnly.txt E159": { "comment": "", "limit": 4.29886928900281, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-StatOnly.txt E500": { "comment": "", "limit": 5.9567912729802286, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-StatOnly.txt E839": { "comment": "", "limit": 8.2739899499845873, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-StatOnly.txt E975": { "comment": "", "limit": 10.99309678726023, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-StatOnly.txt Obs": { "comment": "", "limit": 3.0481897878604411, "limitErr": 0.014177626919616326, "status": "done", "t_real": 0.0041098832152783871 }, 
-            "counting-B5p5-Obs1-Syst30B.txt E025": { "comment": "", "limit": 3.1210290477315645, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30B.txt E159": { "comment": "", "limit": 4.1514548367703643, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30B.txt E500": { "comment": "", "limit": 5.7525242754197867, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30B.txt E839": { "comment": "", "limit": 7.9902628547286456, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30B.txt E975": { "comment": "", "limit": 10.61612758157216, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30B.txt Obs": { "comment": "", "limit": 3.1377265287496039, "limitErr": 0.014456263356299903, "status": "done", "t_real": 0.0043653012253344059 }, 
-            "counting-B5p5-Obs1-Syst30C.txt E025": { "comment": "", "limit": 4.8948174150648658, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30C.txt E159": { "comment": "", "limit": 6.5108696914078186, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30C.txt E500": { "comment": "", "limit": 9.0218820694327508, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30C.txt E839": { "comment": "", "limit": 12.531404602177082, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30C.txt E975": { "comment": "", "limit": 16.649638748027193, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30C.txt Obs": { "comment": "", "limit": 4.3571905270792008, "limitErr": 0.021830812475482908, "status": "done", "t_real": 0.0065694688819348812 }, 
-            "counting-B5p5-Obs1-Syst30S.txt E025": { "comment": "", "limit": 3.5268007087689623, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30S.txt E159": { "comment": "", "limit": 4.6911943582792759, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30S.txt E500": { "comment": "", "limit": 6.5004222586479781, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30S.txt E839": { "comment": "", "limit": 9.0290940162153301, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30S.txt E975": { "comment": "", "limit": 11.996353031793591, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30S.txt Obs": { "comment": "", "limit": 3.3138627534858927, "limitErr": 0.014470400184366294, "status": "done", "t_real": 0.0063861650414764881 }, 
-            "counting-B5p5-Obs1-Syst30U.txt E025": { "comment": "", "limit": 3.439523505575397, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30U.txt E159": { "comment": "", "limit": 4.5751020817267509, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30U.txt E500": { "comment": "", "limit": 6.3395572931563429, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30U.txt E839": { "comment": "", "limit": 8.8056523935719877, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30U.txt E975": { "comment": "", "limit": 11.699481099525253, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs1-Syst30U.txt Obs": { "comment": "", "limit": 3.3888050501149651, "limitErr": 0.015544098722014787, "status": "done", "t_real": 0.0057669002562761307 }, 
-            "counting-B5p5-Obs11-StatOnly.txt E025": { "comment": "", "limit": 3.2318540008053223, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-StatOnly.txt E159": { "comment": "", "limit": 4.29886928900281, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-StatOnly.txt E500": { "comment": "", "limit": 5.9567912729802286, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-StatOnly.txt E839": { "comment": "", "limit": 8.2739899499845873, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-StatOnly.txt E975": { "comment": "", "limit": 10.99309678726023, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-StatOnly.txt Obs": { "comment": "", "limit": 11.992464207779257, "limitErr": 0.037967719451875048, "status": "done", "t_real": 0.0063738981261849403 }, 
-            "counting-B5p5-Obs11-Syst30B.txt E025": { "comment": "", "limit": 3.9454816100797809, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30B.txt E159": { "comment": "", "limit": 5.2481051803920948, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30B.txt E500": { "comment": "", "limit": 7.2721139063741189, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30B.txt E839": { "comment": "", "limit": 10.10097460513828, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30B.txt E975": { "comment": "", "limit": 13.420489044726196, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30B.txt Obs": { "comment": "", "limit": 12.396007020594494, "limitErr": 0.043304298421555032, "status": "done", "t_real": 0.0045018512755632401 }, 
-            "counting-B5p5-Obs11-Syst30C.txt E025": { "comment": "", "limit": 3.913879806164049, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30C.txt E159": { "comment": "", "limit": 5.2060698581601565, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30C.txt E500": { "comment": "", "limit": 7.2138670456778264, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30C.txt E839": { "comment": "", "limit": 10.020069648436957, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30C.txt E975": { "comment": "", "limit": 13.312996042563631, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30C.txt Obs": { "comment": "", "limit": 15.508925784945585, "limitErr": 0.049733253038581893, "status": "done", "t_real": 0.0056475005112588406 }, 
-            "counting-B5p5-Obs11-Syst30S.txt E025": { "comment": "", "limit": 3.5268007087422104, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30S.txt E159": { "comment": "", "limit": 4.6911943582436919, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30S.txt E500": { "comment": "", "limit": 6.5004222585986708, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30S.txt E839": { "comment": "", "limit": 9.0290940161468427, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30S.txt E975": { "comment": "", "limit": 11.996353031702597, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30S.txt Obs": { "comment": "", "limit": 13.823778299700486, "limitErr": 0.041346428455216966, "status": "done", "t_real": 0.006089500617235899 }, 
-            "counting-B5p5-Obs11-Syst30U.txt E025": { "comment": "", "limit": 4.3632815038692643, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30U.txt E159": { "comment": "", "limit": 5.8038441252555373, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30U.txt E500": { "comment": "", "limit": 8.0421817252041503, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30U.txt E839": { "comment": "", "limit": 11.170599693851267, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30U.txt E975": { "comment": "", "limit": 14.841628325458048, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs11-Syst30U.txt Obs": { "comment": "", "limit": 14.378473440795315, "limitErr": 0.044616687126286969, "status": "done", "t_real": 0.0043188175186514854 }, 
-            "counting-B5p5-Obs6-StatOnly.txt E025": { "comment": "", "limit": 3.2318540008053223, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-StatOnly.txt E159": { "comment": "", "limit": 4.29886928900281, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-StatOnly.txt E500": { "comment": "", "limit": 5.9567912729802286, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-StatOnly.txt E839": { "comment": "", "limit": 8.2739899499845873, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-StatOnly.txt E975": { "comment": "", "limit": 10.99309678726023, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-StatOnly.txt Obs": { "comment": "", "limit": 6.4496316698236642, "limitErr": 0.021026047066677656, "status": "done", "t_real": 0.0064939181320369244 }, 
-            "counting-B5p5-Obs6-Syst30B.txt E025": { "comment": "", "limit": 3.4968833168191789, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B.txt E159": { "comment": "", "limit": 4.6513995663648098, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B.txt E500": { "comment": "", "limit": 6.445280021643339, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B.txt E839": { "comment": "", "limit": 8.9525013854032398, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B.txt E975": { "comment": "", "limit": 11.894589528478029, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B.txt Obs": { "comment": "", "limit": 6.9050732562688921, "limitErr": 0.030660500335723651, "status": "done", "t_real": 0.004869349766522646 }, 
-            "counting-B5p5-Obs6-Syst30C.txt E025": { "comment": "", "limit": 4.3408998043128193, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C.txt E159": { "comment": "", "limit": 5.774072978157025, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C.txt E500": { "comment": "", "limit": 8.0009288986349176, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C.txt E839": { "comment": "", "limit": 11.113299470156923, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C.txt E975": { "comment": "", "limit": 14.765497352516178, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C.txt Obs": { "comment": "", "limit": 8.7157966109342517, "limitErr": 0.035546414496201884, "status": "done", "t_real": 0.0043000499717891216 }, 
-            "counting-B5p5-Obs6-Syst30S.txt E025": { "comment": "", "limit": 3.5268007087688096, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S.txt E159": { "comment": "", "limit": 4.6911943582790725, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S.txt E500": { "comment": "", "limit": 6.5004222586476974, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S.txt E839": { "comment": "", "limit": 9.0290940162149393, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S.txt E975": { "comment": "", "limit": 11.996353031793072, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S.txt Obs": { "comment": "", "limit": 7.164245033231885, "limitErr": 0.032713149944611608, "status": "done", "t_real": 0.0039026339072734118 }, 
-            "counting-B5p5-Obs6-Syst30U.txt E025": { "comment": "", "limit": 3.842018790858734, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U.txt E159": { "comment": "", "limit": 5.1104835130790978, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U.txt E500": { "comment": "", "limit": 7.0814164248479452, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U.txt E839": { "comment": "", "limit": 9.836095583307868, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U.txt E975": { "comment": "", "limit": 13.068562012967842, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U.txt Obs": { "comment": "", "limit": 7.6832151019606147, "limitErr": 0.038386022580459311, "status": "done", "t_real": 0.0041149179451167583 }
-        }, 
-        "status": "done"
-    }, 
-    "Gamma_Asymptotic": {
-        "comment": "all 72 jobs done", 
-        "results": {
-            "counting-B5p5-Obs6-Syst30B-gmM.txt E025": { "comment": "", "limit": 3.5755331228461729, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B-gmM.txt E159": { "comment": "", "limit": 4.7560160606839288, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B-gmM.txt E500": { "comment": "", "limit": 6.5902434011915618, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B-gmM.txt E839": { "comment": "", "limit": 9.1538556868269527, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B-gmM.txt E975": { "comment": "", "limit": 12.162115515028951, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30B-gmM.txt Obs": { "comment": "", "limit": 7.3715968175156146, "limitErr": 0.030788317494824913, "status": "done", "t_real": 0.0024037680123001337 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt E025": { "comment": "", "limit": 5.4609912116289401, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt E159": { "comment": "", "limit": 7.2639690410940769, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt E500": { "comment": "", "limit": 10.065425227484621, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt E839": { "comment": "", "limit": 13.98088725255314, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt E975": { "comment": "", "limit": 18.575469352531147, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30C-gmM.txt Obs": { "comment": "", "limit": 11.593051899082106, "limitErr": 0.037612137381594302, "status": "done", "t_real": 0.0021798531524837017 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt E025": { "comment": "", "limit": 4.3607221655160364, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt E159": { "comment": "", "limit": 5.8004398065443228, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt E500": { "comment": "", "limit": 8.037464481057814, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt E839": { "comment": "", "limit": 11.164047436290145, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt E975": { "comment": "", "limit": 14.832922779285058, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30S-gmM.txt Obs": { "comment": "", "limit": 8.4738199558057836, "limitErr": 0.039026186553171804, "status": "done", "t_real": 0.0029988845344632864 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt E025": { "comment": "", "limit": 4.8277248086117925, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt E159": { "comment": "", "limit": 6.4216260729373058, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt E500": { "comment": "", "limit": 8.8982203407464979, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt E839": { "comment": "", "limit": 12.359638318374449, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt E975": { "comment": "", "limit": 16.421424380588437, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-B5p5-Obs6-Syst30U-gmM.txt Obs": { "comment": "", "limit": 9.8129173184590854, "limitErr": 0.028246020547199713, "status": "done", "t_real": 0.0046734493225812912 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt E025": { "comment": "", "limit": 1.6993077366380027, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt E159": { "comment": "", "limit": 2.2603440129961561, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt E500": { "comment": "", "limit": 3.1320788294244437, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt E839": { "comment": "", "limit": 4.3504611072685728, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt E975": { "comment": "", "limit": 5.7801665593640008, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband1-alpha0p3-Obs2.txt Obs": { "comment": "", "limit": 5.3086852574456902, "limitErr": 0.0144906024941025, "status": "done", "t_real": 0.0053429803811013699 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt E025": { "comment": "", "limit": 2.3323795106310303, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt E159": { "comment": "", "limit": 3.1024280942309539, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt E500": { "comment": "", "limit": 4.2989249857025715, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt E839": { "comment": "", "limit": 5.9712117644244955, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt E975": { "comment": "", "limit": 7.9335495039690844, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband10-alpha0p2-Obs2.txt Obs": { "comment": "", "limit": 4.291331824660725, "limitErr": 0.016170965210109411, "status": "done", "t_real": 0.0030979672446846962 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt E025": { "comment": "", "limit": 3.142790179253415, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt E159": { "comment": "", "limit": 4.1804005317089112, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt E500": { "comment": "", "limit": 5.7926333020983538, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt E839": { "comment": "", "limit": 8.0459743390553573, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt E975": { "comment": "", "limit": 10.690147702827758, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband100-alpha0p05-Obs4.txt Obs": { "comment": "", "limit": 5.0016008311248878, "limitErr": 0.014010036624541033, "status": "done", "t_real": 0.00328655238263309 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt E025": { "comment": "", "limit": 2.2380752664869772, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt E159": { "comment": "", "limit": 2.976988758520716, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt E500": { "comment": "", "limit": 4.1251081306149606, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt E839": { "comment": "", "limit": 5.7297799521909107, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt E975": { "comment": "", "limit": 7.6127752106171354, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-S1-Sideband2-alpha0p3-Obs6.txt Obs": { "comment": "", "limit": 10.494518402997961, "limitErr": 0.028782560237703869, "status": "done", "t_real": 0.0023159186821430922 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt E025": { "comment": "", "limit": 2.7211894603252693, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt E159": { "comment": "", "limit": 3.6196058973070815, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt E500": { "comment": "", "limit": 5.0155599929180585, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt E839": { "comment": "", "limit": 6.9666186161642463, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt E975": { "comment": "", "limit": 9.2560799795949897, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs1.txt Obs": { "comment": "", "limit": 3.372740921336586, "limitErr": 0.015261246980891707, "status": "done", "t_real": 0.003392382524907589 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt E025": { "comment": "", "limit": 3.9143297338539762, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt E159": { "comment": "", "limit": 5.2066683320788485, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt E500": { "comment": "", "limit": 7.214696329839847, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt E839": { "comment": "", "limit": 10.021221525094674, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt E975": { "comment": "", "limit": 13.314526464000183, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs11.txt Obs": { "comment": "", "limit": 12.736097867224242, "limitErr": 0.042307879866492648, "status": "done", "t_real": 0.0024382870178669691 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt E025": { "comment": "", "limit": 4.419161773119602, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt E159": { "comment": "", "limit": 5.878173588554815, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt E500": { "comment": "", "limit": 8.1451774360621432, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt E839": { "comment": "", "limit": 11.313660855049921, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt E975": { "comment": "", "limit": 15.031704117314378, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs20.txt Obs": { "comment": "", "limit": 23.168945098074808, "limitErr": 0.10702955037597661, "status": "done", "t_real": 0.0023693840485066175 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt E025": { "comment": "", "limit": 3.6311927755348816, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt E159": { "comment": "", "limit": 4.8300520695879285, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt E500": { "comment": "", "limit": 6.6928324826632473, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt E839": { "comment": "", "limit": 9.2963520393389327, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt E975": { "comment": "", "limit": 12.351440883377828, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "counting-Sideband11-alpha0p5-Obs6.txt Obs": { "comment": "", "limit": 7.1036205977476286, "limitErr": 0.022236488966657308, "status": "done", "t_real": 0.0023431659210473299 }
-        }, 
-        "status": "done"
-    }, 
-    "HWW_Asymptotic": {
-        "comment": "all 24 jobs done", 
-        "results": {
-            "hww4ch-1fb-B+1-mH160.txt E025": { "comment": "", "limit": 0.17475420941519776, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E159": { "comment": "", "limit": 0.23245032225829568, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E500": { "comment": "", "limit": 0.32209819790795513, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E839": { "comment": "", "limit": 0.44739476846990955, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E975": { "comment": "", "limit": 0.59442349116133009, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt Obs": { "comment": "", "limit": 0.62739447934580928, "limitErr": 0.0020820075057124687, "status": "done", "t_real": 0.034754298627376556 }, 
-            "hww4ch-1fb-B-1-mH140.txt E025": { "comment": "", "limit": 0.47470973364352281, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E159": { "comment": "", "limit": 0.63143789745524803, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E500": { "comment": "", "limit": 0.87496118260969702, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E839": { "comment": "", "limit": 1.215322092008996, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E975": { "comment": "", "limit": 1.6147171396038935, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt Obs": { "comment": "", "limit": 0.79980006642231838, "limitErr": 0.0037549266747535781, "status": "done", "t_real": 0.042198751121759415 }, 
-            "hww4ch-1fb-B-mH140.txt E025": { "comment": "", "limit": 0.49679797667666215, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E159": { "comment": "", "limit": 0.6608187016622239, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E500": { "comment": "", "limit": 0.91567312482691476, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E839": { "comment": "", "limit": 1.2718710267144224, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E975": { "comment": "", "limit": 1.6898499251391685, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt Obs": { "comment": "", "limit": 1.6867570680086312, "limitErr": 0.0058084162089543367, "status": "done", "t_real": 0.032044384628534317 }, 
-            "hww4ch-1fb-B-mH160.txt E025": { "comment": "", "limit": 0.17063508016545378, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E159": { "comment": "", "limit": 0.22697123866579888, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E500": { "comment": "", "limit": 0.31450602537756289, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E839": { "comment": "", "limit": 0.43684923206678722, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E975": { "comment": "", "limit": 0.58041234260375707, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt Obs": { "comment": "", "limit": 0.33422982266221124, "limitErr": 0.0014001816507255016, "status": "done", "t_real": 0.057611934840679169 }
-        }, 
-        "status": "done"
-    }, 
-    "HWW_S0_Asymptotic": {
-        "comment": "all 24 jobs done", 
-        "results": {
-            "hww4ch-1fb-B+1-mH160.txt E025": { "comment": "", "limit": 0.15507476891443994, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E159": { "comment": "", "limit": 0.20627360066988693, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E500": { "comment": "", "limit": 0.28582603975884413, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E839": { "comment": "", "limit": 0.39701269895686347, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt E975": { "comment": "", "limit": 0.52748420674747609, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B+1-mH160.txt Obs": { "comment": "", "limit": 0.58440709142714642, "limitErr": 0.00151170189728006, "status": "done", "t_real": 0.0036881486885249615 }, 
-            "hww4ch-1fb-B-1-mH140.txt E025": { "comment": "", "limit": 0.42559478909851967, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E159": { "comment": "", "limit": 0.56610736993668498, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E500": { "comment": "", "limit": 0.78443497908513182, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E839": { "comment": "", "limit": 1.089581090881425, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt E975": { "comment": "", "limit": 1.4476534854445167, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-1-mH140.txt Obs": { "comment": "", "limit": 0.69912403555554592, "limitErr": 0.0028077186931665388, "status": "done", "t_real": 0.0043549658730626106 }, 
-            "hww4ch-1fb-B-mH140.txt E025": { "comment": "", "limit": 0.42559478909851967, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E159": { "comment": "", "limit": 0.56610736993668498, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E500": { "comment": "", "limit": 0.78443497908513182, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E839": { "comment": "", "limit": 1.089581090881425, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt E975": { "comment": "", "limit": 1.4476534854445167, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH140.txt Obs": { "comment": "", "limit": 1.5468632584550983, "limitErr": 0.0049121397045466253, "status": "done", "t_real": 0.007303349208086729 }, 
-            "hww4ch-1fb-B-mH160.txt E025": { "comment": "", "limit": 0.15507476891443994, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E159": { "comment": "", "limit": 0.20627360066988693, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E500": { "comment": "", "limit": 0.28582603975884413, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E839": { "comment": "", "limit": 0.39701269895686347, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt E975": { "comment": "", "limit": 0.52748420674747609, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hww4ch-1fb-B-mH160.txt Obs": { "comment": "", "limit": 0.30354629048148263, "limitErr": 0.0014657811645443219, "status": "done", "t_real": 0.0068063857033848763 }
-        }, 
-        "status": "done"
-    }, 
     "Counting_pValues_Freq_0_CLs_HybridNew": {
         "comment": "", 
         "results": {
@@ -1367,102 +1115,7 @@
     "Summer11_Sig_HWWS_130_PLC_ProfileLikelihood": { "comment": "", "results": { "comb_hww.txt": { "comment": "", "limit": 1.576599387655403, "limitErr": 0.0, "status": "done", "t_real": 0.0048717339523136616 } }, "status": "done" }, 
     "Summer11_Sig_HZZ2L2Q_300_PLC_ProfileLikelihood": { "comment": "", "results": { "comb_hzz2l2q.txt": { "comment": "", "limit": 0.55279765177573259, "limitErr": 0.0, "status": "done", "t_real": 0.0083198510110378265 } }, "status": "done" }, 
     "Summer11_Sig_HZZ4L_145_PLC_ProfileLikelihood": { "comment": "", "results": { "comb_hzz4l.txt": { "comment": "", "limit": 1.7281445785714229, "limitErr": 0.0, "status": "done", "t_real": 0.0049951155669987202 } }, "status": "done" },
-    "Summer11_HGG_115_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "hgg_8cats.txt E025": { "comment": "", "limit": 1.55133338419819, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hgg_8cats.txt E159": { "comment": "", "limit": 2.063515072361747, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hgg_8cats.txt E500": { "comment": "", "limit": 2.8593399213491608, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hgg_8cats.txt E839": { "comment": "", "limit": 3.9716264493176245, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hgg_8cats.txt E975": { "comment": "", "limit": 5.2768342993059427, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "hgg_8cats.txt Obs": { "comment": "", "limit": 3.1584207647593221, "limitErr": 0.014190114308956447, "status": "done", "t_real": 0.23547513782978058 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HTT_125_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_htt.txt E025": { "comment": "", "limit": 3.8062502817737736, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_htt.txt E159": { "comment": "", "limit": 5.0629058238702296, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_htt.txt E500": { "comment": "", "limit": 7.015489702071573, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_htt.txt E839": { "comment": "", "limit": 9.7445232893177476, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_htt.txt E975": { "comment": "", "limit": 12.946896033561289, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_htt.txt Obs": { "comment": "",  "limit": 9.2957897034783059, "limitErr": 0.027293956719500301, "status": "done", "t_real": 0.10544841736555099 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HWWC_170_CNT_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hww_cnt.txt E025": { "comment": "", "limit": 0.16459540133749154, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_cnt.txt E159": { "comment": "", "limit": 0.21893752494528501, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_cnt.txt E500": { "comment": "", "limit": 0.30337399214677829, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_cnt.txt E839": { "comment": "", "limit": 0.42138682506720054, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_cnt.txt E975": { "comment": "", "limit": 0.55986847710017584, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_cnt.txt Obs": { "comment": "", "limit": 0.40212783779517963, "limitErr": 0.0016834126656907755, "status": "done", "t_real": 0.15245796740055084 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HWWC_170_EXT_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hww_ext.txt E025": { "comment": "", "limit": 0.16459540133749154, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_ext.txt E159": { "comment": "", "limit": 0.21893752494528501, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_ext.txt E500": { "comment": "", "limit": 0.30337399214677829, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_ext.txt E839": { "comment": "", "limit": 0.42138682506720054, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_ext.txt E975": { "comment": "", "limit": 0.55986847710017584, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww_ext.txt Obs": { "comment": "", "limit": 0.40212783779517963, "limitErr": 0.0016834126656907755, "status": "done", "t_real": 0.15245796740055084 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HWWS_130_0J_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hww0j.txt E025": { "comment": "", "limit": 0.64180442676798388, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww0j.txt E159": { "comment": "", "limit": 0.85369986982439039, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww0j.txt E500": { "comment": "", "limit": 1.1829417440821755, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww0j.txt E839": { "comment": "", "limit": 1.6431074471837794, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww0j.txt E975": { "comment": "", "limit": 2.1830869154963151, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww0j.txt Obs": { "comment": "", "limit": 1.5931844925263334, "limitErr": 0.0066693152658271471, "status": "done", "t_real": 0.030521750450134277 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HWWS_130_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hww.txt E025": { "comment": "", "limit": 0.50645012782298005, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww.txt E159": { "comment": "", "limit": 0.67365756632794827, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww.txt E500": { "comment": "", "limit": 0.93346348593219552, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww.txt E839": { "comment": "", "limit": 1.2965818588127991, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww.txt E975": { "comment": "", "limit": 1.722681554207282, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hww.txt Obs": { "comment": "", "limit": 1.7420967510719469, "limitErr": 0.005174943777152996, "status": "done", "t_real": 0.095729686319828033 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HZZ2L2Q_300_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hzz2l2q.txt E025": { "comment": "", "limit": 1.2181704660629329, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz2l2q.txt E159": { "comment": "", "limit": 1.6203564901209251, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz2l2q.txt E500": { "comment": "", "limit": 2.2452707329717767, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz2l2q.txt E839": { "comment": "", "limit": 3.1186836382649714, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz2l2q.txt E975": { "comment": "", "limit": 4.1435862614693608, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz2l2q.txt Obs": { "comment": "", "limit": 2.7122282225065866, "limitErr": 0.0095086922253435624, "status": "done", "t_real": 0.085808664560317993 }
-        }, 
-        "status": "done"
-    }, 
-    "Summer11_HZZ4L_145_Asymptotic": {
-        "comment": "", 
-        "results": {
-            "comb_hzz4l.txt E025": { "comment": "", "limit": 0.61139018888352037, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz4l.txt E159": { "comment": "", "limit": 0.81324419541664605, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz4l.txt E500": { "comment": "", "limit": 1.1268837455589216, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz4l.txt E839": { "comment": "", "limit": 1.5652428225659019, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz4l.txt E975": { "comment": "", "limit": 2.0796333991272742, "limitErr": 0, "status": "done", "t_real": 0 }, 
-            "comb_hzz4l.txt Obs": { "comment": "", "limit":  2.0772306329700854, "limitErr": 0.0068701755595230729, "status": "done", "t_real": 0.10684145241975784 }
-        }, 
-        "status": "done"
-    },
+
     "Summer11_HGG_115_MarkovChainMC": {
         "comment": "", 
         "results": {
@@ -1718,5 +1371,1974 @@
         "comment": "", 
         "results": { "comb_hzz4l.txt": { "comment": "", "limit": 1.2215951618076151, "limitErr": 0.023534909431793899, "status": "done", "t_real": 13.609646797180176 } }, 
         "status": "done"
+    },
+    "Asymm_Asymptotic": {
+        "comment": "all 12 jobs done", 
+        "results": {
+            "counting-B5p5-Obs6-Syst1040B.txt E025": {
+                "comment": "", 
+                "limit": 3.11279296875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst1040B.txt E159": {
+                "comment": "", 
+                "limit": 4.27699089050293, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst1040B.txt E500": {
+                "comment": "", 
+                "limit": 6.25, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst1040B.txt E839": {
+                "comment": "", 
+                "limit": 9.364095687866211, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst1040B.txt E975": {
+                "comment": "", 
+                "limit": 13.695121765136719, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst1040B.txt Obs": {
+                "comment": "", 
+                "limit": 6.5902827237098345, 
+                "limitErr": 0.03267600396425685, 
+                "status": "done", 
+                "t_real": 0.02015875093638897
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt E025": {
+                "comment": "", 
+                "limit": 3.73187255859375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt E159": {
+                "comment": "", 
+                "limit": 5.04276704788208, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt E500": {
+                "comment": "", 
+                "limit": 7.15625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt E839": {
+                "comment": "", 
+                "limit": 10.493688583374023, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt E975": {
+                "comment": "", 
+                "limit": 14.851012229919434, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst4010B.txt Obs": {
+                "comment": "", 
+                "limit": 7.632932607999944, 
+                "limitErr": 0.02576945225889382, 
+                "status": "done", 
+                "t_real": 0.007948016747832298
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Counting_Asymptotic": {
+        "comment": "all 90 jobs done", 
+        "results": {
+            "counting-B5p5-Obs1-StatOnly.txt E025": {
+                "comment": "", 
+                "limit": 2.883544921875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-StatOnly.txt E159": {
+                "comment": "", 
+                "limit": 4.022646903991699, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-StatOnly.txt E500": {
+                "comment": "", 
+                "limit": 5.953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-StatOnly.txt E839": {
+                "comment": "", 
+                "limit": 9.061677932739258, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-StatOnly.txt E975": {
+                "comment": "", 
+                "limit": 13.334918022155762, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-StatOnly.txt Obs": {
+                "comment": "", 
+                "limit": 3.054248997329904, 
+                "limitErr": 0.00898660351496372, 
+                "status": "done", 
+                "t_real": 0.02051476575434208
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt E025": {
+                "comment": "", 
+                "limit": 2.826507568359375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt E159": {
+                "comment": "", 
+                "limit": 3.9171957969665527, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt E500": {
+                "comment": "", 
+                "limit": 5.765625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt E839": {
+                "comment": "", 
+                "limit": 8.730306625366211, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt E975": {
+                "comment": "", 
+                "limit": 12.821915626525879, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30B.txt Obs": {
+                "comment": "", 
+                "limit": 3.1289882934872923, 
+                "limitErr": 0.00921333056334217, 
+                "status": "done", 
+                "t_real": 0.0057985661551356316
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt E025": {
+                "comment": "", 
+                "limit": 4.03179931640625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt E159": {
+                "comment": "", 
+                "limit": 5.811391353607178, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt E500": {
+                "comment": "", 
+                "limit": 9.09375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt E839": {
+                "comment": "", 
+                "limit": 14.965938568115234, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt E975": {
+                "comment": "", 
+                "limit": 24.580175399780273, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30C.txt Obs": {
+                "comment": "", 
+                "limit": 4.370368555639976, 
+                "limitErr": 0.012695139860547044, 
+                "status": "done", 
+                "t_real": 0.0033509493805468082
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt E025": {
+                "comment": "", 
+                "limit": 2.97491455078125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt E159": {
+                "comment": "", 
+                "limit": 4.247161388397217, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt E500": {
+                "comment": "", 
+                "limit": 6.59375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt E839": {
+                "comment": "", 
+                "limit": 10.746459007263184, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt E975": {
+                "comment": "", 
+                "limit": 17.506521224975586, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30S.txt Obs": {
+                "comment": "", 
+                "limit": 3.309790732342732, 
+                "limitErr": 0.009380616952887166, 
+                "status": "done", 
+                "t_real": 0.005027067847549915
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt E025": {
+                "comment": "", 
+                "limit": 2.9278564453125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt E159": {
+                "comment": "", 
+                "limit": 4.137141704559326, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt E500": {
+                "comment": "", 
+                "limit": 6.40625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt E839": {
+                "comment": "", 
+                "limit": 10.440873146057129, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt E975": {
+                "comment": "", 
+                "limit": 16.867462158203125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs1-Syst30U.txt Obs": {
+                "comment": "", 
+                "limit": 3.3924096443123433, 
+                "limitErr": 0.011295878594070441, 
+                "status": "done", 
+                "t_real": 0.004097950644791126
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt E025": {
+                "comment": "", 
+                "limit": 2.883544921875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt E159": {
+                "comment": "", 
+                "limit": 4.022646903991699, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt E500": {
+                "comment": "", 
+                "limit": 5.953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt E839": {
+                "comment": "", 
+                "limit": 9.061677932739258, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt E975": {
+                "comment": "", 
+                "limit": 13.334918022155762, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-StatOnly.txt Obs": {
+                "comment": "", 
+                "limit": 11.978743731374523, 
+                "limitErr": 0.05156127552665257, 
+                "status": "done", 
+                "t_real": 0.003018498420715332
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt E025": {
+                "comment": "", 
+                "limit": 3.68328857421875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt E159": {
+                "comment": "", 
+                "limit": 5.046578407287598, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt E500": {
+                "comment": "", 
+                "limit": 7.28125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt E839": {
+                "comment": "", 
+                "limit": 10.735031127929688, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt E975": {
+                "comment": "", 
+                "limit": 15.324238777160645, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30B.txt Obs": {
+                "comment": "", 
+                "limit": 12.406504544989788, 
+                "limitErr": 0.0568229931781552, 
+                "status": "done", 
+                "t_real": 0.003484582994133234
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt E025": {
+                "comment": "", 
+                "limit": 3.28509521484375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt E159": {
+                "comment": "", 
+                "limit": 4.70560359954834, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt E500": {
+                "comment": "", 
+                "limit": 7.28125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt E839": {
+                "comment": "", 
+                "limit": 11.866943359375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt E975": {
+                "comment": "", 
+                "limit": 19.010774612426758, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30C.txt Obs": {
+                "comment": "", 
+                "limit": 15.550857392305714, 
+                "limitErr": 0.06443816202847152, 
+                "status": "done", 
+                "t_real": 0.00460163364186883
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt E025": {
+                "comment": "", 
+                "limit": 2.97491455078125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt E159": {
+                "comment": "", 
+                "limit": 4.247161388397217, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt E500": {
+                "comment": "", 
+                "limit": 6.59375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt E839": {
+                "comment": "", 
+                "limit": 10.746459007263184, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt E975": {
+                "comment": "", 
+                "limit": 17.506521224975586, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30S.txt Obs": {
+                "comment": "", 
+                "limit": 13.81801656485732, 
+                "limitErr": 0.05699963986849177, 
+                "status": "done", 
+                "t_real": 0.010588451288640499
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt E025": {
+                "comment": "", 
+                "limit": 3.84136962890625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt E159": {
+                "comment": "", 
+                "limit": 5.352957725524902, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt E500": {
+                "comment": "", 
+                "limit": 8.09375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt E839": {
+                "comment": "", 
+                "limit": 12.93305492401123, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt E975": {
+                "comment": "", 
+                "limit": 20.50606346130371, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs11-Syst30U.txt Obs": {
+                "comment": "", 
+                "limit": 14.358117234048429, 
+                "limitErr": 0.06465451931434973, 
+                "status": "done", 
+                "t_real": 0.002557647181674838
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt E025": {
+                "comment": "", 
+                "limit": 2.883544921875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt E159": {
+                "comment": "", 
+                "limit": 4.022646903991699, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt E500": {
+                "comment": "", 
+                "limit": 5.953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt E839": {
+                "comment": "", 
+                "limit": 9.061677932739258, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt E975": {
+                "comment": "", 
+                "limit": 13.334918022155762, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-StatOnly.txt Obs": {
+                "comment": "", 
+                "limit": 6.437463217389434, 
+                "limitErr": 0.016735334069519325, 
+                "status": "done", 
+                "t_real": 0.0020904659759253263
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt E025": {
+                "comment": "", 
+                "limit": 3.24700927734375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt E159": {
+                "comment": "", 
+                "limit": 4.442577362060547, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt E500": {
+                "comment": "", 
+                "limit": 6.46875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt E839": {
+                "comment": "", 
+                "limit": 9.691839218139648, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt E975": {
+                "comment": "", 
+                "limit": 14.018534660339355, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B.txt Obs": {
+                "comment": "", 
+                "limit": 6.907649241456674, 
+                "limitErr": 0.027686942218001942, 
+                "status": "done", 
+                "t_real": 0.010081966407597065
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt E025": {
+                "comment": "", 
+                "limit": 3.62005615234375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt E159": {
+                "comment": "", 
+                "limit": 5.175363540649414, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt E500": {
+                "comment": "", 
+                "limit": 8.09375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt E839": {
+                "comment": "", 
+                "limit": 13.19115161895752, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt E975": {
+                "comment": "", 
+                "limit": 21.48904800415039, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C.txt Obs": {
+                "comment": "", 
+                "limit": 8.749169534242876, 
+                "limitErr": 0.02248928812084028, 
+                "status": "done", 
+                "t_real": 0.0025627335999161005
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt E025": {
+                "comment": "", 
+                "limit": 2.97491455078125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt E159": {
+                "comment": "", 
+                "limit": 4.247161388397217, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt E500": {
+                "comment": "", 
+                "limit": 6.59375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt E839": {
+                "comment": "", 
+                "limit": 10.746459007263184, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt E975": {
+                "comment": "", 
+                "limit": 17.506521224975586, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S.txt Obs": {
+                "comment": "", 
+                "limit": 7.137532971917856, 
+                "limitErr": 0.018993999948377915, 
+                "status": "done", 
+                "t_real": 0.0021151662804186344
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt E025": {
+                "comment": "", 
+                "limit": 3.34149169921875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt E159": {
+                "comment": "", 
+                "limit": 4.719736099243164, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt E500": {
+                "comment": "", 
+                "limit": 7.21875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt E839": {
+                "comment": "", 
+                "limit": 11.649984359741211, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt E975": {
+                "comment": "", 
+                "limit": 18.651567459106445, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U.txt Obs": {
+                "comment": "", 
+                "limit": 7.683670121080662, 
+                "limitErr": 0.015957254319197478, 
+                "status": "done", 
+                "t_real": 0.0022114317398518324
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Gamma_Asymptotic": {
+        "comment": "all 72 jobs done", 
+        "results": {
+            "counting-B5p5-Obs6-Syst30B-gmM.txt E025": {
+                "comment": "", 
+                "limit": 3.24700927734375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B-gmM.txt E159": {
+                "comment": "", 
+                "limit": 4.442577362060547, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B-gmM.txt E500": {
+                "comment": "", 
+                "limit": 6.46875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B-gmM.txt E839": {
+                "comment": "", 
+                "limit": 9.640270233154297, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B-gmM.txt E975": {
+                "comment": "", 
+                "limit": 13.910964012145996, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30B-gmM.txt Obs": {
+                "comment": "", 
+                "limit": 7.307398431477629, 
+                "limitErr": 0.013661727754132436, 
+                "status": "done", 
+                "t_real": 0.02044813707470894
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt E025": {
+                "comment": "", 
+                "limit": 4.01312255859375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt E159": {
+                "comment": "", 
+                "limit": 5.867183685302734, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt E500": {
+                "comment": "", 
+                "limit": 9.46875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt E839": {
+                "comment": "", 
+                "limit": 16.48891830444336, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt E975": {
+                "comment": "", 
+                "limit": 28.696958541870117, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30C-gmM.txt Obs": {
+                "comment": "", 
+                "limit": 11.324168380791537, 
+                "limitErr": 0.027760113233606276, 
+                "status": "done", 
+                "t_real": 0.007901831530034542
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt E025": {
+                "comment": "", 
+                "limit": 3.33709716796875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt E159": {
+                "comment": "", 
+                "limit": 4.783694267272949, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt E500": {
+                "comment": "", 
+                "limit": 7.59375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt E839": {
+                "comment": "", 
+                "limit": 13.102710723876953, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt E975": {
+                "comment": "", 
+                "limit": 23.013446807861328, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30S-gmM.txt Obs": {
+                "comment": "", 
+                "limit": 8.288852685854096, 
+                "limitErr": 0.023894118902145323, 
+                "status": "done", 
+                "t_real": 0.00802998524159193
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt E025": {
+                "comment": "", 
+                "limit": 3.76446533203125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt E159": {
+                "comment": "", 
+                "limit": 5.320706367492676, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt E500": {
+                "comment": "", 
+                "limit": 8.34375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt E839": {
+                "comment": "", 
+                "limit": 14.130736351013184, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt E975": {
+                "comment": "", 
+                "limit": 24.933008193969727, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-B5p5-Obs6-Syst30U-gmM.txt Obs": {
+                "comment": "", 
+                "limit": 9.539538689717187, 
+                "limitErr": 0.04391214295114754, 
+                "status": "done", 
+                "t_real": 0.007300448603928089
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt E025": {
+                "comment": "", 
+                "limit": 1.356719970703125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt E159": {
+                "comment": "", 
+                "limit": 1.9877699613571167, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt E500": {
+                "comment": "", 
+                "limit": 3.171875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt E839": {
+                "comment": "", 
+                "limit": 5.270651340484619, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt E975": {
+                "comment": "", 
+                "limit": 8.380687713623047, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband1-alpha0p3-Obs2.txt Obs": {
+                "comment": "", 
+                "limit": 5.258247456178961, 
+                "limitErr": 0.020748942181613383, 
+                "status": "done", 
+                "t_real": 0.003561298130080104
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt E025": {
+                "comment": "", 
+                "limit": 1.988983154296875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt E159": {
+                "comment": "", 
+                "limit": 2.827396869659424, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt E500": {
+                "comment": "", 
+                "limit": 4.296875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt E839": {
+                "comment": "", 
+                "limit": 6.78036642074585, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt E975": {
+                "comment": "", 
+                "limit": 10.267023086547852, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband10-alpha0p2-Obs2.txt Obs": {
+                "comment": "", 
+                "limit": 4.305889750130088, 
+                "limitErr": 0.019758878523735923, 
+                "status": "done", 
+                "t_real": 0.004631900694221258
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt E025": {
+                "comment": "", 
+                "limit": 2.796539306640625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt E159": {
+                "comment": "", 
+                "limit": 3.909945011138916, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt E500": {
+                "comment": "", 
+                "limit": 5.796875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt E839": {
+                "comment": "", 
+                "limit": 8.823838233947754, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt E975": {
+                "comment": "", 
+                "limit": 12.984920501708984, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband100-alpha0p05-Obs4.txt Obs": {
+                "comment": "", 
+                "limit": 4.939812207867004, 
+                "limitErr": 0.016968838705402334, 
+                "status": "done", 
+                "t_real": 0.003756749676540494
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt E025": {
+                "comment": "", 
+                "limit": 1.96832275390625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt E159": {
+                "comment": "", 
+                "limit": 2.791537046432495, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt E500": {
+                "comment": "", 
+                "limit": 4.234375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt E839": {
+                "comment": "", 
+                "limit": 6.681743144989014, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt E975": {
+                "comment": "", 
+                "limit": 10.214471817016602, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-S1-Sideband2-alpha0p3-Obs6.txt Obs": {
+                "comment": "", 
+                "limit": 10.44072921162174, 
+                "limitErr": 0.03847467701524643, 
+                "status": "done", 
+                "t_real": 0.006011366844177246
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt E025": {
+                "comment": "", 
+                "limit": 2.849029541015625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt E159": {
+                "comment": "", 
+                "limit": 3.9313597679138184, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt E500": {
+                "comment": "", 
+                "limit": 5.765625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt E839": {
+                "comment": "", 
+                "limit": 8.684342384338379, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt E975": {
+                "comment": "", 
+                "limit": 12.728192329406738, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs1.txt Obs": {
+                "comment": "", 
+                "limit": 3.1719240594524725, 
+                "limitErr": 0.007317655063305173, 
+                "status": "done", 
+                "t_real": 0.01247895136475563
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt E025": {
+                "comment": "", 
+                "limit": 3.760986328125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt E159": {
+                "comment": "", 
+                "limit": 5.113720893859863, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt E500": {
+                "comment": "", 
+                "limit": 7.40625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt E839": {
+                "comment": "", 
+                "limit": 10.919323921203613, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt E975": {
+                "comment": "", 
+                "limit": 15.587316513061523, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs11.txt Obs": {
+                "comment": "", 
+                "limit": 12.523721728916522, 
+                "limitErr": 0.059059987385742474, 
+                "status": "done", 
+                "t_real": 0.0038110336754471064
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt E025": {
+                "comment": "", 
+                "limit": 4.41436767578125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt E159": {
+                "comment": "", 
+                "limit": 5.99796199798584, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt E500": {
+                "comment": "", 
+                "limit": 8.59375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt E839": {
+                "comment": "", 
+                "limit": 12.5330810546875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt E975": {
+                "comment": "", 
+                "limit": 17.685924530029297, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs20.txt Obs": {
+                "comment": "", 
+                "limit": 23.13446303134024, 
+                "limitErr": 0.07236524017750412, 
+                "status": "done", 
+                "t_real": 0.002834880258888006
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt E025": {
+                "comment": "", 
+                "limit": 3.34112548828125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt E159": {
+                "comment": "", 
+                "limit": 4.571347236633301, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt E500": {
+                "comment": "", 
+                "limit": 6.65625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt E839": {
+                "comment": "", 
+                "limit": 9.866633415222168, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt E975": {
+                "comment": "", 
+                "limit": 14.202662467956543, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "counting-Sideband11-alpha0p5-Obs6.txt Obs": {
+                "comment": "", 
+                "limit": 7.040990711994747, 
+                "limitErr": 0.029647465951302632, 
+                "status": "done", 
+                "t_real": 0.00850210152566433
+            }
+        }, 
+        "status": "done"
+    }, 
+    "HWW_Asymptotic": {
+        "comment": "all 24 jobs done", 
+        "results": {
+            "hww4ch-1fb-B+1-mH160.txt E025": {
+                "comment": "", 
+                "limit": 0.1645030975341797, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E159": {
+                "comment": "", 
+                "limit": 0.22413498163223267, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E500": {
+                "comment": "", 
+                "limit": 0.3251953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E839": {
+                "comment": "", 
+                "limit": 0.4820406436920166, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E975": {
+                "comment": "", 
+                "limit": 0.6938800811767578, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt Obs": {
+                "comment": "", 
+                "limit": 0.6273689135374746, 
+                "limitErr": 0.0028680015713068996, 
+                "status": "done", 
+                "t_real": 0.025839868932962418
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E025": {
+                "comment": "", 
+                "limit": 0.450286865234375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E159": {
+                "comment": "", 
+                "limit": 0.6122440099716187, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E500": {
+                "comment": "", 
+                "limit": 0.88671875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E839": {
+                "comment": "", 
+                "limit": 1.3002551794052124, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E975": {
+                "comment": "", 
+                "limit": 1.8619781732559204, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt Obs": {
+                "comment": "", 
+                "limit": 0.7907241257593137, 
+                "limitErr": 0.0039056033255234768, 
+                "status": "done", 
+                "t_real": 0.014790364541113377
+            }, 
+            "hww4ch-1fb-B-mH140.txt E025": {
+                "comment": "", 
+                "limit": 0.46794891357421875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E159": {
+                "comment": "", 
+                "limit": 0.6384642124176025, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E500": {
+                "comment": "", 
+                "limit": 0.91796875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E839": {
+                "comment": "", 
+                "limit": 1.3460791110992432, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E975": {
+                "comment": "", 
+                "limit": 1.927598476409912, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt Obs": {
+                "comment": "", 
+                "limit": 1.6805814912547812, 
+                "limitErr": 0.007563573437657789, 
+                "status": "done", 
+                "t_real": 0.015972081571817398
+            }, 
+            "hww4ch-1fb-B-mH160.txt E025": {
+                "comment": "", 
+                "limit": 0.1595630645751953, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E159": {
+                "comment": "", 
+                "limit": 0.21862190961837769, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E500": {
+                "comment": "", 
+                "limit": 0.3154296875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E839": {
+                "comment": "", 
+                "limit": 0.47007960081100464, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E975": {
+                "comment": "", 
+                "limit": 0.6783275008201599, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt Obs": {
+                "comment": "", 
+                "limit": 0.3333994223211352, 
+                "limitErr": 0.0014678837149955104, 
+                "status": "done", 
+                "t_real": 0.011506482027471066
+            }
+        }, 
+        "status": "done"
+    }, 
+    "HWW_S0_Asymptotic": {
+        "comment": "all 24 jobs done", 
+        "results": {
+            "hww4ch-1fb-B+1-mH160.txt E025": {
+                "comment": "", 
+                "limit": 0.1458606719970703, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E159": {
+                "comment": "", 
+                "limit": 0.1990106701850891, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E500": {
+                "comment": "", 
+                "limit": 0.2861328125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E839": {
+                "comment": "", 
+                "limit": 0.4172946512699127, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt E975": {
+                "comment": "", 
+                "limit": 0.5888609290122986, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B+1-mH160.txt Obs": {
+                "comment": "", 
+                "limit": 0.5842990246856099, 
+                "limitErr": 0.0026662595782864784, 
+                "status": "done", 
+                "t_real": 0.020655667409300804
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E025": {
+                "comment": "", 
+                "limit": 0.40331268310546875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E159": {
+                "comment": "", 
+                "limit": 0.5479955673217773, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E500": {
+                "comment": "", 
+                "limit": 0.78515625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E839": {
+                "comment": "", 
+                "limit": 1.1388086080551147, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt E975": {
+                "comment": "", 
+                "limit": 1.5924513339996338, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-1-mH140.txt Obs": {
+                "comment": "", 
+                "limit": 0.6940330800467447, 
+                "limitErr": 0.0032342077987926876, 
+                "status": "done", 
+                "t_real": 0.002655251882970333
+            }, 
+            "hww4ch-1fb-B-mH140.txt E025": {
+                "comment": "", 
+                "limit": 0.40331268310546875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E159": {
+                "comment": "", 
+                "limit": 0.5479955673217773, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E500": {
+                "comment": "", 
+                "limit": 0.78515625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E839": {
+                "comment": "", 
+                "limit": 1.1388086080551147, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt E975": {
+                "comment": "", 
+                "limit": 1.5924513339996338, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH140.txt Obs": {
+                "comment": "", 
+                "limit": 1.543582100508034, 
+                "limitErr": 0.005653836516572808, 
+                "status": "done", 
+                "t_real": 0.0027802148833870888
+            }, 
+            "hww4ch-1fb-B-mH160.txt E025": {
+                "comment": "", 
+                "limit": 0.1458606719970703, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E159": {
+                "comment": "", 
+                "limit": 0.1990106701850891, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E500": {
+                "comment": "", 
+                "limit": 0.2861328125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E839": {
+                "comment": "", 
+                "limit": 0.4172946512699127, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt E975": {
+                "comment": "", 
+                "limit": 0.5888609290122986, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hww4ch-1fb-B-mH160.txt Obs": {
+                "comment": "", 
+                "limit": 0.30355431553987694, 
+                "limitErr": 0.000577357638780529, 
+                "status": "done", 
+                "t_real": 0.002253067446872592
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HGG_115_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "hgg_8cats.txt E025": {
+                "comment": "", 
+                "limit": 1.4951934814453125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hgg_8cats.txt E159": {
+                "comment": "", 
+                "limit": 2.0150506496429443, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hgg_8cats.txt E500": {
+                "comment": "", 
+                "limit": 2.8671875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hgg_8cats.txt E839": {
+                "comment": "", 
+                "limit": 4.158634185791016, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hgg_8cats.txt E975": {
+                "comment": "", 
+                "limit": 5.9220967292785645, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "hgg_8cats.txt Obs": {
+                "comment": "", 
+                "limit": 3.1644576036222234, 
+                "limitErr": 0.015334985134423773, 
+                "status": "done", 
+                "t_real": 0.13324452936649323
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HTT_125_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_htt.txt E025": {
+                "comment": "", 
+                "limit": 4.84344482421875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_htt.txt E159": {
+                "comment": "", 
+                "limit": 6.535457611083984, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_htt.txt E500": {
+                "comment": "", 
+                "limit": 9.21875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_htt.txt E839": {
+                "comment": "", 
+                "limit": 13.150607109069824, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_htt.txt E975": {
+                "comment": "", 
+                "limit": 18.091983795166016, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_htt.txt Obs": {
+                "comment": "", 
+                "limit": 9.231736130682803, 
+                "limitErr": 0.030289632735881256, 
+                "status": "done", 
+                "t_real": 0.0450965017080307
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HWWC_170_CNT_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hww_cnt.txt E025": {
+                "comment": "", 
+                "limit": 0.15841293334960938, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_cnt.txt E159": {
+                "comment": "", 
+                "limit": 0.21450649201869965, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_cnt.txt E500": {
+                "comment": "", 
+                "limit": 0.3095703125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_cnt.txt E839": {
+                "comment": "", 
+                "limit": 0.4539436995983124, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_cnt.txt E975": {
+                "comment": "", 
+                "limit": 0.6500518321990967, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_cnt.txt Obs": {
+                "comment": "", 
+                "limit": 0.40055424444359994, 
+                "limitErr": 0.0013448597279336616, 
+                "status": "done", 
+                "t_real": 0.034223079681396484
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HWWC_170_EXT_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hww_ext.txt E025": {
+                "comment": "", 
+                "limit": 0.15841293334960938, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_ext.txt E159": {
+                "comment": "", 
+                "limit": 0.21450649201869965, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_ext.txt E500": {
+                "comment": "", 
+                "limit": 0.3095703125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_ext.txt E839": {
+                "comment": "", 
+                "limit": 0.4539436995983124, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_ext.txt E975": {
+                "comment": "", 
+                "limit": 0.6500518321990967, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww_ext.txt Obs": {
+                "comment": "", 
+                "limit": 0.4005542979192161, 
+                "limitErr": 0.001344795823417233, 
+                "status": "done", 
+                "t_real": 0.040155064314603806
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HWWS_130_0J_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hww0j.txt E025": {
+                "comment": "", 
+                "limit": 0.59765625, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww0j.txt E159": {
+                "comment": "", 
+                "limit": 0.8194427490234375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww0j.txt E500": {
+                "comment": "", 
+                "limit": 1.1953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww0j.txt E839": {
+                "comment": "", 
+                "limit": 1.8099416494369507, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww0j.txt E975": {
+                "comment": "", 
+                "limit": 2.7009713649749756, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww0j.txt Obs": {
+                "comment": "", 
+                "limit": 1.5909098530246608, 
+                "limitErr": 0.0030440721333102605, 
+                "status": "done", 
+                "t_real": 0.011763581074774265
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HWWS_130_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hww.txt E025": {
+                "comment": "", 
+                "limit": 0.474700927734375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww.txt E159": {
+                "comment": "", 
+                "limit": 0.655978798866272, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww.txt E500": {
+                "comment": "", 
+                "limit": 0.953125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww.txt E839": {
+                "comment": "", 
+                "limit": 1.4128278493881226, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww.txt E975": {
+                "comment": "", 
+                "limit": 2.033714532852173, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hww.txt Obs": {
+                "comment": "", 
+                "limit": 1.7453060275056238, 
+                "limitErr": 0.008015072652478694, 
+                "status": "done", 
+                "t_real": 0.029130367562174797
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HZZ2L2Q_300_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hzz2l2q.txt E025": {
+                "comment": "", 
+                "limit": 1.1597747802734375, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz2l2q.txt E159": {
+                "comment": "", 
+                "limit": 1.5758280754089355, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz2l2q.txt E500": {
+                "comment": "", 
+                "limit": 2.2578125, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz2l2q.txt E839": {
+                "comment": "", 
+                "limit": 3.310781717300415, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz2l2q.txt E975": {
+                "comment": "", 
+                "limit": 4.657753944396973, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz2l2q.txt Obs": {
+                "comment": "", 
+                "limit": 2.664505724869861, 
+                "limitErr": 0.008417003710708304, 
+                "status": "done", 
+                "t_real": 0.08154337853193283
+            }
+        }, 
+        "status": "done"
+    }, 
+    "Summer11_HZZ4L_145_Asymptotic": {
+        "comment": "", 
+        "results": {
+            "comb_hzz4l.txt E025": {
+                "comment": "", 
+                "limit": 0.4407005310058594, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz4l.txt E159": {
+                "comment": "", 
+                "limit": 0.6772379875183105, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz4l.txt E500": {
+                "comment": "", 
+                "limit": 1.13671875, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz4l.txt E839": {
+                "comment": "", 
+                "limit": 1.9794865846633911, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz4l.txt E975": {
+                "comment": "", 
+                "limit": 3.283496856689453, 
+                "limitErr": 0, 
+                "status": "done", 
+                "t_real": 0
+            }, 
+            "comb_hzz4l.txt Obs": {
+                "comment": "", 
+                "limit": 2.078760736385968, 
+                "limitErr": 0.007828928539562297, 
+                "status": "done", 
+                "t_real": 0.07837817072868347
+            }
+        }, 
+        "status": "done"
     }
+
 }


### PR DESCRIPTION
Fix a crash running on a pre-existing workspace that doesn't have a "discreteParams" set defined.
Also update json file of validation numbers for asymptotic CLs (it still had the old bands...)
