### PR TITLE
LHC-HCG: more processes and physics models

### DIFF
--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -71,6 +71,8 @@ class CascadeMinimizer {
         static bool setZeroPoint_;
         /// don't do old fallback using robustMinimize 
         static bool oldFallback_;
+        /// storage level for minuit2 (toggles storing of intermediate covariances)
+        static int minuit2StorageLevel_;
 
 	static double discreteMinTol_;
 

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -18,7 +18,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("--default-morphing",  dest="defMorph", type="string", default="shape2N", help="Default template morphing algorithm (to be used when the datacard has just 'shape')")
     parser.add_option("--no-b-only","--for-fits",    dest="noBOnly", default=False, action="store_true", help="Do not save the background-only pdf (saves time)")
     parser.add_option("--no-optimize-pdfs",    dest="noOptimizePdf", default=False, action="store_true", help="Do not save the RooSimultaneous as RooSimultaneousOpt and Gaussian constraints as SimpleGaussianConstraint")
-    parser.add_option("--optimize-simpdf-constraints",    dest="moreOptimizeSimPdf", default=False, action="store_true", help="Deeper optimization of RooSimultaneous: add the constraints only at the end (RooFit-incompatible!)")
+    parser.add_option("--optimize-simpdf-constraints",    dest="moreOptimizeSimPdf", default="none", type="string", help="Handling of constraints in simultaneous pdf: 'none' = add all constraints on all channels (default); 'lhchcg' = add constraints on only the first channel; 'cms' = add constraints to the RooSimultaneousOpt.")
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")

--- a/python/LHCHCGModels.py
+++ b/python/LHCHCGModels.py
@@ -333,8 +333,11 @@ class Lambdas(SMLikeHiggsModel):
             return name
         dscale = self.decayMap_[decay]
         if production == "ggH": 
-            # fixme bbH
-            self.modelBuilder.factory_("expr::%s(\"@0*@0*   @1*@1\",kappa_gZ,%s)" % (name, dscale))
+            if decay in self.add_bbH:
+                b2g = "R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01) 
+                self.modelBuilder.factory_("expr::%s(\"@0*@0*@1*@1*(1+@2*@3*@3*@4*@4)\",kappa_gZ,%s,%s,lambda_bZ,lambda_Zg)" % (name, dscale, b2g))
+            else:
+                self.modelBuilder.factory_("expr::%s(\"@0*@0*   @1*@1\",kappa_gZ,%s)" % (name, dscale))
         else:
             self.modelBuilder.factory_("expr::%s(\"@0*@0*@1*@2*@2\",kappa_gZ,PW_XSscal_%s_%s,%s)" % (name, production, energy, dscale))
         print '[LHC-HCG Lambdas]', name, production, decay, energy,": ",

--- a/python/LHCHCGModels.py
+++ b/python/LHCHCGModels.py
@@ -1,0 +1,348 @@
+from HiggsAnalysis.CombinedLimit.PhysicsModel import *
+from HiggsAnalysis.CombinedLimit.SMHiggsBuilder import SMHiggsBuilder
+
+## Naming conventions
+CMS_to_LHCHCG_Dec = { 
+    'hww': 'WW',
+    'hzz': 'ZZ',
+    'hgg': 'gamgam',
+    'hbb': 'bb',
+    'hcc': 'cc',
+    'htt': 'tautau',
+    'hmm': 'mumu',
+    'hzg': 'Zgam',
+    'hgluglu': 'gluglu',
+}
+CMS_to_LHCHCG_DecSimple = { 
+    'hww': 'WW',
+    'hzz': 'ZZ',
+    'hgg': 'gamgam',
+    'hbb': 'bb',
+    'hcc': 'bb',
+    'htt': 'tautau',
+    'hmm': 'tautau',
+    'hzg': 'gamgam',
+    'hgluglu': 'bb',
+}
+CMS_to_LHCHCG_Prod = { 
+    'ggH': 'ggF',
+    'qqH': 'VBF',
+    'WH': 'VH',
+    'ZH': 'qqZH',
+    'ggZH': 'ggZH',
+    'ttH': 'ttH',
+    'tHq': 'tHq',
+    'tHW': 'tHW',
+    'bbH': 'bbH',
+ } 
+
+class SignalStrengths(SMLikeHiggsModel):
+    "Allow different signal strength fits"
+    def __init__(self):
+        SMLikeHiggsModel.__init__(self) # not using 'super(x,self).__init__' since I don't understand it
+        self.floatMass = False
+        self.POIs = "mu"
+        self.add_bbH = [ "hzz", "hgg" ]
+    def setPhysicsOptions(self,physOptions):
+        for po in physOptions:
+            if po.startswith("bbh="):
+                self.add_bbH = [d.strip() for d in po.replace("bbh=","").split(",")]
+            if po.startswith("poi="):
+                self.POIs = po.replace("poi=","")
+            if po.startswith("higgsMassRange="):
+                self.floatMass = True
+                self.mHRange = po.replace("higgsMassRange=","").split(",")
+                print 'The Higgs mass range:', self.mHRange
+                if len(self.mHRange) != 2:
+                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                elif float(self.mHRange[0]) >= float(self.mHRange[1]):
+                    raise RuntimeError, "Extrama for Higgs mass range defined with inverterd order. Second must be larger the first"
+        print "Will add bbH to signals in the following Higgs boson decay modes: %s" % (", ".join(self.add_bbH))
+    def doVar(self,x,constant=True):
+        self.modelBuilder.doVar(x)
+        vname = re.sub(r"\[.*","",x)
+        self.modelBuilder.out.var(vname).setConstant(constant)
+        print "SignalStrengths:: declaring %s as %s, and set to constant" % (vname,x)
+    def doParametersOfInterest(self):
+        """Create POI out of signal strength and MH"""
+        self.doVar("mu[1,0,5]")
+        for X in CMS_to_LHCHCG_Dec.values():
+            self.doVar("mu_BR_%s[1,0,5]" % X)
+        for X in CMS_to_LHCHCG_Prod.values() + [ "ZH", "tH" ]:
+            self.doVar("mu_XS_%s[1,0,5]" % X)
+            self.doVar("mu_XS7_%s[1,0,5]" % X)
+            self.doVar("mu_XS8_%s[1,0,5]" % X)
+        for X in CMS_to_LHCHCG_DecSimple.values():
+            self.doVar("mu_V_%s[1,0,5]" % X)
+            self.doVar("mu_F_%s[1,0,5]" % X)
+        if self.floatMass:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]),float(self.mHRange[1]))
+                self.modelBuilder.out.var("MH").setConstant(False)
+            else:
+                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1])) 
+        else:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                self.modelBuilder.out.var("MH").setConstant(True)
+            else:
+                self.modelBuilder.doVar("MH[%g]" % self.options.mass)
+        print "Default parameters of interest: ", self.POIs
+        self.modelBuilder.doSet("POI",self.POIs)
+        self.SMH = SMHiggsBuilder(self.modelBuilder)
+        self.setup()
+    def setup(self):
+        for P in ALL_HIGGS_PROD:
+            if P == "VH": continue # skip aggregates 
+            for D in SM_HIGG_DECAYS:
+                for E in 7, 8:
+                    terms = [ "mu", "mu_BR_"+CMS_to_LHCHCG_Dec[D] ]
+                    # Hack for ggH
+                    if D in self.add_bbH and P == "ggH":
+                        b2g = "R_bbH_ggH_%s_%dTeV[%g]" % (D, E, 0.01) 
+                        ggs = ",".join([ "mu_XS_ggF", "mu_XS%d_ggF"%E ])
+                        bbs = ",".join([ "mu_XS_bbH", "mu_XS%d_bbH"%E ])
+                        ## FIXME should include the here also logNormal for QCDscale_bbH
+                        self.modelBuilder.factory_('expr::ggH_bbH_sum_%s_%dTeV(\"@1*@2+@0*@3*@4\",%s,%s,%s)' % (D,E,b2g,ggs,bbs))
+                        terms += [ 'ggH_bbH_sum_%s_%dTeV' % (D,E) ]
+                    else:
+                        terms += [ "mu_XS_"+CMS_to_LHCHCG_Prod[P],  "mu_XS%d_%s"%(E,CMS_to_LHCHCG_Prod[P])  ]
+                    # Summary modes
+                    if P in [ "tHW", "tHq" ]:
+                        terms += [ "mu_XS_tH", "mu_XS%d_tH"%E ]
+                    if P in [ "ggZH", "ZH" ]:
+                        terms += [ "mu_XS_ZH", "mu_XS%d_ZH"%E ]
+                    if P in [ "WH", "ZH", "ggZH" ]:
+                        terms += [ "mu_XS_VH", "mu_XS%d_VH"%E ]
+                    # for 2D scans
+                    if P in [ "ggH", "ttH", "bbH", "tHq", "tHW" ]:
+                        terms += [ "mu_F_"+CMS_to_LHCHCG_DecSimple[D] ]
+                    else:
+                        terms += [ "mu_V_"+CMS_to_LHCHCG_DecSimple[D] ]
+                    self.modelBuilder.factory_('prod::scaling_%s_%s_%dTeV(%s)' % (P,D,E,",".join(terms)))
+                    self.modelBuilder.out.function('scaling_%s_%s_%dTeV' % (P,D,E)).Print("")
+
+    def getHiggsSignalYieldScale(self,production,decay,energy):
+        return "scaling_%s_%s_%s" % (production,decay,energy)
+
+class Kappas(SMLikeHiggsModel):
+    "assume the SM coupling but let the Higgs mass to float"
+    def __init__(self,resolved=True):
+        SMLikeHiggsModel.__init__(self) # not using 'super(x,self).__init__' since I don't understand it
+        self.floatMass = False
+        self.add_bbH = [ "hzz", "hgg" ]
+        self.doBRU = False
+        self.resolved = resolved
+    def setPhysicsOptions(self,physOptions):
+        for po in physOptions:
+            if po.startswith("bbh="):
+                self.add_bbH = [ d.strip() for d in po.replace("bbh=","").split(",") ]
+            if po.startswith("higgsMassRange="):
+                self.floatMass = True
+                self.mHRange = po.replace("higgsMassRange=","").split(",")
+                print 'The Higgs mass range:', self.mHRange
+                if len(self.mHRange) != 2:
+                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                elif float(self.mHRange[0]) >= float(self.mHRange[1]):
+                    raise RuntimeError, "Extrama for Higgs mass range defined with inverterd order. Second must be larger the first"
+    def doParametersOfInterest(self):
+        """Create POI out of signal strength and MH"""
+        self.modelBuilder.doVar("kappa_W[1,0.0,2.0]") 
+        self.modelBuilder.doVar("kappa_Z[1,0.0,2.0]") 
+        self.modelBuilder.doVar("kappa_tau[1,0.0,3.0]")
+        self.modelBuilder.doVar("kappa_mu[1,0.0,5.0]")
+        self.modelBuilder.doVar("kappa_t[1,0.0,4.0]")
+        self.modelBuilder.doVar("kappa_b[1,0.0,3.0]")
+        if not self.resolved:
+            self.modelBuilder.doVar("kappa_g[1,0.0,2.0]")
+            self.modelBuilder.doVar("kappa_gam[1,0.0,2.5]")
+	self.modelBuilder.doVar("BRinv[0,0,1]")
+        self.modelBuilder.out.var("BRinv").setConstant(True)
+        pois = 'kappa_W,kappa_Z,kappa_tau,kappa_t,kappa_b'
+        if not self.resolved:
+            pois += ',kappa_g,kappa_gam'
+        if self.floatMass:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]),float(self.mHRange[1]))
+                self.modelBuilder.out.var("MH").setConstant(False)
+            else:
+                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1]))
+            self.modelBuilder.doSet("POI",pois+',MH')
+        else:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                self.modelBuilder.out.var("MH").setConstant(True)
+            else:
+                self.modelBuilder.doVar("MH[%g]" % self.options.mass)
+            self.modelBuilder.doSet("POI",pois)
+        self.SMH = SMHiggsBuilder(self.modelBuilder)
+        self.setup()
+
+    def setup(self):
+        # SM BR
+        for d in SM_HIGG_DECAYS + [ "hss" ]: 
+            self.SMH.makeBR(d)
+        # BR uncertainties
+        if self.doBRU:
+            self.SMH.makePartialWidthUncertainties()
+        else:
+            for d in SM_HIGG_DECAYS: 
+                self.modelBuilder.factory_('HiggsDecayWidth_UncertaintyScaling_%s[1.0]' % d)
+        # get VBF, tHq, tHW, ggZH cross section
+        self.SMH.makeScaling('qqH', CW='kappa_W', CZ='kappa_Z')
+        self.SMH.makeScaling("tHq", CW='kappa_W', Ctop="kappa_t")
+        self.SMH.makeScaling("tHW", CW='kappa_W', Ctop="kappa_t")
+        self.SMH.makeScaling("ggZH", CZ='kappa_Z', Ctop="kappa_t")
+        # resolve loops
+        if self.resolved:
+            self.SMH.makeScaling('ggH', Cb='kappa_b', Ctop='kappa_t')
+            self.SMH.makeScaling('hgluglu', Cb='kappa_b', Ctop='kappa_t')
+            self.SMH.makeScaling('hgg', Cb='kappa_b', Ctop='kappa_t', CW='kappa_W', Ctau='kappa_tau')
+            self.SMH.makeScaling('hzg', Cb='kappa_b', Ctop='kappa_t', CW='kappa_W', Ctau='kappa_tau')
+        else:
+            self.modelBuilder.factory_('expr::Scaling_hgluglu("@0*@0", kappa_g)')
+            self.modelBuilder.factory_('expr::Scaling_hgg("@0*@0", kappa_gam)')
+            self.modelBuilder.factory_('expr::Scaling_hzg("@0*@0", kappa_gam)')
+            self.modelBuilder.factory_('expr::Scaling_ggH_7TeV("@0*@0", kappa_g)')
+            self.modelBuilder.factory_('expr::Scaling_ggH_8TeV("@0*@0", kappa_g)')
+
+        ## partial witdhs, normalized to the SM one
+        self.modelBuilder.factory_('expr::c7_Gscal_Z("@0*@0*@1*@2", kappa_Z, SM_BR_hzz, HiggsDecayWidth_UncertaintyScaling_hzz)')
+        self.modelBuilder.factory_('expr::c7_Gscal_W("@0*@0*@1*@2", kappa_W, SM_BR_hww, HiggsDecayWidth_UncertaintyScaling_hww)')
+        self.modelBuilder.factory_('expr::c7_Gscal_tau("@0*@0*@1*@4+@2*@2*@3*@5", kappa_tau, SM_BR_htt, kappa_mu, SM_BR_hmm, HiggsDecayWidth_UncertaintyScaling_htt, HiggsDecayWidth_UncertaintyScaling_hmm)')
+        self.modelBuilder.factory_('expr::c7_Gscal_top("@0*@0 * @1*@2", kappa_t, SM_BR_hcc, HiggsDecayWidth_UncertaintyScaling_hcc)')
+        self.modelBuilder.factory_('expr::c7_Gscal_bottom("@0*@0 * (@1*@3+@2)", kappa_b, SM_BR_hbb, SM_BR_hss, HiggsDecayWidth_UncertaintyScaling_hbb)')
+        self.modelBuilder.factory_('expr::c7_Gscal_gluon("  @0  * @1 * @2", Scaling_hgluglu, SM_BR_hgluglu, HiggsDecayWidth_UncertaintyScaling_hgluglu)')
+        self.modelBuilder.factory_('expr::c7_Gscal_gamma("@0*@1*@4 + @2*@3*@5",  Scaling_hgg, SM_BR_hgg, Scaling_hzg, SM_BR_hzg, HiggsDecayWidth_UncertaintyScaling_hgg, HiggsDecayWidth_UncertaintyScaling_hzg)')
+        # fix to have all BRs add up to unity
+        self.modelBuilder.factory_("sum::c7_SMBRs(%s)" %  (",".join("SM_BR_"+X for X in "hzz hww htt hmm hcc hbb hss hgluglu hgg hzg".split())))
+        self.modelBuilder.out.function("c7_SMBRs").Print("")        
+
+        ## total witdh, normalized to the SM one
+        self.modelBuilder.factory_('expr::c7_Gscal_tot("(@1+@2+@3+@4+@5+@6+@7)/@8/(1-@0)", BRinv, c7_Gscal_Z, c7_Gscal_W, c7_Gscal_tau, c7_Gscal_top, c7_Gscal_bottom, c7_Gscal_gluon, c7_Gscal_gamma, c7_SMBRs)')
+
+        ## BRs, normalized to the SM ones: they scale as (partial/partial_SM) / (total/total_SM) 
+        self.modelBuilder.factory_('expr::c7_BRscal_hww("@0*@0*@2/@1", kappa_W, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hww)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hzz("@0*@0*@2/@1", kappa_Z, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hzz)')
+        self.modelBuilder.factory_('expr::c7_BRscal_htt("@0*@0*@2/@1", kappa_tau, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_htt)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hmm("@0*@0*@2/@1", kappa_mu, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hmm)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hbb("@0*@0*@2/@1", kappa_b, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hbb)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hcc("@0*@0*@2/@1", kappa_t, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hcc)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hgg("@0*@2/@1", Scaling_hgg, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hgg)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hzg("@0*@2/@1", Scaling_hzg, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hzg)')
+        self.modelBuilder.factory_('expr::c7_BRscal_hgluglu("@0*@2/@1", Scaling_hgluglu, c7_Gscal_tot, HiggsDecayWidth_UncertaintyScaling_hgluglu)')
+
+    def getHiggsSignalYieldScale(self,production,decay,energy):
+        name = "c7_XSBRscal_%s_%s_%s" % (production,decay,energy)
+        if self.modelBuilder.out.function(name) == None:
+            if production in [ "ggH", "qqH", "ggZH", "tHq", "tHW"]: 
+                XSscal = ("@0", "Scaling_%s_%s" % (production,energy) )
+            elif production == "WH":  XSscal = ("@0*@0", "kappa_W")
+            elif production == "ZH":  XSscal = ("@0*@0", "kappa_Z")
+            elif production == "ttH": XSscal = ("@0*@0", "kappa_t")
+            elif production == "bbH": XSscal = ("@0*@0", "kappa_b")
+            else: raise RuntimeError, "Production %s not supported" % production
+            BRscal = decay
+            if not self.modelBuilder.out.function("c7_BRscal_"+BRscal):
+                raise RuntimeError, "Decay mode %s not supported" % decay
+            if decay == "hss": BRscal = "hbb"
+            if production == "ggH" and (decay in self.add_bbH) and energy in ["7TeV","8TeV"]:
+                b2g = "R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01) 
+                self.modelBuilder.factory_('expr::%s("(%s + @1*@1*@2)*@3", %s, kappa_b, %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], b2g, BRscal))
+            else:
+                self.modelBuilder.factory_('expr::%s("%s*@1", %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], BRscal))
+            print '[LHC-HCG Kappas]', name, production, decay, energy,": ",
+            self.modelBuilder.out.function(name).Print("")
+        return name
+
+
+class Lambdas(SMLikeHiggsModel):
+    def __init__(self):
+        SMLikeHiggsModel.__init__(self) # not using 'super(x,self).__init__' since I don't understand it
+        self.floatMass = False
+        self.add_bbH = [ "hzz", "hgg" ]
+    def setPhysicsOptions(self,physOptions):
+        for po in physOptions:
+            if po.startswith("bbh="):
+                self.add_bbH = [ d.strip() for d in po.replace("bbh=","").split(",") ]
+            if po.startswith("higgsMassRange="):
+                self.floatMass = True
+                self.mHRange = po.replace("higgsMassRange=","").split(",")
+                print 'The Higgs mass range:', self.mHRange
+                if len(self.mHRange) != 2:
+                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                elif float(self.mHRange[0]) >= float(self.mHRange[1]):
+                    raise RuntimeError, "Extrama for Higgs mass range defined with inverterd order. Second must be larger the first"
+    def doParametersOfInterest(self):
+        """Create POI out of signal strength and MH"""
+        self.modelBuilder.doVar("lambda_WZ[1,0.0,2.0]") 
+        self.modelBuilder.doVar("lambda_Zg[1,0.0,4.0]")
+        self.modelBuilder.doVar("lambda_bZ[1,0.0,4.0]")
+        self.modelBuilder.doVar("lambda_gamZ[1,0.0,2.0]")
+        self.modelBuilder.doVar("lambda_tauZ[1,0.0,4.0]")
+        self.modelBuilder.doVar("lambda_tg[1,0.0,4.0]")
+        self.modelBuilder.doVar("kappa_gZ[1,0.0,3.0]")
+        self.modelBuilder.doSet("POI",'lambda_WZ,lambda_Zg,lambda_bZ,lambda_gamZ,lambda_tauZ,lambda_tg,kappa_gZ')
+        if self.floatMass:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]),float(self.mHRange[1]))
+                self.modelBuilder.out.var("MH").setConstant(False)
+            else:
+                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1])) 
+        else:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                self.modelBuilder.out.var("MH").setConstant(True)
+            else:
+                self.modelBuilder.doVar("MH[%g]" % self.options.mass) 
+        self.SMH = SMHiggsBuilder(self.modelBuilder)
+        self.setup()
+    def setup(self):
+        self.modelBuilder.doVar("lambda_one[1]")
+
+        self.modelBuilder.factory_("expr::lambda_tZ(\"@0/@1\",lambda_tg,lambda_Zg)");
+        self.SMH.makeScaling("qqH", CW='lambda_WZ', CZ="lambda_one")
+        self.SMH.makeScaling("tHq", CW='lambda_WZ', Ctop="lambda_tZ")
+        self.SMH.makeScaling("tHW", CW='lambda_WZ', Ctop="lambda_tZ")
+        self.SMH.makeScaling("ggZH", CZ='lambda_one', Ctop="lambda_tZ")
+        self.SMH.makeScaling('hzg', Cb='lambda_bZ', Ctop='lambda_tZ', CW='lambda_WZ', Ctau='lambda_tauZ')
+        self.modelBuilder.factory_("expr::lambda_gZ(\"1/@0\",lambda_Zg)");
+        self.modelBuilder.factory_("expr::sqrt_zgamma(\"sqrt(@0)\",Scaling_hzg)");
+
+        for E in "7TeV", "8TeV":
+            for P in "qqH", "tHq", "tHW", "ggZH":
+                self.modelBuilder.factory_("expr::PW_XSscal_%s_%s(\"@0*@1*@1\",Scaling_%s_%s,lambda_Zg)"%(P,E,P,E))
+            self.modelBuilder.factory_("expr::PW_XSscal_WH_%s(\"@0*@0*@1*@1\",lambda_Zg,lambda_WZ)" % E)
+            self.modelBuilder.factory_("expr::PW_XSscal_ZH_%s(\"@0*@0\",lambda_Zg)" % E)
+            self.modelBuilder.factory_("expr::PW_XSscal_ttH_%s(\"@0*@0\",lambda_tg)" % E)
+        self.decayMap_ = {
+            'hww' : 'lambda_WZ',
+            'hzz' : 'lambda_one',
+            'hgg' : 'lambda_gamZ',
+            'hbb' : 'lambda_bZ',
+            'htt' : 'lambda_tauZ',
+            'hmm' : 'lambda_tauZ',
+            'hcc' : 'lambda_tZ',     # charm scales as top
+            'hgluglu' : 'lambda_gZ', # glu scales as 1/Zgky
+            'hzg'     : 'lambda_gamZ',   # fancier option: 'sqrt_zgamma',
+            #'hss' : 'lambda_bZ', # strange scales as bottom # not used
+        } 
+    def getHiggsSignalYieldScale(self,production,decay,energy):
+        name = "c7_XSBRscal_%s_%s_%s" % (production,decay,energy)
+        if self.modelBuilder.out.function(name):
+            return name
+        dscale = self.decayMap_[decay]
+        if production == "ggH": 
+            # fixme bbH
+            self.modelBuilder.factory_("expr::%s(\"@0*@0*   @1*@1\",kappa_gZ,%s)" % (name, dscale))
+        else:
+            self.modelBuilder.factory_("expr::%s(\"@0*@0*@1*@2*@2\",kappa_gZ,PW_XSscal_%s_%s,%s)" % (name, production, energy, dscale))
+        print '[LHC-HCG Lambdas]', name, production, decay, energy,": ",
+        self.modelBuilder.out.function(name).Print("")
+        return name
+
+
+A1 = SignalStrengths()
+K1 = Kappas(resolved=True)
+K2 = Kappas(resolved=False)
+L1 = Lambdas()

