### PR TITLE
Fix crash when loading snapshot if MH is not there

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -325,12 +325,13 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     if (snapshotName_ != "") {
       bool loaded = w->loadSnapshot(snapshotName_.c_str());
       assert(loaded);
-      //make sure mass value used is really the one from the loaded snapshot unless explicitly requested to override it
-      if (overrideSnapshotMass_) {
-        MH->setVal(mass_);
-      }
-      else {
-        mass_ = MH->getVal();
+      if (MH!=0) {
+          //make sure mass value used is really the one from the loaded snapshot unless explicitly requested to override it
+          if (overrideSnapshotMass_) {
+              MH->setVal(mass_);
+          } else {
+              mass_ = MH->getVal();
+          }
       }
     }
   //*********************************************


### PR DESCRIPTION
Important for running on ATLAS workspaces.