### PR TITLE
Allow to combine lnN and param nuisances with the same name

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -53,6 +53,7 @@ class ModelBuilderBase():
         if self.options.bin: self.out.defineSet(name,vars)
         else: self.out.write("%s = set(%s);\n" % (name,vars));
     def doObj(self,name,type,X):
+        if self.out.obj(name): return 1 # Do not try to reproduce constraint term if it exists
         if self.options.bin: return self.factory_("%s::%s(%s)" % (type, name, X));
         else: self.out.write("%s = %s(%s);\n" % (name, type, X))
     def addDiscrete(self,var):
@@ -120,10 +121,11 @@ class ModelBuilder(ModelBuilderBase):
                     if re.match(pn, n): 
                         sig = float(pf); sigscale = sig * (4 if pdf == "shape" else 7)
                         r = "-%g,%g" % (sigscale,sigscale)
+		r_exp = "" if self.out.var(n) else "[%s]"%r # Specify range to invoke factory to produce a RooRealVar only if it doesn't already exist
                 if self.options.noOptimizePdf:
-                    self.doObj("%s_Pdf" % n, "Gaussian", "%s[%s], %s_In[0,%s], %g" % (n,r,n,r,sig));
+                      self.doObj("%s_Pdf" % n, "Gaussian", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig));
                 else:
-                    self.doObj("%s_Pdf" % n, "SimpleGaussianConstraint", "%s[%s], %s_In[0,%s], %g" % (n,r,n,r,sig));
+                      self.doObj("%s_Pdf" % n, "SimpleGaussianConstraint", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig));
                 self.out.var(n).setVal(0)
                 self.out.var(n).setError(1) 
                 globalobs.append("%s_In" % n)

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -224,7 +224,7 @@ class ModelBuilder(ModelBuilderBase):
                         else:
                           self.doVar("%s[%g,%g]" % (n, mean-4*float(sigmaL), mean+4*float(sigmaR)))
                     self.out.var(n).setVal(mean)
-                    self.doObj("%s_Pdf" % n, "BifurGauss", "%s, %s_In[%s,%g,%g], %s, %s" % (n, n, args[0], self.out.var(n).getMin(), self.out.var(n).getMax(), sigmaL, sigmaR))
+                    self.doObj("%s_Pdf" % n, "BifurGauss", "%s, %s_In[%s,%g,%g], %s, %s" % (n, n, args[0], self.out.var(n).getMin(), self.out.var(n).getMax(), sigmaL, sigmaR),True)
                     self.out.var("%s_In" % n).setConstant(True)
                 else:
                     if len(args) == 3: # mean, sigma, range
@@ -245,7 +245,7 @@ class ModelBuilder(ModelBuilderBase):
                           self.doVar("%s[%g,%g]" % (n, mean-4*sigma, mean+4*sigma))
                     self.out.var(n).setVal(mean)
                     #self.out.var(n).setError(sigma)
-                    self.doObj("%s_Pdf" % n, "Gaussian", "%s, %s_In[%s,%g,%g], %s" % (n, n, args[0], self.out.var(n).getMin(), self.out.var(n).getMax(), args[1]))
+                    self.doObj("%s_Pdf" % n, "Gaussian", "%s, %s_In[%s,%g,%g], %s" % (n, n, args[0], self.out.var(n).getMin(), self.out.var(n).getMax(), args[1]),True)
                     self.out.var("%s_In" % n).setConstant(True)
                 globalobs.append("%s_In" % n)
                 #if self.options.optimizeBoundNuisances: self.out.var(n).setAttribute("optimizeBounds")

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -52,8 +52,8 @@ class ModelBuilderBase():
     def doSet(self,name,vars):
         if self.options.bin: self.out.defineSet(name,vars)
         else: self.out.write("%s = set(%s);\n" % (name,vars));
-    def doObj(self,name,type,X):
-        if self.out.obj(name): return 1 # Do not try to reproduce constraint term if it exists
+    def doObj(self,name,type,X,ignoreExisting=False):
+        if self.out.obj(name) and ignoreExisting: return 1 # Still complain if not explicitly told to ignore the existing object
         if self.options.bin: return self.factory_("%s::%s(%s)" % (type, name, X));
         else: self.out.write("%s = %s(%s);\n" % (name, type, X))
     def addDiscrete(self,var):
@@ -123,9 +123,9 @@ class ModelBuilder(ModelBuilderBase):
                         r = "-%g,%g" % (sigscale,sigscale)
 		r_exp = "" if self.out.var(n) else "[%s]"%r # Specify range to invoke factory to produce a RooRealVar only if it doesn't already exist
                 if self.options.noOptimizePdf:
-                      self.doObj("%s_Pdf" % n, "Gaussian", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig));
+                      self.doObj("%s_Pdf" % n, "Gaussian", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig),True); # Use existing constraint since it could be a param
                 else:
-                      self.doObj("%s_Pdf" % n, "SimpleGaussianConstraint", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig));
+                      self.doObj("%s_Pdf" % n, "SimpleGaussianConstraint", "%s%s, %s_In[0,%s], %g" % (n,r_exp,n,r,sig),True);# Use existing constraint since it could be a param
                 self.out.var(n).setVal(0)
                 self.out.var(n).setError(1) 
                 globalobs.append("%s_In" % n)


### PR DESCRIPTION
Re-use the RooRealVar from the workspace which a pdf depends on in the constraint term if a param nuisance is declared with the same name as lnN or shape (assumes constraint is 0 1! )