--- a/python/LHCHCGModels.py
+++ b/python/LHCHCGModels.py
@@ -31,8 +31,8 @@ CMS_to_LHCHCG_Prod = {
     'ZH': 'qqZH',
     'ggZH': 'ggZH',
     'ttH': 'ttH',
-    'tHq': 'tHq',
-    'tHW': 'tHW',
+    'tHq': 'tHjb',
+    'tHW': 'WtH',
     'bbH': 'bbH',
  } 
 

--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -114,8 +114,10 @@ class MultiSignalModel(PhysicsModel):
 ### This base class implements signal yields by production and decay mode
 ### Specific models can be obtained redefining getHiggsSignalYieldScale
 SM_HIGG_DECAYS   = [ "hww", "hzz", "hgg", "htt", "hbb", 'hzg', 'hmm', 'hcc', 'hgluglu' ]
+SM_HIGG_PROD     = [ "ggH", "qqH", "VH", "WH", "ZH", "ttH", "tHq", "tHW", "ggZH" ]
 BSM_HIGGS_DECAYS = [ "hinv" ]
 ALL_HIGGS_DECAYS = SM_HIGG_DECAYS + BSM_HIGGS_DECAYS
+ALL_HIGGS_PROD   = SM_HIGG_PROD
 def getHiggsProdDecMode(bin,process,options):
     """Return a triple of (production, decay, energy)"""
     processSource = process
