### PR TITLE
add ability to bypass frequenist fit (in case eg. input snapshot already...

### DIFF
--- a/interface/AsimovUtils.h
+++ b/interface/AsimovUtils.h
@@ -6,6 +6,6 @@ namespace asimovutils {
     /// Generate asimov dataset from nominal value of nuisance parameters
     RooAbsData * asimovDatasetNominal(RooStats::ModelConfig *mc, double poiValue=0.0, int verbose=0) ;
     /// Generate asimov dataset from best fit value of nuisance parameters, and fill in snapshot of corresponding global observables
-    RooAbsData * asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsData &realdata, RooAbsCollection &snapshot, double poiValue=0.0, int verbose=0) ;
+    RooAbsData * asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsData &realdata, RooAbsCollection &snapshot, bool needsFit, double poiValue=0.0, int verbose=0) ;
 }
 

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -21,6 +21,8 @@ extern int verbose;
 extern bool withSystematics;
 extern bool doSignificance_, lowerLimit_;
 extern float cl;
+extern bool bypassFrequentistFit_;
+
 
 class Combine {
 public:
@@ -66,6 +68,7 @@ private:
   std::string workspaceName_;
   std::string snapshotName_;
   std::string modelConfigName_, modelConfigNameB_;
+  bool overrideSnapshotMass_;
   bool validateModel_;
   bool saveToys_;
   double mass_;

--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -23,22 +23,21 @@ RooAbsData *asimovutils::asimovDatasetNominal(RooStats::ModelConfig *mc, double 
         return asimov;
 }
 
-RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsData &realdata, RooAbsCollection &snapshot, double poiValue, int verbose) {
+RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsData &realdata, RooAbsCollection &snapshot, bool needsFit, double poiValue, int verbose) {
         RooArgSet  poi(*mc->GetParametersOfInterest());
         RooRealVar *r = dynamic_cast<RooRealVar *>(poi.first());
         r->setConstant(true); r->setVal(poiValue);
         {
             CloseCoutSentry sentry(verbose < 3);
-            bool needsFit = false; 
             if (mc->GetNuisanceParameters()) {
-                needsFit = true;
+                needsFit &= true;
             } else {
                 // Do we have free parameters anyway that need fitting?
                 std::auto_ptr<RooArgSet> params(mc->GetPdf()->getParameters(realdata));
                 std::auto_ptr<TIterator> iter(params->createIterator());
                 for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
                     RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
-                    if ( rrv != 0 && rrv->isConstant() == false ) { needsFit = true; break; }
+                    if ( rrv != 0 && rrv->isConstant() == false ) { needsFit &= true; break; }
                 } 
             }
             if (needsFit) {

--- a/src/Asymptotic.cc
+++ b/src/Asymptotic.cc
@@ -696,7 +696,7 @@ RooAbsData * Asymptotic::asimovDataset(RooWorkspace *w, RooStats::ModelConfig *m
     }
     // get asimov dataset and global observables
     RooAbsData *asimovData = (noFitAsimov_  ? asimovutils::asimovDatasetNominal(mc_s, 0.0, verbose) :
-                                              asimovutils::asimovDatasetWithFit(mc_s, data, snapGlobalObsAsimov, 0.0, verbose));
+                                              asimovutils::asimovDatasetWithFit(mc_s, data, snapGlobalObsAsimov,!bypassFrequentistFit_, 0.0, verbose));
     asimovData->SetName("_Asymptotic_asimovDataset_");
     w->import(*asimovData); // I'm assuming the Workspace takes ownership. Might be false.
     delete asimovData;      //  ^^^^^^^^----- now assuming that the workspace clones.


### PR DESCRIPTION
... corresponds to S+B fit), and also to force override of snapshot mass from the command line (changes in general to allow post-fit expected with b from global S+B floating mu-mh fit)
