### PR TITLE
printing more details about why parameters are at a boundary

### DIFF
--- a/interface/utils.h
+++ b/interface/utils.h
@@ -94,6 +94,12 @@ namespace utils {
     // Set range of physics model parameters
     void setModelParameterRanges( const std::string & setPhysicsModelParameterRangeExpression, const RooArgSet & params);
 
+    /** @return true if the parameter's value is less than one sigma away from the lower end of the range */
+    bool isParameterAtLowerBoundary( const RooRealVar &);
+
+    /** @return true if the parameter's value is less than one sigma away from the upper end of the range */
+    bool isParameterAtUpperBoundary( const RooRealVar &);
+
     bool isParameterAtBoundary( const RooRealVar &);
     bool anyParameterAtBoundaries( const RooArgSet &, int verbosity);
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -759,7 +759,7 @@ bool utils::anyParameterAtBoundaries( const RooArgSet &params, int verbosity ){
     for (RooRealVar *a = (RooRealVar *) iter.Next(); a != 0; a = (RooRealVar *) iter.Next(), ++i) {
       
         bool atLowerBoundary = isParameterAtLowerBoundary(*a);
-        bool atUpperBoundary = isParameterAtLowerBoundary(*a);
+        bool atUpperBoundary = isParameterAtUpperBoundary(*a);
         bool isBad = atLowerBoundary || atUpperBoundary;
 
         if(isBad){

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -771,11 +771,15 @@ bool utils::anyParameterAtBoundaries( const RooArgSet &params, int verbosity ){
 
                 if (atLowerBoundary && atUpperBoundary)
                   fprintf(CloseCoutSentry::trueStdOutGlobal(),"both boundaries");
-                else if (atLowerBoundary)
+                else if (atLowerBoundary && !atUpperBoundary)
                   fprintf(CloseCoutSentry::trueStdOutGlobal(),"lower boundary");
-                else 
-                  // must be at upper boundary
+                else if (!atLowerBoundary && atUpperBoundary)
                   fprintf(CloseCoutSentry::trueStdOutGlobal(),"upper boundary");
+		else
+                {
+		  // we can't come here (as long as we are inside if(isBad) { .. } )
+		  // because isBad = atLowerBoundary || atUpperBoundary
+                }
 
                 fprintf(CloseCoutSentry::trueStdOutGlobal()," (value: %f %+f%+f range: %f..%f)", a->getVal(), a->getErrorHi(), a->getErrorLo(),
                         a->getMin(), a->getMax());


### PR DESCRIPTION
- split method utils::isParameterAtBoundary(..) into two methods utils::isParameterAtLowerBoundary(..) and utils::isParameterAtUpperBoundary(..)
- method utils::anyParameterAtBoundaries(..) now prints more details about why a parameter is at a boundary

This has been useful to identify issues where the uncertainty of a parameter became quite big (and thus the parameter was seen to be close to both boundaries).

Example output:

  [WARNING] Found [paramXYZ] at both boundaries (value: 3.593620 +8.407840-8.407840 range: -4.472136..4.472136). 
