### PR TITLE
barlow-beeston lite

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -95,6 +95,7 @@ class OptimizedCachingPdfT : public CachingPdf {
         OptimizedCachingPdfT(const OptimizedCachingPdfT &other) : 
             CachingPdf(other), vpdf_(0) {}
         virtual ~OptimizedCachingPdfT() { delete vpdf_; }
+        VPdfT const* vpdf() const { return vpdf_; } // need access to this for bb-lite
     protected:
         virtual void realFill_(const RooAbsData &data, std::vector<Double_t> &values) ;
         virtual void newData_(const RooAbsData &data) ;
@@ -137,6 +138,12 @@ class CachingAddNLL : public RooAbsReal {
         mutable std::vector<Double_t> workingArea_;
         mutable bool isRooRealSum_, fastExit_;
         double zeroPoint_;
+
+        std::vector<RooRealVar *> bbLiteVars_; // store vars here for faster access
+        std::vector<double> bbLiteScales_; // store scales here for faster access
+        double SolveBBLite(double exp, double err, double obs) const;
+        // don't want to solve bins unless the pdf sum has changed
+        mutable ArgSetChecker bbChecker_;
 };
 
 class CachingSimNLL  : public RooAbsReal {

--- a/interface/Logging.h
+++ b/interface/Logging.h
@@ -1,0 +1,117 @@
+#ifndef CombineTools_Logging_h
+#define CombineTools_Logging_h
+#include <string>
+#include <iostream>
+#include <chrono>
+
+namespace ch {
+
+#define FNERROR(x) FnError(x, __FILE__, __LINE__, __PRETTY_FUNCTION__)
+
+#define LOGLINE(x, y) LogLine(x, __func__, y)
+
+#define FNLOG(x) x << "[" << __func__ << "]"
+#define FNLOGC(x, y) if (y) x << "[" << __func__ << "] "
+/**
+ * \brief Writes a logging message to a given ostream
+ * \details Should be used with the macro LOGLINE which will call this function
+ * and automatically insert the name of the calling function, e.g.:
+ *
+ *      void MyFunc() {
+ *        LOGLINE(std::cout, "Some message");
+ *      }
+ *
+ * produces
+ *
+ *      [MyFunc] Some message
+ */
+void LogLine(std::ostream& stream, std::string const& func,
+             std::string const& message);
+
+/**
+ * \brief Generates an error message which includes the name of the calling
+ * function and the filename and line number where the error occured
+ * \details Should be used via the macro FNERROR which calls this function and
+ * inserts the file, line and fn arguments automatically.
+ */
+std::string FnError(std::string const& message, std::string const& file,
+                    unsigned line, std::string const& fn);
+
+/**
+ * \brief Extracts the fully-qualified function name from a complete function
+ *signature
+ * \details The input str will typically be the compiler variable
+ * `__PRETTY_FUNCTION__`. The return type and arguments are then removed, e.g.:
+ *
+ *      std::string ch::GetQualififedName(std::string const& str)
+ *
+ * would be converted to
+ *
+ *      ch::GetQualififedName
+ */
+std::string GetQualififedName(std::string const& str);
+
+/**
+ * Conveniently initialise a ch::FnTimer instance
+ *
+ * This macro should be placed at the start of a function, e.g.:
+ *
+ *     void MyFunction() {
+ *      LAUNCH_FUNCTION_TIMER(__timer__, __token__)
+ *     }
+ *
+ * The arguments are the names of two objects (a ch::FnTimer and a
+ * ch::FnTimer::Token) that will be created by this macro. Note that the
+ * ch::FnTimer will be assigned the current function name automatically.
+ */
+#define LAUNCH_FUNCTION_TIMER(x, y)                                 \
+  static ch::FnTimer x(ch::GetQualififedName(__PRETTY_FUNCTION__)); \
+  auto y = x.Inc();
+
+#define START_TIMER(x, y)  \
+  static ch::FnTimer x(ch::GetQualififedName(__PRETTY_FUNCTION__) + "|" + y); \
+  x.StartTimer();
+
+#define STOP_TIMER(x) \
+  x.StopTimer();
+
+/**
+ * Determine the total amount of time spent in a function
+ *
+ * An FnTimer instance should typically be declared as a static variable at
+ * the beginning of a function, follwed by a call to the Inc() method, which
+ * will increment the counter. The Inc() method also returns an FnTimer::Token
+ * object that records the time at which it is constructed and then destroyed,
+ * the latter occurring automatically at the end of the function. At the end
+ * of the program the FnTimer destructor will write a message to the screen
+ * summarising the number of calls and the time information.
+ *
+ *  \note A simple way of using this class is via the LAUNCH_FUNCTION_TIMER(x,y)
+ *  macro
+ */
+class FnTimer {
+ public:
+  class Token {
+    public:
+      explicit Token(FnTimer *src);
+      ~Token();
+    private:
+      FnTimer *src_;
+  };
+
+  explicit FnTimer(std::string name);
+  ~FnTimer();
+  Token Inc();
+  void StartTimer();
+  void StopTimer();
+
+ private:
+  std::string name_;
+  unsigned calls_;
+  std::chrono::time_point<std::chrono::system_clock> start_;
+  std::chrono::time_point<std::chrono::system_clock> end_;
+  double elapsed_;
+};
+}
+
+#endif

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -302,7 +302,8 @@ public:
   FastVerticalInterpHistPdf2(const FastVerticalInterpHistPdf2& other, const char* name=0) :
     FastVerticalInterpHistPdf2Base(other, name),
     _x("x",this,other._x),
-    _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
+    _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog),
+    _binScaleList("binList", this, other._binScaleList) {}
   explicit FastVerticalInterpHistPdf2(const FastVerticalInterpHistPdf& other, const char* name=0) ;
   virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf2(*this,newname) ; }
   virtual ~FastVerticalInterpHistPdf2() {}