@@ -125,7 +127,7 @@ def getHiggsProdDecMode(bin,process,options):
         if decaySource not in ALL_HIGGS_DECAYS:
             print "ERROR", "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)
             #raise RuntimeError, "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)
-    if processSource not in ["ggH", "qqH", "VH", "WH", "ZH", "ttH", "tHq", "tHW"]:
+    if processSource not in ALL_HIGGS_PROD:
         raise RuntimeError, "Validation Error: signal process %s not among the allowed ones." % processSource
     #
     foundDecay = None

--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -146,8 +146,6 @@ class SMHiggsBuilder:
             else:
                 fields = line.split()
                 widthUncertainties[fields[0]] = dict([(k,0.01*float(v)) for (k,v) in zip(widthUncertaintiesKeys, fields[1:])]) 
-        print widthUncertainties
-        print widthUncertaintiesKeys
         for K in widthUncertaintiesKeys[:-1]:
             self.modelBuilder.doVar("param_%s[0,-7,7]" % K)
         for K, DS in THU_GROUPS:

--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -112,6 +112,11 @@ class SMHiggsBuilder:
 )'%locals()
 #            print  rooExpr
             self.modelBuilder.factory_(rooExpr)
+        elif what == 'ggZH':
+            for sqrts in ('7TeV', '8TeV'):
+                scalingName = 'Scaling_'+what+'_'+sqrts
+                rooExpr = 'expr::%(scalingName)s( "(@0*@0)*2.27  + (@1*@1)*0.37 - (@0*@1)*1.44", %(CZ)s, %(Ctop)s)'%locals()
+                self.modelBuilder.factory_(rooExpr)
         elif what == 'tHq':
             for sqrts in ('7TeV', '8TeV'):
                 scalingName = 'Scaling_'+what+'_'+sqrts

