### PR TITLE
remove "static"  for  nPA initialization

### DIFF
--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -132,7 +132,7 @@ RooDataSet *
 toymcoptutils::SinglePdfGenInfo::generateAsimov(RooRealVar *&weightVar, double weightScale) 
 {
     if (mode_ == Counting) return generateCountingAsimov();
-    static int nPA = runtimedef::get("TMCSO_PseudoAsimov");
+    int nPA = runtimedef::get("TMCSO_PseudoAsimov");
     if (observables_.getSize() > 1 && runtimedef::get("TMCSO_AdaptivePseudoAsimov")) {
         int nbins = 1;
         RooLinkedListIter iter = observables_.iterator(); 


### PR DESCRIPTION
"statis" is wrong here, because we overwrite nPA later and it doesn't get reinitialised for the next channel since it's static.