### PR TITLE
Avoid fit duplication in iterative fit

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -242,8 +242,10 @@ bool CascadeMinimizer::minimize(int verbose, bool cascade)
     bool ret = true;
 
     if (runShortCombinations) {
-      double minimumNLL = 10+nll_.getVal();
-      double previousNLL = 1+nll_.getVal();
+      // Initial fit under current index values
+      improve(verbose, cascade);
+      double minimumNLL  = 10+nll_.getVal();
+      double previousNLL = nll_.getVal();
       int maxIterations = 15; int iterationCounter=0;
       for (;iterationCounter<maxIterations;iterationCounter++){
         iterativeMinimize(minimumNLL,verbose,cascade);


### PR DESCRIPTION
Removed a duplication of a fit if the discrete indices are already at the profiled values.
This was due to "previous" nll being ill-defined so the second iteration was performed even if not necessary.
