### PR TITLE
Delete temp file roostats-XXXXXX when running from text datacard

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -225,6 +225,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       char buff[99]; snprintf(buff, 98, "roostats-XXXXXX");
       int fd = mkstemp(buff); close(fd);
       tmpFile = buff;
+      unlink(tmpFile); // this is to be deleted, since we'll use tmpFile+".root"
   }
 
   bool isTextDatacard = false, isBinary = false;


### PR DESCRIPTION
Delete the empty temporary file roostats-XXXXXX  when running from a text datacard directly