### PR TITLE
remove enforcing of positive POI for Profile Test Stat in HybridNew

### DIFF
--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -650,7 +650,8 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
       if (testStat_ != "MLZ" && testStat_ != "Profile") r->setMax(rVal); 
       r->setVal(rVal); 
       if (testStat_ == "LHC" || testStat_ == "Profile") {
-        r->setConstant(false); r->setMin(0); 
+        r->setConstant(false); 
+	if (testStat == "LHC") r->setMin(0); 
         if (workingMode_ == MakeSignificance || workingMode_ == MakeSignificanceTestStatistics) {
             r->setVal(0);
             // r->removeMax(); // NO, this is done within the test statistics, and knowing the scale of the variable is useful


### PR DESCRIPTION
If running Profile testStat in HybridNew, no longer enforce the first POI 
of a 1 POI workspace to be positive