@@ -320,6 +321,8 @@ protected:
   /// Cache of nominal pdf (additive morphing) and its bin-by-bin logarithm (multiplicative)
   FastHisto _cacheNominal; 
   FastHisto _cacheNominalLog; 
+
+  RooListProxy _binScaleList; // Bin scale factors for Barlow-Beeston
 
   void syncTotal() const ;
   void initNominal(TObject *nominal) ;

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -33,6 +33,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("--X-no-optimize-templates",  dest="optimizeExistingTemplates", default=True, action="store_false", help="Don't optimize templates on the fly (relevant for HZZ)")
     parser.add_option("--X-no-optimize-bound-nusances",  dest="optimizeBoundNuisances", default=True, action="store_false", help="Don't flag nuisances to have a different implementation of bounds")
     parser.add_option("--X-no-optimize-bins",  dest="optimizeTemplateBins", default=True, action="store_false", help="Don't optimize template bins")
+    parser.add_option("--bbb", dest="bbb", default=False, action="store_true", help="Create bin-by-bin parameters")
 
 
 from HiggsAnalysis.CombinedLimit.Datacard import Datacard

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -80,8 +80,40 @@ class ModelBuilder(ModelBuilderBase):
 
         self.physics.preProcessNuisances(self.DC.systs)
         self.doNuisances()
+
+        ## This part used to be at the end of doNuisances
+        ## We now attach nuisPdfs and nuisVars to self.out
+        ## so that we can access them in in the shape part
+        if self.options.bin:
+            nuisPdfs = ROOT.RooArgList()
+            nuisVars = ROOT.RooArgSet()
+            for (n,nf,p,a,e) in self.DC.systs:
+                nuisVars.add(self.out.var(n))
+                nuisPdfs.add(self.out.pdf(n+"_Pdf"))
+            self.out.nuisPdfs = nuisPdfs
+            self.out.nuisVars = nuisVars
+
         self.doExpectedEvents()
         self.doIndividualModels()
+
+        ## Do the last part of doNuisances() here instead
+        if self.options.bin:
+            self.out.defineSet("nuisances", self.out.nuisVars)
+            self.out.nuisPdf = ROOT.RooProdPdf("nuisancePdf", "nuisancePdf", self.out.nuisPdfs)
+            self.out._import(self.out.nuisPdf)
+            gobsVars = ROOT.RooArgSet()
+            for g in self.globalobs: gobsVars.add(self.out.var(g))
+            self.out.defineSet("globalObservables", gobsVars)
+        else: # doesn't work for too many nuisances :-(
+            self.doSet("nuisances", ",".join(["%s"    % n for (n,nf,p,a,e) in self.DC.systs]))
+            self.doObj("nuisancePdf", "PROD", ",".join(["%s_Pdf" % n for (n,nf,p,a,e) in self.DC.systs]))
+            self.doSet("globalObservables", ",".join(self.globalobs))
+        for groupName,nuisanceNames in self.DC.groups.iteritems():
+            nuisanceargset = ROOT.RooArgSet()
+            for nuisanceName in nuisanceNames:
+                nuisanceargset.add(self.out.var(nuisanceName))
+            self.out.defineSet("group_%s"%groupName,nuisanceargset)
+
         self.doCombination()
         self.physics.done()
         if self.options.bin:
@@ -96,7 +128,7 @@ class ModelBuilder(ModelBuilderBase):
     def doNuisances(self):
         if len(self.DC.systs) == 0: return
         self.doComment(" ----- nuisances -----")
-        globalobs = []
+        self.globalobs = []
         # Prepare a dictionary of which group a certain nuisance belongs to
         groupsFor = {}
         existingNuisanceNames = tuple(syst[0] for syst in self.DC.systs)
@@ -126,7 +158,7 @@ class ModelBuilder(ModelBuilderBase):
                     self.doObj("%s_Pdf" % n, "SimpleGaussianConstraint", "%s[%s], %s_In[0,%s], %g" % (n,r,n,r,sig));
                 self.out.var(n).setVal(0)
                 self.out.var(n).setError(1) 
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 if self.options.bin:
                   self.out.var("%s_In" % n).setConstant(True)
                 if self.options.optimizeBoundNuisances: self.out.var(n).setAttribute("optimizeBounds")
@@ -141,7 +173,7 @@ class ModelBuilder(ModelBuilderBase):
                 if val == 0: raise RuntimeError, "Error: line %s contains all zeroes"
                 theta = val*val; kappa = 1/theta
                 self.doObj("%s_Pdf" % n, "Gamma", "%s[1,%f,%f], %s_In[%g,%g,%g], %s_scaling[%g], 0" % (n, max(0.01,1-5*val), 1+5*val, n, kappa, 1, 2*kappa+4, n, theta))
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 if self.options.bin: self.out.var("%s_In" % n).setConstant(True)
             elif pdf == "gmN":
                 if False:
@@ -167,7 +199,7 @@ class ModelBuilder(ModelBuilderBase):
                         #print "Poisson(maxObs = %d, %f) = %g > 1e-12" % (maxObs, args[0]+1, ROOT.TMath.Poisson(maxObs, args[0]+1))
                         maxObs += (sqrt(args[0]) if args[0] > 10 else 2);
                     self.doObj("%s_Pdf" % n, "Poisson", "%s_In[%d,%f,%f], %s[%f,%f,%f], 1" % (n,args[0],minObs,maxObs,n,args[0]+1,minExp,maxExp))
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 if self.options.bin: self.out.var("%s_In" % n).setConstant(True)
             elif pdf == "trG":
                 trG_min = -7; trG_max = +7;
@@ -177,7 +209,7 @@ class ModelBuilder(ModelBuilderBase):
                         if v < 0 and 1.0 + trG_max * v < 0: trG_max = -1.0/v;
                 r = "%f,%f" % (trG_min,trG_max);
                 self.doObj("%s_Pdf" % n, "Gaussian", "%s[0,%s], %s_In[0,%s], 1" % (n,r,n,r));
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 if self.options.bin:
                   self.out.var("%s_In" % n).setConstant(True)
             elif pdf == "lnU":
@@ -197,7 +229,7 @@ class ModelBuilder(ModelBuilderBase):
                     self.doObj("%s_Pdf" % n, ROOFIT_EXPR_PDF, "'1/(2*(1+exp(%f*((@0-@1)-1)))*(1+exp(-%f*((@0-@1)+1))))', %s[0,%s], %s_In[0,%s]" % ( args[0] , args[0] , n, r, n, r)   );
                 else:
                     self.doObj("%s_Pdf" % n, ROOFIT_EXPR_PDF, "'1/(2*(1+exp(%f*(@0-1)))*(1+exp(-%f*(@0+1))))', %s[0,%s], %s_In[0,%s]"  % ( args[0] , args[0] , n, r , n, r)   );
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 if self.options.bin:
                     self.out.var("%s_In" % n).setConstant(True)
             elif pdf == "param":
