### PR TITLE
FastVerticalInterpHistPdf2 import

### DIFF
--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -285,6 +285,7 @@ protected:
 
   // initialize the morphParams and the sentry. to be called by the daughter class, sets also _initBase to true
   void initBase() const ; 
+  virtual Bool_t  importWorkspaceHook(RooWorkspace& ws);
 
 private:
   ClassDef(FastVerticalInterpHistPdf2Base,1) // 

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -747,6 +747,12 @@ FastVerticalInterpHistPdf2Base::FastVerticalInterpHistPdf2Base(const FastVertica
 }
 
 
+Bool_t FastVerticalInterpHistPdf2Base::importWorkspaceHook(RooWorkspace& ws) {
+  _initBase = false;
+  _morphParams.clear();
+  _sentry.reset();
+  return kFALSE;
+}
 
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Noticed a problem with importing a FastVerticalInterpHistPdf2 into a workspace, then trying to call evaluate() on the copy made in the workspace. The objects pointed to in the vector `_morphParams` are still the instances created prior to the import outside the workspace, and may well have gone out of scope by this point. 

Unlikely many users will run into this, but I put a fix in this PR in case it's helpful.
