### PR TITLE
Fqq default is not floating

### DIFF
--- a/python/HiggsJPC.py
+++ b/python/HiggsJPC.py
@@ -51,10 +51,14 @@ class TwoHypotesisHiggs(PhysicsModel):
 		self.fqqIncluded = True
                 self.muFloating = True
 	    if po == "fqqFloating":
+		self.fqqIncluded = True
 		self.fqqFloating = True
 		self.fqqRange = "0.","1."
+                self.muFloating = True
             if po.startswith("fqqRange="):
+		self.fqqIncluded = True
 		self.fqqFloating = True
+                self.muFloating = True
                 self.fqqRange = po.replace("fqqRange=","").split(",")
                 if len(self.mHRange) != 2:
                     raise RuntimeError, "fqq range definition requires two extrema"


### PR DESCRIPTION
Now to make HiggsJPC workspace with fqq included use:

--PO=fqqIncluded --setPhysicsModelParameters fqq=0.0 (to set fqq as constant)
--PO=fqqFloating (to set fqq as floating with default range 0-1) can also optionally have --PO=fqqRange to change the range. 

Also means back compatible with previous version.
