### PR TITLE
Add groups of nuisances

### DIFF
--- a/data/tutorials/groupnuisA.txt
+++ b/data/tutorials/groupnuisA.txt
@@ -1,0 +1,46 @@
+# -S 0 
+# --fastScan (MultiDimFit)
+# --profilingMode (ChannelCompatibilityCheck)
+
+
+imax 1  # number of channels
+jmax 1  # number of processes-1
+kmax *  # number of nuisance parameters
+--------------------------
+bin             hww       
+observation     18        
+-------------------------- 
+bin             hww hww   
+process         ggH bkgww
+process           0   1   
+rate             11   7   
+
+lumi lnN        1.05  -
+theo_ggH lnN	1.10  -
+theo_bkgww lnN	- 1.10
+exp_systww lnN		    1.05 1.05
+MCstatww lnN       1.01 -
+
+theo group = theo_bkgww theo_ggH
+theoB group = theo_bkgww
+theoS group = theo_ggH
+lumi group = lumi
+stat group = MCstatww
+
+#does not exist: error in modeltools
+#dummy group = foobar
+
+#empty error
+#testempty group
+
+#missing [+]=
+#testsyntax group bla bla bla
+#testsyntax group -= bla bla bla
+
+#add before define
+#add group += lumi
+
+equals group = lumi
+equals group += lumi MCstatww
+#redefinition error
+#equals group = theo_ggH

--- a/data/tutorials/groupnuisB.txt
+++ b/data/tutorials/groupnuisB.txt
@@ -1,0 +1,24 @@
+imax 1  # number of channels
+jmax 1  # number of processes-1
+kmax *  # number of nuisance parameters
+--------------------------
+bin             hgg
+observation     25
+-------------------------- 
+bin             hgg hgg
+process         ggH bkggg
+process           0   1
+rate             10   8
+
+lumi lnN        1.05  -
+theo_ggH lnN	1.10  -
+theo_bkggg lnN	- 1.10
+exp_systgg lnN		    1.05 1.05
+MCstatgg lnN       1.01 -
+
+theo group = theo_bkggg theo_ggH
+theoB group = theo_bkggg
+theoS group = theo_ggH
+lumi group = lumi
+stat group = MCstatgg
+

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -3,6 +3,8 @@
 #include <TString.h>
 #include <boost/program_options.hpp>
 #include "RooArgSet.h"
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 
 class TDirectory;
 class TTree;
@@ -62,6 +64,7 @@ private:
   std::string setPhysicsModelParameterRangeExpression_;
   std::string redefineSignalPOIs_;
   std::string freezeNuisances_;
+  std::string freezeNuisanceGroups_;
   
   // input-output related variables
   bool saveWorkspace_;

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -145,7 +145,13 @@ for ich,fname in enumerate(args):
             bout = label if singlebin else label+b
             if isVetoed(bout,options.channelVetos): continue
 	    if not isIncluded(bout,options.channelIncludes): continue
-            obsline += [str(DC.obs[b])]; 
+            obsline += [str(DC.obs[b])];
+    #get the groups - keep nuisances in a set so that they are never repetitions
+    for groupName,nuisanceNames in DC.groups.iteritems():
+        if groupName in groups:
+            groups[groupName].update(set(nuisanceNames))
+        else:
+            groups[groupName] = set(nuisanceNames)
 
 bins = []
 for (b,p,s) in keyline:
@@ -215,6 +221,8 @@ for (pname, pargs) in paramSysts.items():
 
 for pname in flatParamNuisances.iterkeys(): 
     print "%-12s  flatParam" % pname
-
 for dname in discreteNuisances.iterkeys(): 
-    print "%-12s  discrete" % dname
+     print "%-12s  discrete" % dname
+for groupName,nuisanceNames in groups.iteritems():
+    nuisances = ' '.join(nuisanceNames)
+    print '%(groupName)s group = %(nuisances)s' % locals()

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -103,6 +103,7 @@ Combine::Combine() :
       ("setPhysicsModelParameterRanges", po::value<string>(&setPhysicsModelParameterRangeExpression_)->default_value(""), "Set the range of relevant physics model parameters. Give a colon separated list of parameter ranges. Example: CV=0.0,2.0:CF=0.0,5.0")      
       ("redefineSignalPOIs", po::value<string>(&redefineSignalPOIs_)->default_value(""), "Redefines the POIs to be this comma-separated list of variables from the workspace.")      
       ("freezeNuisances", po::value<string>(&freezeNuisances_)->default_value(""), "Set as constant all these nuisance parameters.")      
+      ("freezeNuisanceGroups", po::value<string>(&freezeNuisanceGroups_)->default_value(""), "Set as constant all these groups of nuisance parameters.")      
       ;
     ioOptions_.add_options()
       ("saveWorkspace", "Save workspace to output root file")
@@ -422,6 +423,22 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           mc->SetNuisanceParameters(newnuis);
           if (mc_bonly) mc_bonly->SetNuisanceParameters(newnuis);
           nuisances = mc->GetNuisanceParameters();
+      }
+  }
+  if (freezeNuisanceGroups_ != "") {
+      std::vector<string> nuisanceGroups;
+      boost::algorithm::split(nuisanceGroups,freezeNuisanceGroups_,boost::algorithm::is_any_of(","));
+      for (std::vector<string>::iterator ng_it=nuisanceGroups.begin();ng_it!=nuisanceGroups.end();ng_it++){
+        RooArgSet toFreeze(*(w->set(Form("group_%s",(*ng_it).c_str()))));
+        if (verbose > 0) std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print("");
+        utils::setAllConstant(toFreeze, true);
+        if (nuisances) {
+          RooArgSet newnuis(*nuisances);
+          newnuis.remove(toFreeze, /*silent=*/true, /*byname=*/true);      
+          mc->SetNuisanceParameters(newnuis);
+          mc_bonly->SetNuisanceParameters(newnuis);
+          nuisances = mc->GetNuisanceParameters();
+       }
       }
   }
 


### PR DESCRIPTION
closes #32
Adding grouping of nuisance parameters in datacards. 
Example datacards with use cases are found in 
data/tutorials/groupnuisA.txt
data/tutorials/groupnuisB.txt

Groups of nuisances can be frozen with --freezeNuisanceGroups group1,group2...
This can be used in conjunction with best fit snapshots.