--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -2,6 +2,7 @@ from math import *
 from array import array
 import os 
 import ROOT
+from HiggsAnalysis.CombinedLimit.PhysicsModel import ALL_HIGGS_DECAYS
 
 class SMHiggsBuilder:
     def __init__(self,modelBuilder,datadir=None):
@@ -124,8 +125,49 @@ class SMHiggsBuilder:
         else:
             raise RuntimeError, "There is no scaling defined for %(what)s" % locals()
                 
-        
-            
+    def makePartialWidthUncertainties(self):
+        THU_GROUPS = [
+           ('hvv' , [ 'hww', 'hzz' ] ),
+           ('hqq' , [ 'hbb', 'hcc', 'hss' ] ),
+           ('hll' , [ 'htt', 'hmm' ] ),
+           ('hgg' , [ 'hgg' ] ),
+           ('hzg' , [ 'hzg' ] ),
+           ('hgluglu' , [ 'hgluglu' ] ),
+        ]
+        widthUncertainties = {}; widthUncertaintiesKeys = []
+        for line in open(self.brpath+"/WidthUncertainties_126GeV.txt"):
+            if widthUncertaintiesKeys == []:
+                widthUncertaintiesKeys = line.split()[1:]
+            else:
+                fields = line.split()
+                widthUncertainties[fields[0]] = dict([(k,0.01*float(v)) for (k,v) in zip(widthUncertaintiesKeys, fields[1:])]) 
+        print widthUncertainties
+        print widthUncertaintiesKeys
+        for K in widthUncertaintiesKeys[:-1]:
+            self.modelBuilder.doVar("param_%s[0,-7,7]" % K)
+        for K, DS in THU_GROUPS:
+            self.modelBuilder.doVar("HiggsDecayWidthTHU_%s[0,-7,7]" % K)
+        for D in ALL_HIGGS_DECAYS:
+            #print "For decay %s: " % D,
+            if D not in widthUncertainties:
+                self.modelBuilder.doVar("HiggsDecayWidth_UncertaintyScaling_%s[1]" % D)
+                #print " no uncertainties."
+                continue
+            pnorm = ROOT.ProcessNormalization("HiggsDecayWidth_UncertaintyScaling_%s" %D, "")
+            for K in widthUncertaintiesKeys:
+                if K == "thu":
+                    var = None
+                    for K2, DS in THU_GROUPS:
+                        if D in DS:
+                            var = self.modelBuilder.out.var("HiggsDecayWidthTHU_%s" % K2)
+                            break
+                    if var == None: continue
+                else:
+                    var = self.modelBuilder.out.var("param_%s" % K)
+                #print " [ %+.1f%% from %s ]  " % (widthUncertainties[D][K]*100, var.GetName()),
+                pnorm.addLogNormal(exp(widthUncertainties[D][K]), var)
+            #print "."
+            self.modelBuilder.out._import(pnorm)
     def dump(self,name,xvar,values,logfile):
         xv = self.modelBuilder.out.var(xvar)
         yf = self.modelBuilder.out.function(name)

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -72,6 +72,7 @@ class ShapeBuilder(ModelBuilder):
                     bgpdfs.add(pdf); bgcoeffs.add(coeff)
             if self.options.verbose > 1: print "Creating RooAddPdf %s with %s elements" % ("pdf_bin"+b, coeffs.getSize())
             sum_s = ROOT.RooAddPdf("pdf_bin%s"       % b, "",   pdfs,   coeffs)
