### PR TITLE
fix singles algo when using discrete parameters

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -156,7 +156,7 @@ are freely floating. We should cut them down to find which ones are
    std::vector<std::vector<bool>> contIndex;
    // start from simplest scan, this is the full scan if runShortCombinations is off
    //bool discretesHaveChanged = 
-   //multipleMinimize(reallyCleanParameters,ret,minimumNLL,verbose,cascade,0,contIndex); 
+   multipleMinimize(reallyCleanParameters,ret,minimumNLL,verbose,cascade,0,contIndex); 
  
    if (simnll) simnll->clearZeroPoint();
 


### PR DESCRIPTION
Enforce one more full floating fit after discrete loops to make sure RooFitResult is consistent with last minimizer state for Methods that need it (such as singles algo in MultiDimFit).