@@ -245,7 +277,7 @@ class ModelBuilder(ModelBuilderBase):
                     #self.out.var(n).setError(sigma)
                     self.doObj("%s_Pdf" % n, "Gaussian", "%s, %s_In[%s,%g,%g], %s" % (n, n, args[0], self.out.var(n).getMin(), self.out.var(n).getMax(), args[1]))
                     self.out.var("%s_In" % n).setConstant(True)
-                globalobs.append("%s_In" % n)
+                self.globalobs.append("%s_In" % n)
                 #if self.options.optimizeBoundNuisances: self.out.var(n).setAttribute("optimizeBounds")
             else: raise RuntimeError, "Unsupported pdf %s" % pdf
             if nofloat: 
@@ -258,29 +290,6 @@ class ModelBuilder(ModelBuilderBase):
                 for groupName in groupNames:
                     self.out.var(n).setAttribute('group_'+groupName,True)
             #self.out.var(n).Print('V')
-        if self.options.bin:
-            nuisPdfs = ROOT.RooArgList()
-            nuisVars = ROOT.RooArgSet()
-            for (n,nf,p,a,e) in self.DC.systs:
-                nuisVars.add(self.out.var(n))
-                nuisPdfs.add(self.out.pdf(n+"_Pdf"))
-            self.out.defineSet("nuisances", nuisVars)
-            self.out.nuisPdf = ROOT.RooProdPdf("nuisancePdf", "nuisancePdf", nuisPdfs)
-            self.out._import(self.out.nuisPdf)
-            self.out.nuisPdfs = nuisPdfs
-            gobsVars = ROOT.RooArgSet()
-            for g in globalobs: gobsVars.add(self.out.var(g))
-            self.out.defineSet("globalObservables", gobsVars)
-        else: # doesn't work for too many nuisances :-(
-            self.doSet("nuisances", ",".join(["%s"    % n for (n,nf,p,a,e) in self.DC.systs]))
-            self.doObj("nuisancePdf", "PROD", ",".join(["%s_Pdf" % n for (n,nf,p,a,e) in self.DC.systs]))
-            self.doSet("globalObservables", ",".join(globalobs))
-	
-        for groupName,nuisanceNames in self.DC.groups.iteritems():
-	    nuisanceargset = ROOT.RooArgSet()
-            for nuisanceName in nuisanceNames:
-		nuisanceargset.add(self.out.var(nuisanceName))
-	    self.out.defineSet("group_%s"%groupName,nuisanceargset)
 
     def doExpectedEvents(self):
         self.doComment(" --- Expected events in each bin, for each process ----")

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -44,11 +44,14 @@ class ShapeBuilder(ModelBuilder):
             #print "  + Getting model for bin %s" % (b)
             pdfs   = ROOT.RooArgList(); bgpdfs   = ROOT.RooArgList()
             coeffs = ROOT.RooArgList(); bgcoeffs = ROOT.RooArgList()
+            if self.options.bbb:
+                (binVarList, binScaleList) = self.createBBLiteVars(b)
             for p in self.DC.exp[b].keys(): # so that we get only self.DC.processes contributing to this bin
                 if self.DC.exp[b][p] == 0: continue
                 if self.physics.getYieldScale(b,p) == 0: continue # exclude really the pdf
                 #print "  +--- Getting pdf for %s in bin %s" % (p,b)
                 (pdf,coeff) = (self.getPdf(b,p), self.out.function("n_exp_bin%s_proc_%s" % (b,p)))
+                if (self.options.bbb): pdf.setBinParams(binVarList, binScaleList)
                 if self.options.optimizeExistingTemplates:
                     pdf1 = self.optimizeExistingTemplates(pdf)
                     if (pdf1 != pdf):
@@ -417,7 +420,6 @@ class ShapeBuilder(ModelBuilder):
                     rebins.Add(rebinned)
                     maxbins = max(maxbins, rebinned._original_bins)
                 rhp = ROOT.FastVerticalInterpHistPdf2("shape%s_%s_%s_morph" % (postFix,channel,process), "", self.out.binVar, rebins, coeffs, qrange, qalgo)
-                rhp.createBinParams()
                 if self.options.optimizeTemplateBins and maxbins < self.out.maxbins:
                     #print "Optimizing binning: %d -> %d for %s " % (self.out.maxbins, maxbins, rhp.GetName())
                     rhp.setActiveBins(maxbins) 