+            sum_s.setAttribute("MAIN_MEASUREMENT") # useful for plain ROOFIT optimization on ATLAS side
             if not self.options.noBOnly: sum_b = ROOT.RooAddPdf("pdf_bin%s_bonly" % b, "", bgpdfs, bgcoeffs)
             if b in self.pdfModes: 
                 sum_s.setAttribute('forceGen'+self.pdfModes[b].title())

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -76,7 +76,13 @@ class ShapeBuilder(ModelBuilder):
             if b in self.pdfModes: 
                 sum_s.setAttribute('forceGen'+self.pdfModes[b].title())
                 if not self.options.noBOnly: sum_b.setAttribute('forceGen'+self.pdfModes[b].title())
-            if len(self.DC.systs) and (self.options.noOptimizePdf or not self.options.moreOptimizeSimPdf):
+            addSyst = False
+            if    self.options.moreOptimizeSimPdf == "none":   addSyst = True
+            elif  self.options.moreOptimizeSimPdf == "lhchcg": addSyst = (i > 1)
+            elif  self.options.moreOptimizeSimPdf == "cms":
+                if self.options.noOptimizePdf: raise RuntimeError, "--optimize-simpdf-constraints=cms is incompatible with --no-optimize-pdfs"
+                addSyst = False
+            if len(self.DC.systs) and addSyst:
                 ## rename the pdfs
                 sum_s.SetName("pdf_bin%s_nuis" % b); 
                 if not self.options.noBOnly: sum_b.SetName("pdf_bin%s_bonly_nuis" % b)
