### PR TITLE
Fixed crash when running singles algo with discrete params

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -90,7 +90,7 @@ bool CascadeMinimizer::improveOnce(int verbose)
 
 
 bool CascadeMinimizer::minos(const RooArgSet & params , int verbose ) {
-
+   
    minimizer_->setPrintLevel(verbose-1); // for debugging
    std::string myType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
    std::string myAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
@@ -160,9 +160,11 @@ are freely floating. We should cut them down to find which ones are
    if (simnll) simnll->clearZeroPoint();
 
    utils::setAllConstant(frozen,false);
-   minimizer_.reset(new RooMinimizerOpt(nll_));
 
-   if (discretesHaveChanged) improve(verbose, cascade); 
+   if (discretesHaveChanged) { 
+        minimizer_.reset(new RooMinimizerOpt(nll_));
+   	improve(verbose, cascade); 
+   }
    minimumNLL = nll_.getVal();
    return ret;
 }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -175,7 +175,11 @@ void MultiDimFit::doSingles(RooFitResult &res)
         len = std::max<int>(len, poi_[i].length());
     }
     for (int i = 0, n = poi_.size(); i < n; ++i) {
-        RooRealVar *rf = dynamic_cast<RooRealVar*>(res.floatParsFinal().find(poi_[i].c_str()));
+	RooAbsArg *rfloat = res.floatParsFinal().find(poi_[i].c_str());
+	if (!rfloat) {
+		rfloat = res.constPars().find(poi_[i].c_str());
+	}
+        RooRealVar *rf = dynamic_cast<RooRealVar*>(rfloat);
         double bestFitVal = rf->getVal();
 
         double hiErr = +(rf->hasRange("err68") ? rf->getMax("err68") - bestFitVal : rf->getAsymErrorHi());


### PR DESCRIPTION
singles algo would crash if last iteration in discretes loop was not a "full floating" fit
