### PR TITLE
Fix scaling of tHq, tHW in C6 model

### DIFF
--- a/python/LOFullParametrization.py
+++ b/python/LOFullParametrization.py
@@ -164,7 +164,11 @@ class C6(SMLikeHiggsModel):
             if decay in ["hbb", "htt"]: BRscal = decay
             if decay in ["hww", "hzz"]: BRscal = "hvv"
             if self.doHZg and decay == "hzg": BRscal = "hzg"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+            if "Scaling" in XSscal: # already squared, just put XSscal
+                self.modelBuilder.factory_('expr::%s("@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+            else: # plain coupling, put (XSscal)^2
+                self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+    
         return name
 
 


### PR DESCRIPTION
By mistake, the previous version of C6 in #194 was taking the scaling factor for tHq and tHW and squaring them another time when deriving the signal strength.
That ended up overestimating by a huge amount the effect of tHq and tHW (e.g for k<sub>t</sub> = -1, the scaling was 12<sup>2</sup>=144 instead of 12)