@@ -504,6 +506,8 @@ class ShapeBuilder(ModelBuilder):
         rebinh1 = ROOT.TH1F(shape.GetName()+"_rebin", "", self.out.maxbins, 0.0, float(self.out.maxbins))
         for i in range(1,min(shape.GetNbinsX(),self.out.maxbins)+1): 
             rebinh1.SetBinContent(i, shape.GetBinContent(i))
+            # Also copy the bin error - needed for creating bbb terms later
+            rebinh1.SetBinError(i, shape.GetBinError(i))
         rebinh1._original_bins = shape.GetNbinsX()
         return rebinh1;
     def shape2Data(self,shape,channel,process,_cache={}):
@@ -602,4 +606,33 @@ class ShapeBuilder(ModelBuilder):
                 #print "Optimize %s in \t" % (pdf.GetName()),; ret.Print("")
                 return ret
         return pdf
+    def createBBLiteVars(self, b):
+        print 'Doing bb-lite for bin ' + b
+        procs = [p for p in self.DC.exp[b].keys() if self.DC.exp[b][p] != 0 and self.physics.getYieldScale(b,p) != 0]
+        print procs
+        ROOT.TH1.SetDefaultSumw2(True)
+        hsum = self.getShape(b,procs[0]).Clone()
+        for p in procs[1:]:
+            hsum.Add(self.getShape(b,p))
+        hsum.Print("range")
+        nbins = hsum.GetNbinsX()
+        binVarList = ROOT.RooArgList()
+        binScaleList = ROOT.RooArgList()
+        for x in range(nbins):
+            binvar = b + '_bbblite_' + str(x)
+            print 'Creating bbb param ' + binvar                
+            self.doObj("%s_Pdf" % binvar, "SimpleGaussianConstraint", "%s[-4,4], %s_In[0,-4,4], %g" % (binvar,binvar,1))
+            self.out.var(binvar).setConstant(False)
+            self.out.var(binvar).setVal(0)
+            self.out.var(binvar).setError(1)
+            self.globalobs.append("%s_In" % binvar)
+            self.out.nuisVars.add(self.out.var(binvar))
+            self.out.nuisPdfs.add(self.out.pdf(binvar+"_Pdf"))
+            scalevar = (hsum.GetBinError(x+1) / hsum.GetBinContent(x+1)) if hsum.GetBinContent(x+1) > 0 else 0.
+            self.doObj("%s_Scale" % binvar, "ConstVar", "%g" % (scalevar))
+            binVarList.add(self.out.var(binvar))
+            binScaleList.add(self.out.function(binvar+'_Scale'))
+        binVarList.Print("v")
+        binScaleList.Print("v")
+        return (binVarList, binScaleList)
 

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -417,6 +417,7 @@ class ShapeBuilder(ModelBuilder):
                     rebins.Add(rebinned)
                     maxbins = max(maxbins, rebinned._original_bins)
                 rhp = ROOT.FastVerticalInterpHistPdf2("shape%s_%s_%s_morph" % (postFix,channel,process), "", self.out.binVar, rebins, coeffs, qrange, qalgo)
+                rhp.createBinParams()
                 if self.options.optimizeTemplateBins and maxbins < self.out.maxbins:
                     #print "Optimizing binning: %d -> %d for %s " % (self.out.maxbins, maxbins, rhp.GetName())
                     rhp.setActiveBins(maxbins) 

