### PR TITLE
fix overflows in TH1Keys

### DIFF
--- a/src/TH1Keys.cc
+++ b/src/TH1Keys.cc
@@ -166,8 +166,8 @@ void TH1Keys::FillH1() const
         cache_ = pdf.createHistogram(GetName(), *x_);
         if (cache_->Integral()) cache_->Scale(1.0/cache_->Integral());
         cache_->Scale(dataset_->sumEntries() * globalScale_);
-        cache_->SetBinContent(0,                     underflow_);
-        cache_->SetBinContent(cache_->GetNbinsX()+1, overflow_);
+        cache_->SetBinContent(0,                     underflow_ * globalScale_);
+        cache_->SetBinContent(cache_->GetNbinsX()+1, overflow_  * globalScale_);
         RooMsgService::instance().setGlobalKillBelow(gKill);
     }
     isCacheGood_ = true;


### PR DESCRIPTION
The histogram returned by createHistogram is still not normalized.
So, we must first normalize it and then add up the overflows,
otherwise the overflows will be scaled by the number of entries in the dataset
