### PR TITLE
save post-fit snapshot in workspace for MultiDimFit and add ability to l...

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -64,6 +64,7 @@ private:
   // input-output related variables
   bool saveWorkspace_;
   std::string workspaceName_;
+  std::string snapshotName_;
   std::string modelConfigName_, modelConfigNameB_;
   bool validateModel_;
   bool saveToys_;

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -104,6 +104,7 @@ Combine::Combine() :
     ioOptions_.add_options()
       ("saveWorkspace", "Save workspace to output root file")
       ("workspaceName,w", po::value<std::string>(&workspaceName_)->default_value("w"), "Workspace name, when reading it from or writing it to a rootfile.")
+      ("snapshotName", po::value<std::string>(&snapshotName_)->default_value(""), "Default snapshot name for pre-fit snapshot for reading or writing to workspace")
       ("modelConfigName",  po::value<std::string>(&modelConfigName_)->default_value("ModelConfig"), "ModelConfig name, when reading it from or writing it to a rootfile.")
       ("modelConfigNameB", po::value<std::string>(&modelConfigNameB_)->default_value("%s_bonly"), "Name of the ModelConfig for b-only hypothesis.\n"
                                                                                                   "If not present, it will be made from the singal model taking zero signal strength.\n"
@@ -299,6 +300,9 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
         mc_bonly = new RooStats::ModelConfig(*mc);
         mc_bonly->SetPdf(*model_b);
     }
+    if (snapshotName_ != "") {
+      w->loadSnapshot(snapshotName_.c_str());
+    }
   } else {
     hlf.reset(new RooStats::HLFactory("factory", fileToLoad));
     w = hlf->GetWs();
@@ -441,12 +445,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   addPOI(POI);
 
   w->saveSnapshot("clean", w->allVars());
-
-  if (saveWorkspace_) {
-    w->SetName(workspaceName_.c_str());
-    outputFile->WriteTObject(w,workspaceName_.c_str());
-  }
-
+  
   tree_ = tree;
 
   bool isExtended = mc_bonly->GetPdf()->canBeExtended();
@@ -627,6 +626,12 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
         cout << "   95% expected band : " << lo95 << " < r < " << hi95 << endl;
     }
   }
+  
+  if (saveWorkspace_) {
+    w->SetName(workspaceName_.c_str());
+    w->loadSnapshot("clean");
+    outputFile->WriteTObject(w,workspaceName_.c_str());
+  }  
 
 }
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -113,6 +113,10 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     if (algo_ != None && algo_ != Singles) {
         nll.reset(pdf.createNLL(data, constrainCmdArg, RooFit::Extended(pdf.canBeExtended())));
     } 
+    
+    //set snapshot for best fit
+    w->saveSnapshot("MultiDimFit",w->allVars());
+    
     switch(algo_) {
         case None: 
             if (verbose > 0) {


### PR DESCRIPTION
...oad named snapshot from the command line.

Usage example:

``` bash
text2workspace.py hgg_datacard_mva_8TeV_bernsteins.txt -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingHiggsMass --PO higgsMassRange=120,130 -o testmass.root

combine -m 123 -M MultiDimFit --saveWorkspace -n teststep1 testmass.root  --verbose 9

combine -m 123 -M MaxLikelihoodFit -d higgsCombineteststep1.MultiDimFit.mH123.root -w w --snapshotName "MultiDimFit" -n teststep2  --verbose 9 --freezeNuisances MH,lumi_8TeV
```

In the above example, one sets up and performs the floating mu,MH fit.

Then for the final step, the output is loaded and a new fit performed with MH and lumi_8TeV frozen to their best-fit values from the previous fit.  (Any nuisance or other floating parameter in the workspace or physics model can be specified in freezeNuisances and things should behave properly)