--- a/src/Logging.cc
+++ b/src/Logging.cc
@@ -1,0 +1,66 @@
+#include "../interface/Logging.h"
+#include <string>
+#include <iostream>
+#include "boost/lexical_cast.hpp"
+
+namespace ch {
+
+std::string GetQualififedName(std::string const& str) {
+  std::size_t bpos = str.find_first_of('(');
+  if (bpos == std::string::npos) return str;
+  std::size_t apos = bpos;
+  bool break_cond = false;
+  bool in_clause = false;
+  while (!break_cond && apos > 0) {
+    --apos;
+    if (str[apos] == '>') in_clause = true;
+    if (str[apos] == '<') in_clause = false;
+    if (str[apos] == ' ' && !in_clause) {
+      break_cond = true;
+      ++apos;
+    }
+  }
+  std::string cpy = str.substr(apos, bpos - apos);
+  return cpy;
+}
+
+void LogLine(std::ostream& stream, std::string const& func,
+             std::string const& message) {
+  stream << "[" << func << "] " << message << "\n";
+}
+
+std::string FnError(std::string const& message, std::string const& file,
+                    unsigned line, std::string const& fn) {
+  std::string res;
+  std::string banner(79, '*');
+  res += "\n" + banner;
+  res += "\nContext: Function " + GetQualififedName(fn) + " at ";
+  res += "\n  " + file + ":" + boost::lexical_cast<std::string>(line);
+  res += "\nProblem: " + message;
+  res += "\n" + banner;
+  res +=
+      "\nPlease report issues at\n  "
+      "https://github.com/cms-analysis/HiggsAnalysis-HiggsToTauTau/issues/new";
+  res += "\n" + banner;
+  return res;
+}
+
+// Implementation of FnTimer ("Function Timer") class
+FnTimer::FnTimer(std::string name) : name_(name), calls_(0), elapsed_(0.) {}
+FnTimer::~FnTimer() {
+  printf(
+      "[Timer] %-40s Calls: %-20u Total [s]: %-20.5g Per-call [s]: %-20.5g\n",
+      name_.c_str(), calls_, elapsed_, elapsed_ / double(calls_));
+}
+FnTimer::Token FnTimer::Inc() {
+  ++calls_;
+  return Token(this);
+}
+void FnTimer::StartTimer() { start_ = std::chrono::system_clock::now(); }
+void FnTimer::StopTimer() {
+  end_ = std::chrono::system_clock::now();
+  elapsed_ += std::chrono::duration<double>(end_ - start_).count();
+}
+FnTimer::Token::Token(FnTimer* src) : src_(src) { src_->StartTimer(); }
+FnTimer::Token::~Token() { src_->StopTimer(); }
+}

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -1,4 +1,5 @@
 #include "../interface/VerticalInterpHistPdf.h"
+#include "../interface/Logging.h" // Need this for now to debug performance: remove later
 
 #include <cassert>
 #include <memory>
@@ -10,6 +11,7 @@
 #include "RooRealVar.h"
 #include "RooMsgService.h"
 #include "RooAbsData.h"
+#include "RooConstVar.h"
 
 //#define TRACE_CALLS
 #ifdef TRACE_CALLS
@@ -754,18 +756,20 @@ Bool_t FastVerticalInterpHistPdf2Base::importWorkspaceHook(RooWorkspace& ws) {
   return kFALSE;
 }
 