@@ -117,7 +123,7 @@ class ShapeBuilder(ModelBuilder):
                 for b in self.DC.bins:
                     pdfi = self.out.pdf("pdf_bin%s%s" % (b,postfixIn))
                     simPdf.addPdf(pdfi, b)
-                if len(self.DC.systs) and (not self.options.noOptimizePdf) and self.options.moreOptimizeSimPdf:
+                if len(self.DC.systs) and (not self.options.noOptimizePdf) and self.options.moreOptimizeSimPdf == "cms":
                     simPdf.addExtraConstraints(self.out.nuisPdfs)
                 if self.options.verbose:
                     stderr.write("Importing combined pdf %s\n" % simPdf.GetName()); stderr.flush()

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -6,6 +6,7 @@
 #include "../interface/ProfilingTools.h"
 
 #include <Math/MinimizerOptions.h>
+#include <Math/IOptions.h>
 #include <RooCategory.h>
 #include <RooNumIntConfig.h>
 #include <TStopwatch.h>
@@ -21,6 +22,7 @@ bool CascadeMinimizer::poiOnlyFit_;
 bool CascadeMinimizer::singleNuisFit_;
 bool CascadeMinimizer::setZeroPoint_ = true;
 bool CascadeMinimizer::oldFallback_ = true;
