### PR TITLE
Added "discrete parameters" (if exists) to the list of parameters passed to setModelParameters

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -335,7 +335,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   //set physics model parameters    after loading the snapshot
   //*********************************************
   if (setPhysicsModelParameterExpression_ != "") {
-      utils::setModelParameters( setPhysicsModelParameterExpression_, w->allVars());
+      RooArgSet allParams(w->allVars());
+      if (w->genobj("discreteParams")) allParams.add(*(RooArgSet*)w->genobj("discreteParams"));
+      utils::setModelParameters( setPhysicsModelParameterExpression_, allParams);
+      // also allow for "discrete" parameters to be set 
   }
 
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -564,13 +564,27 @@ void utils::setModelParameters( const std::string & setPhysicsModelParameterExpr
     if (SetParameterExpression.size() != 2) {
       std::cout << "Error parsing physics model parameter expression : " << SetParameterExpressionList[p] << endl;
     } else {
-      double PhysicsParameterValue = atof(SetParameterExpression[1].c_str());
-      RooRealVar *tmpParameter = (RooRealVar*)params.find(SetParameterExpression[0].c_str());      
-      if (tmpParameter) {
-        cout << "Set Default Value of Parameter " << SetParameterExpression[0] 
-             << " To : " << PhysicsParameterValue << "\n";
-        tmpParameter->setVal(PhysicsParameterValue);
-      } else {
+      
+      RooAbsArg  *tmp = (RooAbsArg*)params.find(SetParameterExpression[0].c_str());     
+      if (tmp){
+
+        bool isrvar = tmp->IsA()->InheritsFrom(RooRealVar::Class());  // check its type
+
+        if (isrvar) {
+          RooRealVar *tmpParameter = dynamic_cast<RooRealVar*>(tmp);
+          double PhysicsParameterValue = atof(SetParameterExpression[1].c_str());
+          cout << "Set Default Value of Parameter " << SetParameterExpression[0] 
+               << " To : " << PhysicsParameterValue << "\n";
+          tmpParameter->setVal(PhysicsParameterValue);
+        } else {
+          RooCategory *tmpCategory  = dynamic_cast<RooCategory*>(tmp);
+          int PhysicsParameterValue = atoi(SetParameterExpression[1].c_str());
+          cout << "Set Default Index of Parameter " << SetParameterExpression[0] 
+               << " To : " << PhysicsParameterValue << "\n";
+          tmpCategory->setIndex(PhysicsParameterValue);
+	}
+      }
+        else {
         std::cout << "Warning: Did not find a parameter with name " << SetParameterExpression[0] << endl;
       }
     }


### PR DESCRIPTION
Users can specify a discrete parameter's (RooCategory) default value.
This would be useful for example in bias studies where one pdf is used
to generate toys and another to fit.