-void FastVerticalInterpHistPdf2::createBinParams() {
-  RooArgSet params;
-  for (unsigned i = 0; i < _cacheNominal.size(); ++i) {
-    const char *name = Form("%s_bin_%i", GetName(), i);
-    std::cout << "Creating param: " << name << "\n";
-    RooRealVar *var = new RooRealVar(name, name, 0, 1000);
-    var->setVal(1.);
-    var->setConstant(kTRUE);
-    params.add(*var);
-    _binScaleList.add(*var);
+unsigned FastVerticalInterpHistPdf2::setBinParams(RooArgList & vars, RooArgList & scales) {
+  // std::cout << "vars: " << vars.getSize() << "\tscales: " << scales.getSize()
+  // << "\tbins: " << _cacheNominal.size() << "\n";
+
+  // Possible that _cacheNominal can have more bins than the input TH1 due to
+  // the bin optimisation in ShapeTools.py
+  if (vars.getSize() > int(_cacheNominal.size()) ||
+      scales.getSize() > int(_cacheNominal.size())) {
+    std::cout << "Wrong number of params!\n";
+    return 0;
   }
-  addOwnedComponents(params);
+  _binParamList.add(vars);
+  _binScaleList.add(scales);
+  return _cacheNominal.size();
 }
 
 //_____________________________________________________________________________
@@ -800,8 +804,9 @@ FastVerticalInterpHistPdf2Base::initBase() const
 FastVerticalInterpHistPdf2::FastVerticalInterpHistPdf2(const char *name, const char *title, const RooRealVar &x, const TList & funcList, const RooArgList& coefList, Double_t smoothRegion, Int_t smoothAlgo) :
     FastVerticalInterpHistPdf2Base(name,title,RooArgSet(x),funcList,coefList,smoothRegion,smoothAlgo),
     _x("x","Independent variable",this,const_cast<RooRealVar&>(x)),
-    _cache(), _cacheNominal(), _cacheNominalLog(),
-    _binScaleList("binList", "", this)
+    _cache(), _cache2(), _cacheNominal(), _cacheNominalLog(),
+    _binScaleList("binScaleList", "", this),
+    _binParamList("binParamList", "", this)
 {
     initBase();
     initNominal(funcList.At(0));
@@ -831,7 +836,7 @@ FastVerticalInterpHistPdf2D2::FastVerticalInterpHistPdf2D2(const char *name, con
 FastVerticalInterpHistPdf2::FastVerticalInterpHistPdf2(const FastVerticalInterpHistPdf& other, const char* name) :
     FastVerticalInterpHistPdf2Base(other,name),
     _x("x",this,other._x),
-    _cache(), _cacheNominal(), _cacheNominalLog()
+    _cache(), _cache2(), _cacheNominal(), _cacheNominalLog()
 {
     initBase();
     other.getVal(RooArgSet(_x.arg()));
@@ -862,16 +867,19 @@ FastVerticalInterpHistPdf2D2::FastVerticalInterpHistPdf2D2(const FastVerticalInt
 //_____________________________________________________________________________
 Double_t FastVerticalInterpHistPdf2::evaluate() const 
 {
-  if (!_initBase) initBase();
-  if (_cache.size() == 0) _cache = _cacheNominal; // _cache is not persisted
-  if (!_sentry.good()) syncTotal();
-  if (_binScaleList.getSize() > 0) {
-    int bin = _cache.FindBin(_x);
-    RooRealVar *tmp = static_cast<RooRealVar*>(_binScaleList.at(bin));
-    std::cout << "[FastVerticalInterpHistPdf2::evaluate] " << _x << "\t"
-              << _cache.GetBinContent(bin) << "\t" << tmp->getVal() << "\n";
-    return _cache.GetBinContent(bin) * tmp->getVal();
+  if (!_initBase) {
+    initBase();
+    // For now have _sentryBins check the coeff and bin params, but clearly
+    // this is not optimal
+    _sentryBins.addVars(_binParamList);
+    _sentryBins.addVars(_coefList);
+    _sentryBins.setValueDirty();
   }
+  if (_cache.size() == 0) _cache = _cacheNominal; // _cache is not persisted
+  // Only need to sync morphs when first sentry is not good
+  if (!_sentry.good()) syncTotal();
+  // Have to sync bins when anything changes
+  if (!_sentryBins.good()) syncBins();
   return _cache.GetAt(_x);
 }
 Double_t FastVerticalInterpHistPdf2D2::evaluate() const 
@@ -886,9 +894,11 @@ Double_t FastVerticalInterpHistPdf2D2::evaluate() const
 void FastVerticalInterpHistPdf2::setActiveBins(unsigned int bins) {
   assert(bins <= _cacheNominal.fullsize());
   if (_cache.size() == 0) _cache = _cacheNominal; // _cache is not persisted
+  if (_cache2.size() == 0) _cache2 = _cacheNominal; // _cache is not persisted
   _cache.CropUnderflows(1e-9,false);        // set all bins, also the non-active ones
   _cacheNominal.CropUnderflows(1e-9,false); // set all bins, also the non-active ones
   _cache.SetActiveSize(bins);
+  _cache2.SetActiveSize(bins);
   _cacheNominal.SetActiveSize(bins);
   _cacheNominalLog.SetActiveSize(bins);
   for (Morph & m : _morphs) {
@@ -1054,11 +1064,36 @@ void FastVerticalInterpHistPdf2Base::syncTotal(FastTemplate &cache, const FastTe
 }
 
 void FastVerticalInterpHistPdf2::syncTotal() const {
-    FastVerticalInterpHistPdf2Base::syncTotal(_cache, _cacheNominal, _cacheNominalLog);
-
-    // normalize the result
-    _cache.Normalize(); 
+    LAUNCH_FUNCTION_TIMER(__timer__, __token__) // DEBUG
+    if (_binParamList.getSize() > 0) {
+      // If we're doing bb-lite, morph into _cache2 instead
+      if (_cache2.size() == 0) _cache2 = _cache;
+      FastVerticalInterpHistPdf2Base::syncTotal(_cache2, _cacheNominal, _cacheNominalLog);
+      _cache2.Normalize();
+    } else {
+      FastVerticalInterpHistPdf2Base::syncTotal(_cache, _cacheNominal, _cacheNominalLog);
+      _cache.Normalize();
+    }
     //printf("Normalized result\n");  _cache.Dump();
+}
+
+void FastVerticalInterpHistPdf2::syncBins() const {
+    LAUNCH_FUNCTION_TIMER(__timer__, __token__) // DEBUG
+    if (_binParamList.getSize() > 0) {
+      _cache.Clear(); // FIXME: not sure why I need to do this
+      // printf("[SyncTotal]: %s\n", this->GetName());
+      for (int i = 0; i < _binParamList.getSize(); ++i) {
+        double var = static_cast<RooRealVar*>(_binParamList.at(i))->getVal();
+        double err = static_cast<RooConstVar*>(_binScaleList.at(i))->getVal();
+        _cache[i] = _cache2[i] * (1. + var*err);
+        //printf("%i %7.5f %7.5f %7.5f %7.5f\n", i, _cache2[i], err, var, _cache[i]);
+
+      }
+      // normalize the result
+      _cache.CropUnderflows();
+      _cache.Normalize();
+      _sentryBins.reset();
+    }
 }
 
 void FastVerticalInterpHistPdf2D2::syncTotal() const {
@@ -1074,9 +1109,15 @@ FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInter
     hpdf_(hpdf),begin_(0),end_(0)
 {
     // check init
-    if (!hpdf._initBase) hpdf.initBase();
+    if (!hpdf._initBase) {
+      hpdf.initBase();
+      hpdf._sentryBins.addVars(hpdf._binParamList);
+      hpdf._sentryBins.addVars(hpdf._coefList);
+      hpdf._sentryBins.setValueDirty();
+    }
     if (hpdf._cache.size() == 0) hpdf._cache = hpdf._cacheNominal;
     if (!hpdf._sentry.good()) hpdf.syncTotal();
+    if (!hpdf._sentryBins.good()) hpdf.syncBins();
     // find bins
     std::vector<int> bins;
     RooArgSet obs(hpdf._x.arg());
@@ -1094,6 +1135,7 @@ FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInter
     } else if (aligned) {
         begin_ = bins.front();
         end_   = bins.back()+1;
+        bins_.swap(bins); // want to keep this info around for later
         //std::cout << "Created FastVerticalInterpHistPdf2V from " << hpdf.GetName() << ", aligned, " << (end_-begin_) << " bins." << std::endl;
     } else {
         nbins_ = bins.size();
@@ -1110,7 +1152,7 @@ FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInter
         blocks_.push_back(Block(istart,start,bins_.back()+1));
         if (blocks_.size() < 4*bins_.size()) {
             //std::cout << "Created FastVerticalInterpHistPdf2V from " << hpdf.GetName() << ", block-aligned, " << bins_.size() << " bins, " <<  blocks_.size() << " blocks." << std::endl;
-            bins_.clear();
+            // bins_.clear(); // Don't clear here, want to keep this info for later
         } else {
             //std::cout << "Created FastVerticalInterpHistPdf2V from " << hpdf.GetName() << ", non-aligned, " << bins_.size() << " bins, " <<  blocks_.size() << " blocks." << std::endl;
             blocks_.clear();
@@ -1121,6 +1163,7 @@ FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInter
 void FastVerticalInterpHistPdf2V::fill(std::vector<Double_t> &out) const 
 {
     if (!hpdf_._sentry.good()) hpdf_.syncTotal();
+    if (!hpdf_._sentryBins.good()) hpdf_.syncBins();
     if (begin_ != end_) {
         out.resize(end_-begin_);
         std::copy(& hpdf_._cache.GetBinContent(begin_), & hpdf_._cache.GetBinContent(end_), out.begin());


### PR DESCRIPTION
Hi all,

This is currently a very rough implementation of the simple barlow-beeston method (one NP per bin, shared with all processes). Making the PR now as it would be useful to get some feedback on the implementation so far. 

Notes:

  - Add option `--bbb` in text2workspace.py to create per-bin parameters (must be TH1 shape input).
  - Add option `--X-rtd ENABLE_BB_LITE` in combine to solve these NPs directly  in CachingAddNLL instead of fitting
  - At the moment the performance is not great, though generally faster than fitting all params with minuit2, at least for the full htautau model. I have a fairly good idea how this can be improved though.
  - I've added Logging.h/.cc temporarily to help with tracking the performance, will be removed again later.

Can make a presentation of this in an upcoming combinations meeting.
