### PR TITLE
RooExponential's slope is composed by multipars

### DIFF
--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -435,6 +435,8 @@ cacheutils::makeCachingPdf(RooAbsReal *pdf, const RooArgSet *obs) {
     } else if (gaussNll && typeid(*pdf) == typeid(RooGaussian)) {
         return new CachingGaussPdf(pdf, obs);
     } else if (gaussNll && typeid(*pdf) == typeid(RooExponential)) {
+	std::auto_ptr<RooArgSet> params(pdf->getParameters(obs));
+	if(params->getSize()!=1) {return new CachingPdf(pdf,obs);}
         return new CachingExpoPdf(pdf, obs);
     } else if (gaussNll && typeid(*pdf) == typeid(RooPower)) {
         return new CachingPowerPdf(pdf, obs);


### PR DESCRIPTION
RooExponential's slope is composed by multipars (e.g. HWWlvJ pdf),

let the code make a plain CachingPdf instead of vectorizing it