+int  CascadeMinimizer::minuit2StorageLevel_ = 0;
 bool CascadeMinimizer::runShortCombinations = true;
 float CascadeMinimizer::nuisancePruningThreshold_ = 0;
 double CascadeMinimizer::discreteMinTol_ = 0.001;
@@ -482,6 +484,7 @@ void CascadeMinimizer::initOptions()
 	("cminDefaultMinimizerAlgo",boost::program_options::value<std::string>(&defaultMinimizerAlgo_)->default_value(defaultMinimizerAlgo_), "Set the default minimizer Algo")
         ("cminRunAllDiscreteCombinations",  "Run all combinations for discrete nuisances")
         ("cminDiscreteMinTol", boost::program_options::value<double>(&discreteMinTol_)->default_value(discreteMinTol_), "tolerance on min NLL for discrete combination iterations")
+        ("cminM2StorageLevel", boost::program_options::value<int>(&minuit2StorageLevel_)->default_value(minuit2StorageLevel_), "storage level for minuit2 (0 = don't store intermediate covariances, 1 = store them)")
         //("cminNuisancePruning", boost::program_options::value<float>(&nuisancePruningThreshold_)->default_value(nuisancePruningThreshold_), "if non-zero, discard constrained nuisances whose effect on the NLL when changing by 0.2*range is less than the absolute value of the threshold; if threshold is negative, repeat afterwards the fit with these floating")
 
         //("cminDefaultIntegratorEpsAbs", boost::program_options::value<double>(), "RooAbsReal::defaultIntegratorConfig()->setEpsAbs(x)")
@@ -536,7 +539,10 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
                             ", tolerance " << fallbacks_.back().tolerance << std::endl;
         }
     }
-
+    
+    ROOT::Math::IOptions & options = ROOT::Math::MinimizerOptions::Default("Minuit2");
+    options.SetValue("StorageLevel", minuit2StorageLevel_);
+    
     ROOT::Math::MinimizerOptions::SetDefaultMinimizer(defaultMinimizerType_.c_str(),defaultMinimizerAlgo_.c_str());
 
     //if (vm.count("cminDefaultIntegratorEpsAbs")) RooAbsReal::defaultIntegratorConfig()->setEpsAbs(vm["cminDefaultIntegratorEpsAbs"].as<double>());

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -353,6 +353,19 @@ void MultiDimFit::doGrid(RooAbsReal &nll)
             poiVals_[0] = x;
             poiVars_[0]->setVal(x);
             // now we minimize
+            nll.clearEvalErrorLog();
+            deltaNLL_ = nll.getVal() - nll0;
+            if (nll.numEvalErrors() > 0) {
+                deltaNLL_ = 9990;
+		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+			specifiedVals_[j]=specifiedVars_[j]->getVal();
+		}
+		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+		}
+                Combine::commitPoint(true, /*quantile=*/0);
+                continue;
+            }
             bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ? 
                         true : 
                         minim.minimize(verbose-1);

--- a/test/datacardDump.py
+++ b/test/datacardDump.py
@@ -43,6 +43,9 @@ for b in DC.bins:
     exps = {}
     for (p,e) in DC.exp[b].items(): # so that we get only self.DC.processes contributing to this bin
         exps[p] = [ e, [] ]
