### PR TITLE
implemented needed function in SimplCacheSentry

### DIFF
--- a/interface/SimpleCacheSentry.h
+++ b/interface/SimpleCacheSentry.h
@@ -32,6 +32,7 @@ class SimpleCacheSentry : public RooAbsArg {
         virtual void attachToVStore(RooVectorDataStore& vstore) {}
         virtual void setTreeBranchStatus(TTree& t, Bool_t active) {}
         virtual void fillTreeBranch(TTree& t) {}
+	virtual Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) ;
     private:
         RooSetProxy _deps;
         ClassDef(SimpleCacheSentry,1) 

--- a/src/SimpleCacheSentry.cc
+++ b/src/SimpleCacheSentry.cc
@@ -44,4 +44,15 @@ void SimpleCacheSentry::addFunc(const RooAbsArg &func, const RooArgSet *obs)
     delete deps;
 }
 
+Bool_t SimpleCacheSentry::isIdentical(const RooAbsArg& other, 
+				    Bool_t /*assumeSameType*/) {
+  bool ret = kFALSE;
+  SimpleCacheSentry const& otherSentry = dynamic_cast<SimpleCacheSentry const&>(other);
+  RooAbsCollection * common = _deps.selectCommon(otherSentry._deps);
+  if ( (common->getSize() == otherSentry._deps.getSize()) && 
+       (common->getSize() == _deps.getSize()) )
+    ret = kTRUE;
+  delete common;
+  return ret;
+}
 


### PR DESCRIPTION
The RooAbsArg has a purely virtual method isIdentical(...).  For SimpleCacheSentry to not be an abstract class it needs to implement this method.  I wrote a basic implementation.
