### PR TITLE
Fix param nuisances with range

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -183,7 +183,14 @@ class ModelBuilder(ModelBuilderBase):
                     if sigmaL[0] != "-" or sigmaR[0] != "+": raise RuntimeError, "Asymmetric parameter uncertainties should be entered as -x/+y"
                     sigmaL = sigmaL[1:]; sigmaR = sigmaR[1:]
                     if len(args) == 3: # mean, sigma, range
-                        self.doVar("%s%s" % (n,args[2]))
+                        if self.out.var(n):
+                          bounds = [float(x) for x in args[2][1:-1].split(",")]
+                          self.out.var(n).setConstant(False)
+                          if (self.out.var(n).getMin() != bounds[0] or self.out.var(n).getMax() != bounds[1]):
+                            print "Resetting range for %s to be [%s,%s] from param statement (was [%s,%s])" % (n, bounds[0], bounds[1], self.out.var(n).getMin(), self.out.var(n).getMax())
+                          self.out.var(n).setRange(bounds[0],bounds[1])
+                        else:
+                          self.doVar("%s%s" % (n,args[2]))
                     else:
                         if self.out.var(n):
                           self.out.var(n).setConstant(False)
@@ -195,7 +202,14 @@ class ModelBuilder(ModelBuilderBase):
                     self.out.var("%s_In" % n).setConstant(True)
                 else:
                     if len(args) == 3: # mean, sigma, range
-                        self.doVar("%s%s" % (n,args[2]))
+                        if self.out.var(n):
+                          bounds = [float(x) for x in args[2][1:-1].split(",")]
+                          self.out.var(n).setConstant(False)
+                          if (self.out.var(n).getMin() != bounds[0] or self.out.var(n).getMax() != bounds[1]):
+                            print "Resetting range for %s to be [%s,%s] from param statement (was [%s,%s])" % (n, bounds[0], bounds[1], self.out.var(n).getMin(), self.out.var(n).getMax())
+                            self.out.var(n).setRange(bounds[0],bounds[1])
+                        else:
+                          self.doVar("%s%s" % (n,args[2]))
                     else:
                         sigma = float(args[1])
                         if self.out.var(n):


### PR DESCRIPTION
Before, param nuisances with an explicit range could give errors if they hadn't been created with a factory statement identical to the one used by combine.
Now, if a variable specified as param nuisance with an explicit range already exist, it sets the range appropriately instead of recreating it.
