### PR TITLE
fixes of constant optimization when running on atlas workspaces

### DIFF
--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -244,8 +244,15 @@ int main(int argc, char **argv) {
   runtimedef::set("ADDNLL_HISTNLL", 1);
   runtimedef::set("ADDNLL_CBNLL", 1);
   runtimedef::set("TMCSO_AdaptivePseudoAsimov", 1);
+  // Optimization for bare RooFit likelihoods (--optimizeSimPdf=0)
   runtimedef::set("MINIMIZER_optimizeConst", 2); 
   runtimedef::set("MINIMIZER_rooFitOffset", 1); 
+  // Optimization for ATLAS HistFactory likelihoods
+  runtimedef::set("ADDNLL_ROOREALSUM_FACTOR",1);
+  runtimedef::set("ADDNLL_ROOREALSUM_NONORM",1);
+  runtimedef::set("ADDNLL_ROOREALSUM_BASICINT",1);
+  runtimedef::set("ADDNLL_ROOREALSUM_KEEPZEROS",1);
+
 
   for (vector<string>::const_iterator rtdp = runtimeDefines.begin(), endrtdp = runtimeDefines.end(); rtdp != endrtdp; ++rtdp) {
     std::string::size_type idx = rtdp->find('=');

--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -244,6 +244,8 @@ int main(int argc, char **argv) {
   runtimedef::set("ADDNLL_HISTNLL", 1);
   runtimedef::set("ADDNLL_CBNLL", 1);
   runtimedef::set("TMCSO_AdaptivePseudoAsimov", 1);
+  runtimedef::set("MINIMIZER_optimizeConst", 2); 
+  runtimedef::set("MINIMIZER_rooFitOffset", 1); 
 
   for (vector<string>::const_iterator rtdp = runtimeDefines.begin(), endrtdp = runtimeDefines.end(); rtdp != endrtdp; ++rtdp) {
     std::string::size_type idx = rtdp->find('=');

--- a/interface/CachingMultiPdf.h
+++ b/interface/CachingMultiPdf.h
@@ -15,6 +15,7 @@ namespace cacheutils {
             virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
             const RooAbsReal *pdf() const { return pdf_; }
             virtual void  setDataDirty() ;
+            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         protected:
             const RooMultiPdf * pdf_;
             boost::ptr_vector<CachingPdfBase>  cachingPdfs_;
@@ -27,6 +28,7 @@ namespace cacheutils {
             virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
             const RooAbsReal *pdf() const { return pdf_; }
             virtual void  setDataDirty() ;
+            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         protected:
             const RooAddPdf * pdf_;
             std::vector<const RooAbsReal *> coeffs_;

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -126,7 +126,7 @@ class CachingAddNLL : public RooAbsReal {
         RooAbsPdf *pdf_;
         RooSetProxy params_;
         const RooAbsData *data_;
-        std::vector<Double_t>  weights_;
+        std::vector<Double_t>  weights_, binWidths_;
         double               sumWeights_;
         mutable std::vector<RooAbsReal*> coeffs_;
         mutable boost::ptr_vector<CachingPdfBase>  pdfs_;
@@ -136,6 +136,7 @@ class CachingAddNLL : public RooAbsReal {
         mutable std::vector<Double_t> partialSum_;
         mutable std::vector<Double_t> workingArea_;
         mutable bool isRooRealSum_, fastExit_;
+        mutable int canBasicIntegrals_, basicIntegrals_;
         double zeroPoint_;
 };
 

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -65,6 +65,7 @@ class CachingPdfBase {
         virtual const std::vector<Double_t> & eval(const RooAbsData &data) = 0;
         virtual const RooAbsReal *pdf() const = 0;
         virtual void  setDataDirty() = 0;
+        virtual void  setIncludeZeroWeights(bool includeZeroWeights) = 0;
 };
 class CachingPdf : public CachingPdfBase {
     public:
@@ -74,6 +75,7 @@ class CachingPdf : public CachingPdfBase {
         virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
         const RooAbsReal *pdf() const { return pdf_; }
         virtual void  setDataDirty() { lastData_ = 0; }
+        virtual void  setIncludeZeroWeights(bool includeZeroWeights) { includeZeroWeights_ = includeZeroWeights;  setDataDirty(); }
     protected:
         const RooArgSet *obs_;
         RooAbsReal *pdfOriginal_;
@@ -83,6 +85,7 @@ class CachingPdf : public CachingPdfBase {
         ValuesCache cache_;
         std::vector<uint8_t> nonZeroW_;
         unsigned int         nonZeroWEntries_;
+        bool                 includeZeroWeights_;
         virtual void newData_(const RooAbsData &data) ;
         virtual void realFill_(const RooAbsData &data, std::vector<Double_t> &values) ;
 };
@@ -105,7 +108,7 @@ CachingPdfBase * makeCachingPdf(RooAbsReal *pdf, const RooArgSet *obs) ;
 
 class CachingAddNLL : public RooAbsReal {
     public:
-        CachingAddNLL(const char *name, const char *title, RooAbsPdf *pdf, RooAbsData *data) ;
+        CachingAddNLL(const char *name, const char *title, RooAbsPdf *pdf, RooAbsData *data, bool includeZeroWeights = false) ;
         CachingAddNLL(const CachingAddNLL &other, const char *name = 0) ;
         virtual ~CachingAddNLL() ;
         virtual CachingAddNLL *clone(const char *name = 0) const ;
@@ -119,6 +122,8 @@ class CachingAddNLL : public RooAbsReal {
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() { zeroPoint_ = -this->getVal(); setValueDirty(); }
         void clearZeroPoint() { zeroPoint_ = 0.0; setValueDirty();  }
+        /// note: setIncludeZeroWeights(true) won't have effect unless you also re-call setData
+        virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         RooSetProxy & params() { return params_; }
     private:
         void setup_();
@@ -128,6 +133,7 @@ class CachingAddNLL : public RooAbsReal {
         const RooAbsData *data_;
         std::vector<Double_t>  weights_, binWidths_;
         double               sumWeights_;
+        bool includeZeroWeights_;
         mutable std::vector<RooAbsReal*> coeffs_;
         mutable boost::ptr_vector<CachingPdfBase>  pdfs_;
         mutable boost::ptr_vector<RooAbsReal>  prods_;

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -82,6 +82,8 @@ private:
   bool rebuildSimPdf_;
   bool optSimPdf_;
   bool noMCbonly_;
+  bool floatAllNuisances_;
+  bool freezeAllGlobalObs_;
 
   static TTree *tree_;
 };

--- a/interface/VectorizedCB.h
+++ b/interface/VectorizedCB.h
@@ -17,7 +17,7 @@ class VectorizedCBShape {
             const RooAbsReal & sigmavar() const { return sigma.arg(); }
     };
     public:
-        VectorizedCBShape(const RooCBShape &gaus, const RooAbsData &data) ;
+        VectorizedCBShape(const RooCBShape &gaus, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
         double getIntegral() const ;
 

--- a/interface/VectorizedGaussian.h
+++ b/interface/VectorizedGaussian.h
@@ -14,7 +14,7 @@ class VectorizedGaussian {
             const RooAbsReal & sigvar()  const { return sigma.arg(); }
     };
     public:
-        VectorizedGaussian(const RooGaussian &gaus, const RooAbsData &data) ;
+        VectorizedGaussian(const RooGaussian &gaus, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
     private:
         const RooRealVar * x_;

--- a/interface/VectorizedSimplePdfs.h
+++ b/interface/VectorizedSimplePdfs.h
@@ -8,7 +8,7 @@
 
 class VectorizedExponential {
     public:
-        VectorizedExponential(const RooExponential &pdf, const RooAbsData &data) ;
+        VectorizedExponential(const RooExponential &pdf, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
     private:
         const RooRealVar * x_;
@@ -19,7 +19,7 @@ class VectorizedExponential {
 
 class VectorizedPower {
     public:
-        VectorizedPower(const RooPower &pdf, const RooAbsData &data) ;
+        VectorizedPower(const RooPower &pdf, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
     private:
         const RooRealVar * x_;

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -167,7 +167,7 @@ private:
 
 class FastVerticalInterpHistPdfV {
     public: 
-        FastVerticalInterpHistPdfV(const FastVerticalInterpHistPdf &, const RooAbsData &data) ;
+        FastVerticalInterpHistPdfV(const FastVerticalInterpHistPdf &, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
     private:
         const FastVerticalInterpHistPdf & hpdf_;
@@ -330,7 +330,7 @@ private:
 };
 class FastVerticalInterpHistPdf2V {
     public: 
-        FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &, const RooAbsData &data) ;
+        FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &, const RooAbsData &data, bool includeZeroWeights=false) ;
         void fill(std::vector<Double_t> &out) const ;
     private:
         const FastVerticalInterpHistPdf2 & hpdf_;

--- a/src/CachingMultiPdf.cc
+++ b/src/CachingMultiPdf.cc
@@ -61,6 +61,15 @@ void cacheutils::CachingMultiPdf::setDataDirty()
     }
 }
 
+void cacheutils::CachingMultiPdf::setIncludeZeroWeights(bool includeZeroWeights) 
+{
+    for (CachingPdfBase &pdf : cachingPdfs_) {
+        pdf.setIncludeZeroWeights(includeZeroWeights);
+    }
+}
+
+
+
 cacheutils::CachingAddPdf::CachingAddPdf(const RooAddPdf &pdf, const RooArgSet &obs) :
     pdf_(&pdf)
 {
@@ -111,6 +120,13 @@ void cacheutils::CachingAddPdf::setDataDirty()
 {
     for (CachingPdfBase &pdf : cachingPdfs_) {
         pdf.setDataDirty();
+    }
+}
+
+void cacheutils::CachingAddPdf::setIncludeZeroWeights(bool includeZeroWeights) 
+{
+    for (CachingPdfBase &pdf : cachingPdfs_) {
+        pdf.setIncludeZeroWeights(includeZeroWeights);
     }
 }
 

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -863,7 +863,7 @@ cacheutils::CachingSimNLL::setup_()
             //RooAbsData *data = (RooAbsData *) dataSets_->FindObject(catClone->getLabel());
             //std::cout << "   bin " << ib << " (label " << catClone->getLabel() << ") has pdf " << pdf->GetName() << " of type " << pdf->ClassName() << " and " << (data ? data->numEntries() : -1) << " dataset entries" << std::endl;
             if (data == 0) { throw std::logic_error("Error: no data"); }
-            bool includeZeroWeights = (pdf->getAttribute("BinnedLikelihood") && runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS") && (dynamic_cast<RooRealSumPdf*>(pdf)!=0));
+            bool includeZeroWeights = (runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS") && (dynamic_cast<RooRealSumPdf*>(pdf)!=0));
             pdfs_[ib] = new CachingAddNLL(catClone->getLabel(), "", pdf, data, includeZeroWeights);
             params_.add(pdfs_[ib]->params(), /*silent=*/true); 
         } else { 
@@ -955,7 +955,7 @@ void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const R
         for (int ib = 0; ib < nb; ++ib) {
             catClone->setBin(ib);
             RooAbsPdf *pdf = factorizedPdf_->getPdf(catClone->getLabel());
-            if (pdf->getAttribute("BinnedLikelihood") && (dynamic_cast<RooRealSumPdf*>(pdf)!=0)) {
+            if (dynamic_cast<RooRealSumPdf*>(pdf)!=0) {
                 includeZeroWeights[ib] = 1;
                 includeZeroWeightsAny = true;
             }

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -74,16 +74,19 @@ bool CascadeMinimizer::improve(int verbose, bool cascade)
 bool CascadeMinimizer::improveOnce(int verbose) 
 {
     static int optConst = runtimedef::get("MINIMIZER_optimizeConst");
+    static int rooFitOffset = runtimedef::get("MINIMIZER_rooFitOffset");
     std::string myType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
     std::string myAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
     bool outcome = false;
     if (oldFallback_){
         if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
+        if (rooFitOffset) minimizer_->setOffsetting(std::max(0,rooFitOffset));
         outcome = nllutils::robustMinimize(nll_, *minimizer_, verbose, setZeroPoint_);
     } else {
         cacheutils::CachingSimNLL *simnll = setZeroPoint_ ? dynamic_cast<cacheutils::CachingSimNLL *>(&nll_) : 0;
         if (simnll) simnll->setZeroPoint();
         if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
+        if (rooFitOffset) minimizer_->setOffsetting(std::max(0,rooFitOffset));
         int status = minimizer_->minimize(myType.c_str(), myAlgo.c_str());
         if (simnll) simnll->clearZeroPoint();
         outcome = (status == 0);
@@ -177,6 +180,7 @@ are freely floating. We should cut them down to find which ones are
 bool CascadeMinimizer::minimize(int verbose, bool cascade) 
 {
     static int optConst = runtimedef::get("MINIMIZER_optimizeConst");
+    static int rooFitOffset = runtimedef::get("MINIMIZER_rooFitOffset");
     if (runtimedef::get("CMIN_CENSURE")) {
         RooMsgService::instance().setStreamStatus(0,kFALSE);
         RooMsgService::instance().setStreamStatus(1,kFALSE);
@@ -205,6 +209,7 @@ bool CascadeMinimizer::minimize(int verbose, bool cascade)
         cacheutils::CachingSimNLL *simnll = setZeroPoint_ ? dynamic_cast<cacheutils::CachingSimNLL *>(&nll_) : 0;
         if (simnll) simnll->setZeroPoint();
         if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
+        if (rooFitOffset) minimizer_->setOffsetting(std::max(0,rooFitOffset));
         minimizer_->minimize(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str(), ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
         if (simnll) simnll->clearZeroPoint();
         utils::setAllConstant(frozen,false);

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -78,12 +78,12 @@ bool CascadeMinimizer::improveOnce(int verbose)
     std::string myAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
     bool outcome = false;
     if (oldFallback_){
-        if (optConst) minimizer_->optimizeConst(std::min(0,optConst));
+        if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
         outcome = nllutils::robustMinimize(nll_, *minimizer_, verbose, setZeroPoint_);
     } else {
         cacheutils::CachingSimNLL *simnll = setZeroPoint_ ? dynamic_cast<cacheutils::CachingSimNLL *>(&nll_) : 0;
         if (simnll) simnll->setZeroPoint();
-        if (optConst) minimizer_->optimizeConst(std::min(0,optConst));
+        if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
         int status = minimizer_->minimize(myType.c_str(), myAlgo.c_str());
         if (simnll) simnll->clearZeroPoint();
         outcome = (status == 0);
@@ -204,7 +204,7 @@ bool CascadeMinimizer::minimize(int verbose, bool cascade)
         minimizer_->setStrategy(preFit_-1);
         cacheutils::CachingSimNLL *simnll = setZeroPoint_ ? dynamic_cast<cacheutils::CachingSimNLL *>(&nll_) : 0;
         if (simnll) simnll->setZeroPoint();
-        if (optConst) minimizer_->optimizeConst(std::min(0,optConst));
+        if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
         minimizer_->minimize(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str(), ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
         if (simnll) simnll->clearZeroPoint();
         utils::setAllConstant(frozen,false);

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -121,6 +121,8 @@ Combine::Combine() :
 
       ("validateModel,V", "Perform some sanity checks on the model and abort if they fail.")
       ("saveToys",   "Save results of toy MC in output file")
+      ("floatAllNuisances", po::value<bool>(&floatAllNuisances_)->default_value(true), "Make all nuisance parameters floating")
+      ("freezeAllGlobalObs", po::value<bool>(&freezeAllGlobalObs_)->default_value(true), "Make all global observables constant")
       ;
     miscOptions_.add_options()
       ("newGenerator", po::value<bool>(&newGen_)->default_value(true), "Use new generator code for toys, fixes all issues with binned and mixed generation (equivalent of --newToyMC but affects the top-level toys from option '-t' instead of the ones within the HybridNew)")
@@ -563,10 +565,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   if (validateModel_ && verbose) std::cout << "Sanity checks on the model: " << (validModel ? "OK" : "FAIL") << std::endl;
 
   // make sure these things are set consistently with what we expect
-  if (mc->GetNuisanceParameters() && withSystematics) utils::setAllConstant(*mc->GetNuisanceParameters(), false);
-  if (mc->GetGlobalObservables()) utils::setAllConstant(*mc->GetGlobalObservables(), true);
-  if (mc_bonly && mc_bonly->GetNuisanceParameters() && withSystematics) utils::setAllConstant(*mc_bonly->GetNuisanceParameters(), false);
-  if (mc_bonly && mc_bonly->GetGlobalObservables()) utils::setAllConstant(*mc_bonly->GetGlobalObservables(), true);
+  if (floatAllNuisances_  && mc->GetNuisanceParameters() && withSystematics) utils::setAllConstant(*mc->GetNuisanceParameters(), false);
+  if (freezeAllGlobalObs_ && mc->GetGlobalObservables()) utils::setAllConstant(*mc->GetGlobalObservables(), true);
+  if (floatAllNuisances_  && mc_bonly && mc_bonly->GetNuisanceParameters() && withSystematics) utils::setAllConstant(*mc_bonly->GetNuisanceParameters(), false);
+  if (freezeAllGlobalObs_ && mc_bonly && mc_bonly->GetGlobalObservables()) utils::setAllConstant(*mc_bonly->GetGlobalObservables(), true);
 
   // Setup the CascadeMinimizer with discrete nuisances 
   addDiscreteNuisances(w);

--- a/src/RooMinimizerOpt.cc
+++ b/src/RooMinimizerOpt.cc
@@ -312,9 +312,12 @@ RooMinimizerFcnOpt::DoEval(const double * x) const
       }
   }
 
-  // Calculate the function for these parameters
+  // Calculate the function for these parameters  
+  RooAbsReal::setHideOffset(kFALSE) ;
   double fvalue = _funct->getVal();
-  if (RooAbsPdf::evalError() || RooAbsReal::numEvalErrors()>0) {
+  RooAbsReal::setHideOffset(kTRUE) ;
+
+  if (RooAbsPdf::evalError() || RooAbsReal::numEvalErrors()>0 || fvalue>1e30) {
 
     if (_printEvalErrors>=0) {
 
@@ -342,7 +345,7 @@ RooMinimizerFcnOpt::DoEval(const double * x) const
     } 
 
     if (_doEvalErrorWall) {
-      fvalue = _maxFCN ;
+      fvalue = _maxFCN+1 ;
     }
 
     RooAbsPdf::clearEvalError() ;
@@ -356,10 +359,13 @@ RooMinimizerFcnOpt::DoEval(const double * x) const
   if (_logfile) 
     (*_logfile) << setprecision(15) << fvalue << setprecision(4) << endl;
   if (_verbose) {
-    cout << "\nprevFCN = " << setprecision(10) 
+    cout << "\nprevFCN" << (_funct->isOffsetting()?"-offset":"") << " = " << setprecision(10) 
          << fvalue << setprecision(4) << "  " ;
     cout.flush() ;
   }
+
+  _evalCounter++ ;
+
   return fvalue;
 }
 

--- a/src/SequentialMinimizer.cc
+++ b/src/SequentialMinimizer.cc
@@ -19,8 +19,8 @@
 //#define DEBUG_SM_printf   if (0) printf
 //#define DEBUGV_SM_printf  if (0) printf
 // #define DEBUG_ODM_printf printf
-#define DEBUG_SM_printf  if (fDebug > 1) printf
-#define DEBUGV_SM_printf if (fDebug > 2) printf  
+#define DEBUG_SM_printf  if (PrintLevel() > 1) printf
+#define DEBUGV_SM_printf if (PrintLevel() > 2) printf  
 
 namespace { 
     const double GOLD_R1 = 0.61803399 ;
@@ -384,7 +384,7 @@ bool cmsmath::SequentialMinimizer::improve(int smallsteps)
 
     state_ = Active;
     for (int i = 0; i < bigsteps; ++i) {
-        DEBUG_SM_printf("Start of loop. Strategy %d, State is %s\n",fStrategy,(state_ == Done ? "DONE" : "ACTIVE"));
+        DEBUG_SM_printf("Start of loop. Strategy %d, State is %s\n",Strategy(),(state_ == Done ? "DONE" : "ACTIVE"));
         State newstate = Done;
         int oldActiveWorkers = 0, newActiveWorkers = 0;
         foreach(Worker &w, workers_) {
@@ -404,12 +404,12 @@ bool cmsmath::SequentialMinimizer::improve(int smallsteps)
                 newActiveWorkers++;
             }
         }
-        if (fStrategy >= 2 && newActiveWorkers <= 30) { // arbitrary cut-off
-            DEBUG_SM_printf("Middle of loop. Strategy %d, active workers %d: firing full minimizer\n", fStrategy, newActiveWorkers);
+        if (Strategy() >= 2 && newActiveWorkers <= 30) { // arbitrary cut-off
+            DEBUG_SM_printf("Middle of loop. Strategy %d, active workers %d: firing full minimizer\n", Strategy(), newActiveWorkers);
             if (doFullMinim()) newstate = Done;
         }
         if (newstate == Done) {
-            DEBUG_SM_printf("Middle of loop. Strategy %d, State is %s, active workers %d --> %d \n",fStrategy,(state_ == Done ? "DONE" : "ACTIVE"), oldActiveWorkers, newActiveWorkers);
+            DEBUG_SM_printf("Middle of loop. Strategy %d, State is %s, active workers %d --> %d \n",Strategy(),(state_ == Done ? "DONE" : "ACTIVE"), oldActiveWorkers, newActiveWorkers);
             oldActiveWorkers = 0; newActiveWorkers = 0;
             double y0 = func_->eval();
             std::list<Worker*>::iterator it = doneWorkers.begin();
@@ -434,7 +434,7 @@ bool cmsmath::SequentialMinimizer::improve(int smallsteps)
                     w.nUnaffected = 0;
                     it = doneWorkers.erase(it);
                     newActiveWorkers++;
-                    if (fStrategy == 0) break;
+                    if (Strategy() == 0) break;
                 }
             }
             if (newstate == Active) { // wake up him too
@@ -444,7 +444,7 @@ bool cmsmath::SequentialMinimizer::improve(int smallsteps)
             double y1 = func_->eval();
             edm_ = y0 - y1;
         }
-        DEBUG_SM_printf("End of loop. Strategy %d, State is %s, active workers %d --> %d \n",fStrategy,(state_ == Done ? "DONE" : "ACTIVE"), oldActiveWorkers, newActiveWorkers);
+        DEBUG_SM_printf("End of loop. Strategy %d, State is %s, active workers %d --> %d \n",Strategy(),(state_ == Done ? "DONE" : "ACTIVE"), oldActiveWorkers, newActiveWorkers);
         if (state_ == Done && newstate == Done) {
             DEBUG_SM_printf("Converged after %d big steps\n",i);
             minValue_ = func_->eval();

--- a/src/VectorizedCB.cc
+++ b/src/VectorizedCB.cc
@@ -5,7 +5,7 @@
 #include <RooRealVar.h>
 #include <stdexcept>
 
-VectorizedCBShape::VectorizedCBShape(const RooCBShape &gaus, const RooAbsData &data)
+VectorizedCBShape::VectorizedCBShape(const RooCBShape &gaus, const RooAbsData &data, bool includeZeroWeights)
 {
     RooArgSet obs(*data.get());
     if (obs.getSize() != 1) throw std::invalid_argument("Multi-dimensional dataset?");
@@ -25,7 +25,7 @@ VectorizedCBShape::VectorizedCBShape(const RooCBShape &gaus, const RooAbsData &d
     xvals_.reserve(data.numEntries());
     for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
         obs.assignValueOnly(*data.get(i), true);
-        if (data.weight()) xvals_.push_back(x->getVal());        
+        if (data.weight() || includeZeroWeights) xvals_.push_back(x->getVal());        
     }
     work1_.resize(xvals_.size());
     work2_.resize(xvals_.size());

--- a/src/VectorizedGaussian.cc
+++ b/src/VectorizedGaussian.cc
@@ -4,7 +4,7 @@
 #include <RooRealVar.h>
 #include <stdexcept>
 
-VectorizedGaussian::VectorizedGaussian(const RooGaussian &gaus, const RooAbsData &data)
+VectorizedGaussian::VectorizedGaussian(const RooGaussian &gaus, const RooAbsData &data, bool includeZeroWeights)
 {
     RooArgSet obs(*data.get());
     if (obs.getSize() != 1) throw std::invalid_argument("Multi-dimensional dataset?");
@@ -26,7 +26,7 @@ VectorizedGaussian::VectorizedGaussian(const RooGaussian &gaus, const RooAbsData
     xvals_.reserve(data.numEntries());
     for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
         obs.assignValueOnly(*data.get(i), true);
-        if (data.weight()) xvals_.push_back(x->getVal());        
+        if (data.weight() || includeZeroWeights) xvals_.push_back(x->getVal());        
     }
     work_.resize(xvals_.size());
     work2_.resize(xvals_.size());

--- a/src/VectorizedSimplePdfs.cc
+++ b/src/VectorizedSimplePdfs.cc
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <memory>
 
-VectorizedExponential::VectorizedExponential(const RooExponential &pdf, const RooAbsData &data)
+VectorizedExponential::VectorizedExponential(const RooExponential &pdf, const RooAbsData &data, bool includeZeroWeights)
 {
     RooArgSet obs(*data.get());
     std::auto_ptr<RooArgSet> params(pdf.getParameters(data));
@@ -17,7 +17,7 @@ VectorizedExponential::VectorizedExponential(const RooExponential &pdf, const Ro
     xvals_.reserve(data.numEntries());
     for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
         obs.assignValueOnly(*data.get(i), true);
-        if (data.weight()) xvals_.push_back(x_->getVal());        
+        if (data.weight() || includeZeroWeights) xvals_.push_back(x_->getVal());        
     }
     work_.resize(xvals_.size());
 }
@@ -29,7 +29,7 @@ void VectorizedExponential::fill(std::vector<Double_t> &out) const {
     vectorized::exponentials(xvals_.size(), lambda, norm, &xvals_[0], &out[0], &work_[0]);
 }
 
-VectorizedPower::VectorizedPower(const RooPower &pdf, const RooAbsData &data)
+VectorizedPower::VectorizedPower(const RooPower &pdf, const RooAbsData &data, bool includeZeroWeights)
 {
     RooArgSet obs(*data.get());
     if (obs.find(pdf.base()) == 0) throw std::invalid_argument("Dataset does not depend on the base of the power");
@@ -39,7 +39,7 @@ VectorizedPower::VectorizedPower(const RooPower &pdf, const RooAbsData &data)
     xvals_.reserve(data.numEntries());
     for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
         obs.assignValueOnly(*data.get(i), true);
-        if (data.weight()) xvals_.push_back(x_->getVal());        
+        if (data.weight() || includeZeroWeights) xvals_.push_back(x_->getVal());        
     }
     work_.resize(xvals_.size());
 }

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -599,7 +599,7 @@ void FastVerticalInterpHistPdf3D::setupCaches() const {
 }
 
 
-FastVerticalInterpHistPdfV::FastVerticalInterpHistPdfV(const FastVerticalInterpHistPdf &hpdf, const RooAbsData &data) :
+FastVerticalInterpHistPdfV::FastVerticalInterpHistPdfV(const FastVerticalInterpHistPdf &hpdf, const RooAbsData &data, bool includeZeroWeights) :
     hpdf_(hpdf),begin_(0),end_(0)
 {
     // check init
@@ -612,7 +612,7 @@ FastVerticalInterpHistPdfV::FastVerticalInterpHistPdfV(const FastVerticalInterpH
     bool aligned = true;
     for (int i = 0, n = data.numEntries(); i < n; ++i) {
         obs = *data.get(i);
-        if (data.weight() == 0) continue;
+        if (data.weight() == 0 && !includeZeroWeights) continue;
         int idx = hpdf._cache.FindBin(x.getVal());
         if (!bins.empty() && idx != bins.back() + 1) aligned = false;
         bins.push_back(idx);
@@ -1049,7 +1049,7 @@ void FastVerticalInterpHistPdf2D2::syncTotal() const {
     //printf("Normalized result\n");  _cache.Dump();
 }
 
-FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &hpdf, const RooAbsData &data) :
+FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &hpdf, const RooAbsData &data, bool includeZeroWeights) :
     hpdf_(hpdf),begin_(0),end_(0)
 {
     // check init
@@ -1063,7 +1063,7 @@ FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInter
     bool aligned = true;
     for (int i = 0, n = data.numEntries(); i < n; ++i) {
         obs = *data.get(i);
-        if (data.weight() == 0) continue;
+        if (data.weight() == 0 && !includeZeroWeights) continue;
         int idx = hpdf._cache.FindBin(x.getVal());
         if (!bins.empty() && idx != bins.back() + 1) aligned = false;
         bins.push_back(idx);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -210,7 +210,7 @@ void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArg
         //std::cout << "Function " << func.GetName() << " is a RooProduct with " << components.getSize() << " components." << std::endl;
         std::auto_ptr<TIterator> iter(components.createIterator());
         for (RooAbsReal *funci = (RooAbsReal *) iter->Next(); funci != 0; funci = (RooAbsReal *) iter->Next()) {
-            //std::cout << "  component " << funci->GetName() << " of type " << funci->ClassName() << std::endl;
+            //std::cout << "  component " << funci->GetName() << " of type " << funci->ClassName() << "(dep obs? " << funci->dependsOn(observables) << ")" << std::endl;
             factorizeFunc(observables, *funci, obsTerms, constraints);
         }
     } else if (func.dependsOn(observables)) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -103,7 +103,7 @@ RooAbsPdf *utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, Roo
             if (newpdf != pdfi) { needNew = true; newOwned.add(*newpdf); }
             newFactors.add(*newpdf);
         }
-        if (!needNew) { copyAttributes(pdf, *prod); return prod; }
+        if (!needNew && newFactors.getSize() > 1) { copyAttributes(pdf, *prod); return prod; }
         else if (newFactors.getSize() == 0) return 0;
         else if (newFactors.getSize() == 1) {
             RooAbsPdf *ret = (RooAbsPdf *) newFactors.first()->Clone(TString::Format("%s_obsOnly", pdf.GetName()));

--- a/src/vectorized.cc
+++ b/src/vectorized.cc
@@ -59,3 +59,13 @@ void vectorized::powers(const uint32_t size, double exponent, double norm, const
     }
     vdt::fast_expv(size, workingArea, out);
 }
+
+double vectorized::dot_product(const uint32_t size, double const * __restrict__ vec1, double const *  __restrict__ vec2) {
+    double ret = 0;
+    for (uint32_t i = 0; i < size; ++i) {
+        ret += vec1[i]*vec2[i];
+    }
+    return ret;
+}
+
+

--- a/src/vectorized.h
+++ b/src/vectorized.h
@@ -15,5 +15,8 @@ namespace vectorized {
 
     // powers
     void powers(const uint32_t size, double lambda, double norm, const double* __restrict__ xvals, double * __restrict__ out, double * __restrict__ workingArea) ;
+
+    // dot product of two vectors 
+    double dot_product(const uint32_t size, double const * __restrict__ iarray, double const * __restrict__ iarray2) ;
 }
 

--- a/test/unit/plainfit.cxx
+++ b/test/unit/plainfit.cxx
@@ -1,0 +1,84 @@
+#include <cstdlib>
+#include <unistd.h>
+#include "TFile.h"
+#include "TStopwatch.h"
+#include "RooWorkspace.h"
+#include "RooRealVar.h"
+#include "RooMinimizer.h"
+#include "RooStats/ModelConfig.h"
+#include "Math/MinimizerOptions.h"
+
+int main(int argc, char **argv) {
+    if (argc <= 1) { printf("Usage: %s file -w workspace(=w) -c modelConfig(=ModelConfig) -D dataset(=data_obs)  -S snapshot  -s strategy(=0) -t tolerance(=1) -M param_to_run_minos_on  \n",argv[0]); return 1; }
+    const char *workspace = "w"; // -w
+    const char *dataset   = "data_obs"; // -D
+    const char *modelConfig = "ModelConfig"; // -c
+    const char *snapshot    = NULL; // -S
+    int   strategy    = 0; // -s
+    float tolerance   = 1; // -t
+    const char *minos = NULL; // -M
+    int   optimize    = 2; // -O
+    bool  useFitTo    = false; // -f ( use pdf->fitTo instead of Minimizer )
+    do {
+        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:f");
+        switch (opt) {
+            case 'w': workspace = optarg; break;
+            case 'D': dataset = optarg; break;
+            case 'c': modelConfig = optarg; break;
+            case 'S': snapshot = optarg; break;
+            case 's': strategy = atoi(optarg); break;
+            case 't': tolerance = atof(optarg); break;
+            case 'M': minos = optarg; break;
+            case 'O': optimize = atoi(optarg); break;
+            case 'f': useFitTo = true; break;
+            case '?': std::cerr << "Unsupported option. Please see the code. " << std::endl; return 1; break;
+        }
+        if (opt == -1) break;
+    } while (true);
+    TFile *f = TFile::Open(argv[optind]);
+    if (!f) { std::cerr << "ERROR: could not open " << argv[optind] << std::endl; return 2; }
+    RooWorkspace *w = (RooWorkspace *) f->Get(workspace);
+    if (!w)  { std::cerr << "ERROR: could not find workspace '" << workspace << "' in " << argv[optind] << std::endl; f->ls(); return 2; }
+    RooStats::ModelConfig *mc = (RooStats::ModelConfig *) w->genobj(modelConfig);
+    if (!mc) { std::cerr << "ERROR: could not find ModelConfig '" << modelConfig << "' in worskpace" << std::endl; return 2; }
+    RooAbsData *d = w->data(dataset);
+    if (!d) { 
+        std::cerr << "ERROR: could not find dataset '" << dataset << "' in workspace. Available datasets are: " << std::endl;
+        std::list<RooAbsData*> datasets = w->allData();
+        for (std::list<RooAbsData*>::const_iterator it = datasets.begin(), ed = datasets.end(); it != ed; ++it) {
+            (*it)->Print("");
+        }
+        return 2;
+    }
+    if (minos && !w->var(minos)) {
+        std::cerr << "ERROR: POI '" << minos << "' not found. Available POIs are: " << std::endl;
+        mc->GetParametersOfInterest()->Print("");
+        return 2;
+    }
+    if (snapshot) w->loadSnapshot(snapshot);
+    RooArgSet poi; if (minos) poi.add(*w->var(minos));
+    ROOT::Math::MinimizerOptions::SetDefaultTolerance(tolerance);
+    TStopwatch timer;
+    if (useFitTo) {
+        const RooCmdArg & maybeMinos = (minos ? RooFit::Minos(poi) : RooCmdArg::none());
+        mc->GetPdf()->fitTo(*d, 
+                RooFit::Constrain(*mc->GetNuisanceParameters()),
+                RooFit::Minimizer("Minuit2","minimize"),
+                RooFit::Offset(true),
+                RooFit::Optimize(optimize > 0),
+                RooFit::Strategy(strategy),
+                RooFit::Hesse(kFALSE),
+                maybeMinos);
+        if (minos) w->var(minos)->Print("");
+    } else {
+        RooAbsReal *nll = mc->GetPdf()->createNLL(*d, RooFit::Constrain(*mc->GetNuisanceParameters()));
+        RooMinimizer minim(*nll);
+        minim.setStrategy(strategy);
+        minim.setEps(tolerance);
+        minim.setOffsetting(1);
+        minim.optimizeConst(optimize);
+        minim.minimize("Minuit2","minimize");
+        if (minos) { minim.minos(poi); w->var(minos)->Print(""); }
+    }
+    timer.Stop(); printf("Done in %.2f min (cpu), %.2f min (real)\n", timer.CpuTime()/60., timer.RealTime()/60.);
+}

--- a/test/unit/plainscan.cxx
+++ b/test/unit/plainscan.cxx
@@ -1,0 +1,119 @@
+#include <cstdlib>
+#include <unistd.h>
+#include "TFile.h"
+#include "TTree.h"
+#include "TStopwatch.h"
+#include "RooWorkspace.h"
+#include "RooRealVar.h"
+#include "RooMinimizer.h"
+#include "RooStats/ModelConfig.h"
+#include "Math/MinimizerOptions.h"
+
+int main(int argc, char **argv) {
+    if (argc <= 1) { printf("Usage: %s file -w workspace(=w) -c modelConfig(=ModelConfig) -D dataset(=data_obs)  -S snapshot  -s strategy(=0) -t tolerance(=1) -o outfile(=scan.root) -P poi(=r) -m min -M max -n points(=10)  \n",argv[0]); return 1; }
+    const char *workspace = "w"; // -w
+    const char *dataset   = "data_obs"; // -D
+    const char *modelConfig = "ModelConfig"; // -c
+    const char *snapshot    = NULL; // -S
+    int   strategy    = 0; // -s
+    float tolerance   = 1; // -t
+    float minval      = NAN;
+    float maxval      = NAN;
+    const char *poi = "r"; // -P
+    const char *out = "out.root"; // -P
+    int   optimize    = 2; // -O
+    int   points      = 10;
+    bool  allvars = false;
+    do {
+        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:m:n:o:P:A");
+        switch (opt) {
+            case 'w': workspace = optarg; break;
+            case 'D': dataset = optarg; break;
+            case 'c': modelConfig = optarg; break;
+            case 'S': snapshot = optarg; break;
+            case 's': strategy = atoi(optarg); break;
+            case 't': tolerance = atof(optarg); break;
+            case 'n': points = atoi(optarg); break;
+            case 'm': minval = atof(optarg); break;
+            case 'M': maxval = atof(optarg); break;
+            case 'P': poi = optarg; break;
+            case 'o': out = optarg; break;
+            case 'O': optimize = atoi(optarg); break;
+            case 'A': allvars = true; break;
+            case '?': std::cerr << "Unsupported option. Please see the code. " << std::endl; return 1; break;
+        }
+        if (opt == -1) break;
+    } while (true);
+    TFile *f = TFile::Open(argv[optind]);
+    if (!f) { std::cerr << "ERROR: could not open " << argv[optind] << std::endl; return 2; }
+    RooWorkspace *w = (RooWorkspace *) f->Get(workspace);
+    if (!w)  { std::cerr << "ERROR: could not find workspace '" << workspace << "' in " << argv[optind] << std::endl; f->ls(); return 2; }
+    RooStats::ModelConfig *mc = (RooStats::ModelConfig *) w->genobj(modelConfig);
+    if (!mc) { std::cerr << "ERROR: could not find ModelConfig '" << modelConfig << "' in worskpace" << std::endl; return 2; }
+    RooAbsData *d = w->data(dataset);
+    if (!d) { 
+        std::cerr << "ERROR: could not find dataset '" << dataset << "' in workspace. Available datasets are: " << std::endl;
+        std::list<RooAbsData*> datasets = w->allData();
+        for (std::list<RooAbsData*>::const_iterator it = datasets.begin(), ed = datasets.end(); it != ed; ++it) {
+            (*it)->Print("");
+        }
+        return 2;
+    }
+    if (!w->var(poi)) {
+        std::cerr << "ERROR: POI '" << poi << "' not found. Available POIs are: " << std::endl;
+        mc->GetParametersOfInterest()->Print("");
+        return 2;
+    }
+    if (snapshot) w->loadSnapshot(snapshot);
+    RooRealVar *r = w->var(poi);
+    if (!std::isnan(minval)) r->setMin(minval);
+    if (!std::isnan(maxval)) r->setMax(maxval);
+
+    TFile *fOut = TFile::Open(out,"RECREATE");
+    TTree *limit = new TTree("limit","limit");
+    float xvar, deltaNll; 
+    limit->Branch(poi, &xvar, (std::string(poi)+"/F").c_str());
+    limit->Branch("deltaNLL", &deltaNll, "deltaNLL/F");
+    std::vector<std::pair<float,RooRealVar*> > vars;
+    if (allvars) {
+        RooLinkedListIter iter = w->allVars().iterator();
+        for (RooAbsArg *arg = (RooAbsArg*) iter.Next(); arg; arg = (RooAbsArg*) iter.Next()) {
+            RooRealVar *rrv = dynamic_cast<RooRealVar *>(arg);
+            if (rrv != 0 && !rrv->isConstant() && rrv != r) {
+                vars.push_back(std::make_pair(r->getVal(),r));
+            }
+        }
+        for (std::vector<std::pair<float,RooRealVar*> >::iterator it = vars.begin(), ed = vars.end(); it != ed; ++it) {
+            limit->Branch(it->second->GetName(), & it->first, (std::string(it->second->GetName())+"/F").c_str());
+        }
+    }
+    
+    TStopwatch timer;
+    RooAbsReal *nll = mc->GetPdf()->createNLL(*d, RooFit::Constrain(*mc->GetNuisanceParameters()));
+    RooMinimizer minim(*nll);
+    minim.setStrategy(strategy);
+    minim.setEps(tolerance);
+    minim.setOffsetting(1);
+    minim.optimizeConst(optimize);
+    minim.minimize("Minuit2","minimize");
+    xvar = r->getVal(); deltaNll = 0; 
+    for (std::vector<std::pair<float,RooRealVar*> >::iterator it = vars.begin(), ed = vars.end(); it != ed; ++it) {
+        it->first = it->second->getVal();
+    }
+    limit->Fill();
+    double nll0 = nll->getVal();
+    for (int i = 0; i < points; ++i) {
+        xvar = r->getMin() + ((i+0.5)/points)*(r->getMax()-r->getMin());
+        r->setVal(xvar);
+        minim.minimize("Minuit2","minimize");
+        std::cout << "Point " << i << "/" << points << ": " << poi << " = " << xvar << std::endl;
+        deltaNll = nll->getVal() - nll0; 
+        for (std::vector<std::pair<float,RooRealVar*> >::iterator it = vars.begin(), ed = vars.end(); it != ed; ++it) {
+            it->first = it->second->getVal();
+        }
+        limit->Fill();
+    }
+    timer.Stop(); printf("Done in %.2f min (cpu), %.2f min (real)\n", timer.CpuTime()/60., timer.RealTime()/60.);
+    fOut->Close();
+
+}

--- a/test/unit/testChachingNLL.cxx
+++ b/test/unit/testChachingNLL.cxx
@@ -161,7 +161,7 @@ void testCachingSimTestStat(RooStats::ModelConfig &mc, RooAbsData *data, int nat
     mc.GetParametersOfInterest()->snapshot(snap);
     snap.setRealValue("r", 1);
     snap.Print("V");
-    ProfiledLikelihoodTestStatOpt testStat(*mc.GetObservables(), *pdf, mc.GetNuisanceParameters(), snap, RooArgList(), RooArgList(), 0);
+    ProfiledLikelihoodTestStatOpt testStat(*mc.GetObservables(), *pdf, mc.GetNuisanceParameters(), *mc.GetParametersOfInterest(), snap, RooArgList(), RooArgList(), 0);
     std::cout << "value: " << testStat.Evaluate(*data, snap) << std::endl;
 }
 

--- a/test/unit/testFastVerticalInterpHistPdf.cxx
+++ b/test/unit/testFastVerticalInterpHistPdf.cxx
@@ -74,8 +74,9 @@ void testPdfs(RooStats::ModelConfig &mc, RooAbsData *data, int tries, bool perfo
         RooAbsPdf *pdf = (RooAbsPdf *) allPdfs.at(i);
         if (pdf->dependsOn(*obs) && pdf->InheritsFrom("VerticalInterpHistPdf")) {
             std::cout << "Will use pdf " << pdf->GetName() << " (" << pdf->ClassName() << ")" << std::endl;
+#if 0 // --- no longer supported. why?
             VerticalInterpHistPdf &oldpdf = dynamic_cast<VerticalInterpHistPdf &>(*pdf);
-            FastVerticalInterpHistPdf newpdf(oldpdf);
+            FastVerticalInterpHistPdf newpdf(oldpdf,"nil");
             if (performances) {
                 double tslow = testPerformances(oldpdf,*data,*nuisdata);
                 double tfast = testPerformances(newpdf,*data,*nuisdata);
@@ -83,6 +84,7 @@ void testPdfs(RooStats::ModelConfig &mc, RooAbsData *data, int tries, bool perfo
             } else {
                 testFastHistPdf(oldpdf, newpdf, *data, *nuisdata);
             }
+#endif 
         }
     }
 }


### PR DESCRIPTION
Fix the logic of `--X-rtd MINIMIZER_optimizeConst=N`; now -1, 1, 2 will call RooFit' optimizeConst with arguments 0,1,2 (as it was intended originally). Using 2 may be the best for the moment.