+        if exps[p][0] < 0:
+            s0 = MB.getShape(b,p)
+            if s0.InheritsFrom("TH1"): exps[p][0] = s0.Integral()
     for (lsyst,nofloat,pdf,pdfargs,errline) in DC.systs:
         if pdf in ('param', 'flatParam'): continue
         # begin skip systematics

--- a/test/unit/plainfit.cxx
+++ b/test/unit/plainfit.cxx
@@ -14,13 +14,15 @@ int main(int argc, char **argv) {
     const char *dataset   = "data_obs"; // -D
     const char *modelConfig = "ModelConfig"; // -c
     const char *snapshot    = NULL; // -S
+    const char *tofix       = NULL;
+    const char *tofloat     = NULL;
     int   strategy    = 0; // -s
     float tolerance   = 1; // -t
     const char *minos = NULL; // -M
     int   optimize    = 2; // -O
     bool  useFitTo    = false; // -f ( use pdf->fitTo instead of Minimizer )
     do {
-        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:f");
+        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:X:L:f");
         switch (opt) {
             case 'w': workspace = optarg; break;
             case 'D': dataset = optarg; break;
@@ -29,6 +31,8 @@ int main(int argc, char **argv) {
             case 's': strategy = atoi(optarg); break;
             case 't': tolerance = atof(optarg); break;
             case 'M': minos = optarg; break;
+            case 'X': tofix = optarg; break;
+            case 'L': tofloat = optarg; break;
             case 'O': optimize = atoi(optarg); break;
             case 'f': useFitTo = true; break;
             case '?': std::cerr << "Unsupported option. Please see the code. " << std::endl; return 1; break;
@@ -56,6 +60,22 @@ int main(int argc, char **argv) {
         return 2;
     }
     if (snapshot) w->loadSnapshot(snapshot);
+    if (tofix) {
+        RooArgSet set(w->argSet(tofix));
+        RooLinkedListIter iter = set.iterator();
+        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+            RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
+            if (rrv) { std::cout << "Fixing " << a->GetName() << std::endl; rrv->setConstant(true); }
+        }
+    }
+    if (tofloat) {
+        RooArgSet set(w->argSet(tofloat));
+        RooLinkedListIter iter = set.iterator();
+        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+            RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
+            if (rrv) { std::cout << "Floating " << a->GetName() << std::endl; rrv->setConstant(false); }
+        }
+    }
     RooArgSet poi; if (minos) poi.add(*w->var(minos));
     ROOT::Math::MinimizerOptions::SetDefaultTolerance(tolerance);
     TStopwatch timer;

--- a/test/unit/plainscan.cxx
+++ b/test/unit/plainscan.cxx
@@ -15,6 +15,8 @@ int main(int argc, char **argv) {
     const char *dataset   = "data_obs"; // -D
     const char *modelConfig = "ModelConfig"; // -c
     const char *snapshot    = NULL; // -S
+    const char *tofix       = NULL;
+    const char *tofloat     = NULL;
     int   strategy    = 0; // -s
     float tolerance   = 1; // -t
     float minval      = NAN;
@@ -25,7 +27,7 @@ int main(int argc, char **argv) {
     int   points      = 10;
     bool  allvars = false;
     do {
-        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:m:n:o:P:A");
+        int opt = getopt(argc, argv, "w:D:c:S:s:t:M:O:X:L:m:n:o:P:A");
         switch (opt) {
             case 'w': workspace = optarg; break;
             case 'D': dataset = optarg; break;
@@ -33,6 +35,8 @@ int main(int argc, char **argv) {
             case 'S': snapshot = optarg; break;
             case 's': strategy = atoi(optarg); break;
             case 't': tolerance = atof(optarg); break;
+            case 'X': tofix = optarg; break;
+            case 'L': tofloat = optarg; break;
             case 'n': points = atoi(optarg); break;
             case 'm': minval = atof(optarg); break;
             case 'M': maxval = atof(optarg); break;
@@ -65,6 +69,23 @@ int main(int argc, char **argv) {
         return 2;
     }
     if (snapshot) w->loadSnapshot(snapshot);
+    if (tofix) {
+        RooArgSet set(w->argSet(tofix));
+        RooLinkedListIter iter = set.iterator();
+        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+            RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
+            if (rrv) { std::cout << "Fixing " << a->GetName() << std::endl; rrv->setConstant(true); }
+        }
+    }
+    if (tofloat) {
+        RooArgSet set(w->argSet(tofloat));
+        RooLinkedListIter iter = set.iterator();
+        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+            RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
+            if (rrv) { std::cout << "Floating " << a->GetName() << std::endl; rrv->setConstant(false); }
+        }
+    }
+
     RooRealVar *r = w->var(poi);
     if (!std::isnan(minval)) r->setMin(minval);
     if (!std::isnan(maxval)) r->setMax(maxval);


### PR DESCRIPTION
 * Preparatory work for implementing the models in https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCRun1HiggsCouplingCombinationPOIs
 * on-the-fly adding of bbH implemented in model with signal strengths and kappas, for ZZ and &gamma;&gamma; decay modes
 * add BR uncertainties in the model with the kappas and lambdas
 * A few improvements to basic tools (datacardDump, plainfit, plainscan)
 * Stabilize memory usage during fits by not storing all intermediate states of the fit
 * improve `--optimize-simpdf-constraints` ( ce526a95c31ed642a9d3be05ddcd404e47ffcccd )