### PR TITLE
properly flag lack of support for analytic integration over reduced range

### DIFF
--- a/interface/RooBernsteinFast.h
+++ b/interface/RooBernsteinFast.h
@@ -71,6 +71,12 @@ public:
   
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const
     {
+      
+      // No analytical calculation available (yet) of integrals over subranges (as for standard RooBernstein)
+      if (rangeName && strlen(rangeName)) {
+        return 0 ;
+      }      
+      
       if (matchArgs(allVars, analVars, _x)) return 1;
       return 0;
     }


### PR DESCRIPTION
Fixes problem using RooBernsteinFast with reduced fit/plotting ranges reported by @adavidzh and @matthewkenzie
