### PR TITLE
Code to improve the accuracy and performance of LHC combined fits

### DIFF
--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -252,6 +252,10 @@ int main(int argc, char **argv) {
   runtimedef::set("ADDNLL_ROOREALSUM_NONORM",1);
   runtimedef::set("ADDNLL_ROOREALSUM_BASICINT",1);
   runtimedef::set("ADDNLL_ROOREALSUM_KEEPZEROS",1);
+  runtimedef::set("ADDNLL_PRODNLL",1);
+  runtimedef::set("ADDNLL_HFNLL",1);
+  runtimedef::set("ADDNLL_ROOREALSUM_CHEAPPROD",1);
+ 
 
 
   for (vector<string>::const_iterator rtdp = runtimeDefines.begin(), endrtdp = runtimeDefines.end(); rtdp != endrtdp; ++rtdp) {

--- a/interface/Accumulators.h
+++ b/interface/Accumulators.h
@@ -1,0 +1,55 @@
+#ifndef HiggsAnalysis_CombinedLimit_Accumulators_h
+#define HiggsAnalysis_CombinedLimit_Accumulators_h
+
+#include <vector>
+
+class NaiveAccumulator {
+    public:
+        NaiveAccumulator(const double & value = 0) : sum_(value) {}
+        NaiveAccumulator & operator+=(const double &inc) { sum_ += inc; return *this;  }
+        NaiveAccumulator & operator-=(const double &inc) { sum_ -= inc; return *this; }
+        double sum() const { return sum_; } 
+    private:
+        double sum_;
+};
+
+class KahanAccumulator {
+    public:
+        KahanAccumulator(const double & value = 0) : sum_(value), compensation_(0) {}
+        void operator+=(const double &inc) { 
+            double y = inc - compensation_;
+            double sumnew = sum_ + y;
+            double sumerr = ( sumnew - sum_ );
+            compensation_ = sumerr - y;
+            sum_ = sumnew; 
+        }
+        void operator-=(const double &inc) { this->operator+=(-inc); }
+        double sum() const { return sum_; } 
+    private:
+        double sum_, compensation_;
+};
+
+template<typename A>
+inline double sumWith(const std::vector<double> & vals) {
+    A ret = 0;
+    for (const double & v : vals) ret += v;
+    return ret.sum();
+}
+
+typedef KahanAccumulator PreciseAccumulator;
+typedef NaiveAccumulator FastAccumulator;
+typedef FastAccumulator DefaultAccumulator;
+
+inline double sumPrecise(const std::vector<double> & vals) {
+    return sumWith<PreciseAccumulator>(vals);
+}
+
+inline double sumFast(const std::vector<double> & vals) {
+    return sumWith<FastAccumulator>(vals);
+}
+
+inline double sumDefault(const std::vector<double> & vals) {
+    return sumWith<DefaultAccumulator>(vals);
+}
+
+#endif

--- a/interface/Accumulators.h
+++ b/interface/Accumulators.h
@@ -38,7 +38,7 @@ inline double sumWith(const std::vector<double> & vals) {
 
 typedef KahanAccumulator PreciseAccumulator;
 typedef NaiveAccumulator FastAccumulator;
-typedef FastAccumulator DefaultAccumulator;
+typedef PreciseAccumulator DefaultAccumulator;
 
 inline double sumPrecise(const std::vector<double> & vals) {
     return sumWith<PreciseAccumulator>(vals);

--- a/interface/CachingMultiPdf.h
+++ b/interface/CachingMultiPdf.h
@@ -5,6 +5,7 @@
 #include "../interface/CachingNLL.h"
 #include <RooAbsData.h>
 #include <RooAddPdf.h>
+#include <RooProduct.h>
 #include <vector>
 
 namespace cacheutils {
@@ -35,6 +36,22 @@ namespace cacheutils {
             boost::ptr_vector<CachingPdfBase>  cachingPdfs_;
             std::vector<Double_t> work_;
     };
+
+    class CachingProduct : public CachingPdfBase {
+        public:
+            CachingProduct(const RooProduct &pdf, const RooArgSet &obs) ;
+            ~CachingProduct() ;
+            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
+            const RooAbsReal *pdf() const { return pdf_; }
+            virtual void  setDataDirty() ;
+            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+        protected:
+            const RooProduct * pdf_;
+            boost::ptr_vector<CachingPdfBase>  cachingPdfs_;
+            std::vector<Double_t> work_;
+    };
+
+
 
 } // namespace
 

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -13,8 +13,10 @@
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
 #include <RooGaussian.h>
+#include <RooPoisson.h>
 #include <RooProduct.h>
 #include "../interface/SimpleGaussianConstraint.h"
+#include "../interface/SimplePoissonConstraint.h"
 #include <boost/ptr_container/ptr_vector.hpp>
 
 class RooMultiPdf;
@@ -177,6 +179,8 @@ class CachingSimNLL  : public RooAbsReal {
         std::vector<RooAbsPdf *>        constrainPdfs_;
         std::vector<SimpleGaussianConstraint *>  constrainPdfsFast_;
         std::vector<bool>                        constrainPdfsFastOwned_;
+        std::vector<SimplePoissonConstraint *>   constrainPdfsFastPoisson_;
+        std::vector<bool>                        constrainPdfsFastPoissonOwned_;
         std::vector<CachingAddNLL*>     pdfs_;
         std::auto_ptr<TList>            dataSets_;
         std::vector<RooDataSet *>       datasets_;
@@ -185,6 +189,7 @@ class CachingSimNLL  : public RooAbsReal {
         static bool optimizeContraints_;
         std::vector<double> constrainZeroPoints_;
         std::vector<double> constrainZeroPointsFast_;
+        std::vector<double> constrainZeroPointsFastPoisson_;
 };
 
 }

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -122,8 +122,8 @@ class CachingAddNLL : public RooAbsReal {
         virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const ;
         double  sumWeights() const { return sumWeights_; }
         const RooAbsPdf *pdf() const { return pdf_; }
-        void setZeroPoint() { zeroPoint_ = -this->getVal(); setValueDirty(); }
-        void clearZeroPoint() { zeroPoint_ = 0.0; setValueDirty();  }
+        void setZeroPoint() ;
+        void clearZeroPoint() ;
         /// note: setIncludeZeroWeights(true) won't have effect unless you also re-call setData
         virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         RooSetProxy & params() { return params_; }
@@ -145,7 +145,8 @@ class CachingAddNLL : public RooAbsReal {
         mutable std::vector<Double_t> workingArea_;
         mutable bool isRooRealSum_, fastExit_;
         mutable int canBasicIntegrals_, basicIntegrals_;
-        double zeroPoint_;
+        double zeroPoint_; 
+        double constantZeroPoint_; // this is arbitrary and kept constant for all the lifetime of the PDF
 };
 
 class CachingSimNLL  : public RooAbsReal {

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -59,6 +59,8 @@ class CascadeMinimizer {
         static std::vector<Algo> fallbacks_;
         /// do a pre-scan
         static bool preScan_;
+        /// do a pre-fit (with larger tolerance)
+        static double approxPreFit_;
         /// do a pre-fit (w/o nuisances)
         static int preFit_;
         /// do first a fit of only the POI

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -60,7 +60,7 @@ class CascadeMinimizer {
         /// do a pre-scan
         static bool preScan_;
         /// do a pre-fit (with larger tolerance)
-        static double approxPreFit_;
+        static double approxPreFitTolerance_;
         /// do a pre-fit (w/o nuisances)
         static int preFit_;
         /// do first a fit of only the POI

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -61,6 +61,8 @@ class CascadeMinimizer {
         static bool preScan_;
         /// do a pre-fit (with larger tolerance)
         static double approxPreFitTolerance_;
+        /// do a pre-fit (with larger tolerance)
+        static int approxPreFitStrategy_;
         /// do a pre-fit (w/o nuisances)
         static int preFit_;
         /// do first a fit of only the POI

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -82,6 +82,7 @@ private:
   bool rebuildSimPdf_;
   bool optSimPdf_;
   bool noMCbonly_;
+  bool noDefaultPrior_;
   bool floatAllNuisances_;
   bool freezeAllGlobalObs_;
 

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -46,6 +46,7 @@ protected:
   static bool loadedSnapshot_, savingSnapshot_;
   static float maxDeltaNLLForProf_;
   static float autoRange_;
+  static bool  startFromPreFit_;
 
   static std::string saveSpecifiedFuncs_;
   static std::string saveSpecifiedNuis_;
@@ -63,11 +64,11 @@ protected:
 
   // variables
   void doSingles(RooFitResult &res) ;
-  void doGrid(RooAbsReal &nll) ;
-  void doRandomPoints(RooAbsReal &nll) ;
-  void doFixedPoint(RooWorkspace *w,RooAbsReal &nll) ;
-  void doContour2D(RooAbsReal &nll) ;
-  void doStitch2D(RooAbsReal &nll) ;
+  void doGrid(RooWorkspace *w, RooAbsReal &nll) ;
+  void doRandomPoints(RooWorkspace *w, RooAbsReal &nll) ;
+  void doFixedPoint(RooWorkspace *w, RooAbsReal &nll) ;
+  void doContour2D(RooWorkspace *w, RooAbsReal &nll) ;
+  void doStitch2D(RooWorkspace *w, RooAbsReal &nll) ;
 
   // utilities
   /// for each RooRealVar, set a range 'box' from the PL profiling all other parameters

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -43,7 +43,7 @@ protected:
   static bool squareDistPoiStep_;
   static bool fastScan_;
   static bool hasMaxDeltaNLLForProf_;
-  static bool loadedSnapshot_;
+  static bool loadedSnapshot_, savingSnapshot_;
   static float maxDeltaNLLForProf_;
   static float autoRange_;
 

--- a/interface/RooCheapProduct.h
+++ b/interface/RooCheapProduct.h
@@ -1,0 +1,22 @@
+#ifndef HiggsAnalysis_CombinedLimit_RooCheapProduct_h
+#define HiggsAnalysis_CombinedLimit_RooCheapProduct_h
+#include <RooAbsReal.h>
+#include <RooListProxy.h>
+#include <vector>
+
+class RooCheapProduct : public RooAbsReal {
+    public:
+        RooCheapProduct() {}
+        RooCheapProduct(const char *name, const char *title, const RooArgList &terms, bool pruneConstants=false);
+        RooCheapProduct(const RooCheapProduct& other, const char* name=0);
+        virtual ~RooCheapProduct() {}
+        virtual TObject *clone(const char *newname) const { return new RooCheapProduct(*this,newname); } 
+        const RooArgList & components() const { return terms_; }
+    protected:
+        RooListProxy terms_;
+        std::vector<RooAbsReal *> vterms_;
+        double offset_;
+        virtual Double_t evaluate() const ;
+};
+
+#endif

--- a/interface/SimplePoissonConstraint.h
+++ b/interface/SimplePoissonConstraint.h
@@ -1,0 +1,48 @@
+#ifndef SimplePoissonConstraint_h
+#define SimplePoissonConstraint_h
+
+#include <RooPoisson.h>
+
+class SimplePoissonConstraint : public RooPoisson {
+    public:
+        SimplePoissonConstraint() {} ;
+        SimplePoissonConstraint(const char *name, const char *title,
+                RooAbsReal& _x, RooAbsReal& _mean, bool noRounding = false ):
+            RooPoisson(name,title,_x,_mean, noRounding) { init(); }
+        SimplePoissonConstraint(const SimplePoissonConstraint& other, const char* name=0) :
+            RooPoisson(other, name) { init(); }
+        SimplePoissonConstraint(const RooPoisson &g) : RooPoisson(g, "") { init(); }
+
+        virtual TObject* clone(const char* newname) const { return new SimplePoissonConstraint(*this,newname); }
+        inline virtual ~SimplePoissonConstraint() { }
+
+        double getLogValFast() const { 
+            if (_valueDirty) {
+                Double_t expected = mean;
+                Double_t observed = x;
+                if (std::abs(observed)<1e-10) {
+                    _value = (std::abs(expected)<1e-10) ? 0 : -1*expected;
+                } else {
+                    if(observed<1000000) {
+                        _value = - ( - observed * log(expected) + expected + logGamma_ );
+                    } else {
+                        //if many observed events, use Gauss approximation
+                        Double_t sigma_square = expected;
+                        Double_t diff = observed - expected;
+                        _value = log(sigma_square)/2 - (diff*diff)/(2*sigma_square);
+                    }
+                }
+                _valueDirty = false;
+            }
+            return _value;
+        }
+
+        static RooPoisson * make(RooPoisson &c) ;
+    private:
+        double logGamma_;
+        void init() ;
+
+        ClassDef(SimplePoissonConstraint,1) // Poisson PDF with fast log
+};
+
+#endif

--- a/interface/VectorizedHistFactoryPdfs.h
+++ b/interface/VectorizedHistFactoryPdfs.h
@@ -1,0 +1,55 @@
+#ifndef VectorizedHistFactoryPdfs_h
+#define VectorizedHistFactoryPdfs_h
+
+#include <RooHistFunc.h>
+#include <RooStats/HistFactory/ParamHistFunc.h>
+#include <RooStats/HistFactory/PiecewiseInterpolation.h>
+#include "../interface/CachingNLL.h"
+
+namespace cacheutils {
+    class VectorizedHistFunc : public CachingPdfBase {
+        public:
+            VectorizedHistFunc(const RooHistFunc &pdf, bool includeZeroWeights=false) ;
+            virtual ~VectorizedHistFunc() {}
+            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
+            virtual const RooAbsReal *pdf() const { return pdf_; };
+            virtual void  setDataDirty() { data_ = 0; }
+            virtual void  setIncludeZeroWeights(bool includeZeroWeights) { includeZeroWeights_ = includeZeroWeights; }
+        private:
+            const RooHistFunc * pdf_;
+            const RooAbsData * data_;
+            bool includeZeroWeights_;
+            std::vector<Double_t> yvals_;
+            void fill() ;
+    };
+
+    class VectorizedParamHistFunc {
+        public:
+            VectorizedParamHistFunc(const ParamHistFunc &pdf, const RooAbsData &data, bool includeZeroWeights=false) ;
+            void fill(std::vector<Double_t> &out) const ;
+        private:
+            std::vector<const RooRealVar *> yvars_;
+    };
+
+    class CachingPiecewiseInterpolation : public CachingPdfBase {
+        public:
+            CachingPiecewiseInterpolation(const PiecewiseInterpolation &pdf, const RooArgSet &obs) ;
+            ~CachingPiecewiseInterpolation() ;
+            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
+            const RooAbsReal *pdf() const { return pdf_; }
+            virtual void  setDataDirty() ;
+            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+        protected:
+            const PiecewiseInterpolation * pdf_;
+            std::vector<const RooAbsReal *> coeffs_;
+            std::vector<int>                codes_;
+            bool positiveDefinite_;
+            std::unique_ptr<CachingPdfBase>    cachingPdfNominal_;
+            boost::ptr_vector<CachingPdfBase>  cachingPdfsHi_;
+            boost::ptr_vector<CachingPdfBase>  cachingPdfsLow_;
+            std::vector<Double_t> work_;
+    };
+}
+
+
+#endif

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -21,7 +21,7 @@ namespace RooStats { class ModelConfig; }
 namespace utils {
     void printRDH(RooAbsData *data) ;
     void printRAD(const RooAbsData *d) ;
-    void printPdf(RooAbsPdf *pdf) ;
+    void printPdf(const RooAbsReal *pdf) ;
     void printPdf(RooStats::ModelConfig &model) ;
     void printPdf(RooWorkspace *w, const char *pdfName) ;
 

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -16,6 +16,7 @@ struct RooAbsCollection;
 struct RooWorkspace;
 struct RooPlot;
 struct RooRealVar;
+struct RooProduct;
 namespace RooStats { class ModelConfig; }
 namespace utils {
     void printRDH(RooAbsData *data) ;
@@ -42,6 +43,8 @@ namespace utils {
 
     /// factorize a RooAbsReal
     void factorizeFunc(const RooArgSet &observables, RooAbsReal &pdf, RooArgList &obsTerms, RooArgList &otherTerms, bool keepDuplicates = true, bool debug=false);
+    /// workaround for RooProdPdf::components()
+    RooArgList factors(const RooProduct &prod) ;
 
     /// Note: doesn't recompose Simultaneous pdfs properly, for that use factorizePdf method
     RooAbsPdf *makeObsOnlyPdf(RooStats::ModelConfig &model, const char *name="obsPdf") ;

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -29,6 +29,8 @@ namespace utils {
     RooAbsPdf *fullClonePdf(const RooAbsPdf *pdf, RooArgSet &holder, bool cloneLeafNodes=false) ;
     // Clone a function and all it's branch nodes. on request, clone also leaf nodes (i.e. RooRealVars)
     RooAbsReal *fullCloneFunc(const RooAbsReal *pdf, RooArgSet &holder, bool cloneLeafNodes=false) ;
+    // Clone a function and all it's branch nodes that depends on the observables. on request, clone also leaf nodes (i.e. RooRealVars)
+    RooAbsReal *fullCloneFunc(const RooAbsReal *pdf, const RooArgSet &obs, RooArgSet &holder, bool cloneLeafNodes=false) ;
 
     /// Create a pdf which depends only on observables, and collect the other constraint terms
     /// Will return 0 if it's all constraints, &pdf if it's all observables, or a new pdf if it's something mixed

--- a/src/CachingMultiPdf.cc
+++ b/src/CachingMultiPdf.cc
@@ -1,5 +1,6 @@
 #include "../interface/CachingMultiPdf.h"
 #include "vectorized.h"
+#include "../interface/utils.h"
 
 // Uncomment do do regression testing wrt uncached multipdf
 //#define CachingMultiPdf_VALIDATE
@@ -124,6 +125,47 @@ void cacheutils::CachingAddPdf::setDataDirty()
 }
 
 void cacheutils::CachingAddPdf::setIncludeZeroWeights(bool includeZeroWeights) 
+{
+    for (CachingPdfBase &pdf : cachingPdfs_) {
+        pdf.setIncludeZeroWeights(includeZeroWeights);
+    }
+}
+
+cacheutils::CachingProduct::CachingProduct(const RooProduct &pdf, const RooArgSet &obs) :
+    pdf_(&pdf)
+{
+    const RooArgList & pdfs = utils::factors(pdf);
+    //std::cout << "Making a CachingProduct for " << pdf.GetName() << " with " << pdfs.getSize() << " pdfs, " << coeffs.getSize() << " coeffs." << std::endl;
+    for (int i = 0, n = pdfs.getSize(); i < n; ++i) {
+        RooAbsReal *pdfi = (RooAbsReal*) pdfs.at(i);
+        cachingPdfs_.push_back(makeCachingPdf(pdfi, &obs));
+    }
+}
+
+cacheutils::CachingProduct::~CachingProduct()
+{
+}
+
+const std::vector<Double_t> & cacheutils::CachingProduct::eval(const RooAbsData &data)
+{
+    const std::vector<Double_t> & one = cachingPdfs_.front().eval(data);
+    unsigned int size = one.size();
+    work_.resize(size);
+    std::copy(one.begin(), one.end(), work_.begin());
+    for (int i = 1, n =  cachingPdfs_.size(); i < n; ++i) {
+        vectorized::mul_inplace(size, &cachingPdfs_[i].eval(data)[0], &work_[0]);
+    }
+    return work_;
+}
+
+void cacheutils::CachingProduct::setDataDirty()
+{
+    for (CachingPdfBase &pdf : cachingPdfs_) {
+        pdf.setDataDirty();
+    }
+}
+
+void cacheutils::CachingProduct::setIncludeZeroWeights(bool includeZeroWeights) 
 {
     for (CachingPdfBase &pdf : cachingPdfs_) {
         pdf.setIncludeZeroWeights(includeZeroWeights);

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -673,9 +673,10 @@ cacheutils::CachingAddNLL::evaluate() const
         if (!CachingSimNLL::noDeepLEE_) logEvalError("Expected number of events is negative"); else CachingSimNLL::hasError_ = true;
         expectedEvents = 1e-6;
     }
-    //ret += expectedEvents - UInt_t(sumWeights_) * log(expectedEvents); // no, doesn't work with Asimov dataset
-    ret += expectedEvents - sumWeights_ * log(expectedEvents);
-    ret += zeroPoint_;
+    // I can add any arbitrary constant that does not depend on the expected events,
+    // so I choose it in order to minimize the number assuming that expectedEvents ~ sumWeights_
+    //    ret += expectedEvents - sumWeights_ * log(expectedEvents);
+    ret += (expectedEvents - sumWeights_)  - sumWeights_ * (log(expectedEvents) - (sumWeights_ ? log(sumWeights_) : 0));
 
     // multipdfs want to add a correction factor to the NLL
     if (!multiPdfs_.empty()) {
@@ -686,6 +687,8 @@ cacheutils::CachingAddNLL::evaluate() const
         // Add correction 
         ret += correctionFactor;
     }
+
+    ret += zeroPoint_;
 
     TRACE_NLL("AddNLL for " << pdf_->GetName() << ": " << ret)
     return ret;

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -602,7 +602,7 @@ cacheutils::CachingAddNLL::evaluate() const
         if (basicIntegrals_) {
             double integral = (binWidths_.size() > 1) ? 
                                     vectorized::dot_product(pdfvals.size(), &pdfvals[0], &binWidths_[0]) :
-                                    binWidths_.front() * std::accumulate(pdfvals.begin(), pdfvals.end(), 0.0);
+                                    binWidths_.front() * sumDefault(pdfvals);
             if (basicIntegrals_ == 1) {
                 double refintegral = integrals_[itc - coeffs_.begin()]->getVal();
                 if (refintegral > 0) {

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -18,6 +18,7 @@ boost::program_options::options_description CascadeMinimizer::options_("Cascade 
 std::vector<CascadeMinimizer::Algo> CascadeMinimizer::fallbacks_;
 bool CascadeMinimizer::preScan_;
 double CascadeMinimizer::approxPreFitTolerance_ = 0;
+int CascadeMinimizer::approxPreFitStrategy_ = 0;
 int  CascadeMinimizer::preFit_ = 0;
 bool CascadeMinimizer::poiOnlyFit_;
 bool CascadeMinimizer::singleNuisFit_;
@@ -54,8 +55,10 @@ bool CascadeMinimizer::improve(int verbose, bool cascade)
         if (verbose > 1) std::cout << "Running pre-fit with " << nominalType << "," << nominalAlgo << " and tolerance " << tol << std::endl;
         ProfileLikelihood::MinimizerSentry minimizerConfig(nominalType+","+nominalAlgo, tol);
         minimizer_->setEps(tol);
+        minimizer_->setStrategy(approxPreFitStrategy_);
         improveOnce(verbose-1);
         minimizer_->setEps(nominalTol);
+        minimizer_->setStrategy(strategy_);
     }
     bool outcome = improveOnce(verbose-1);
     if (cascade && !outcome && !fallbacks_.empty()) {
@@ -487,6 +490,7 @@ void CascadeMinimizer::initOptions()
         ("cminPreScan",  "Do a scan before first minimization")
         ("cminPreFit", boost::program_options::value<int>(&preFit_)->default_value(preFit_), "if set to a value N > 0, it will perform a pre-fit with strategy (N-1) with frozen nuisance parameters.")
         ("cminApproxPreFitTolerance", boost::program_options::value<double>(&approxPreFitTolerance_)->default_value(approxPreFitTolerance_), "If non-zero, do first a pre-fit with this tolerance (or 10 times the final tolerance, whichever is largest)")
+        ("cminApproxPreFitStrategy", boost::program_options::value<int>(&approxPreFitStrategy_)->default_value(approxPreFitStrategy_), "Strategy to use in the pre-fit")
         ("cminSingleNuisFit", "Do first a minimization of each nuisance parameter individually")
         ("cminFallbackAlgo", boost::program_options::value<std::vector<std::string> >(), "Fallback algorithms if the default minimizer fails (can use multiple ones). Syntax is algo[,subalgo][,strategy][:tolerance]")
         ("cminSetZeroPoint", boost::program_options::value<bool>(&setZeroPoint_)->default_value(setZeroPoint_), "Change the reference point of the NLL to be zero during minimization")

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -93,6 +93,11 @@ bool CascadeMinimizer::improveOnce(int verbose)
     std::string myType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
     std::string myAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
     bool outcome = false;
+    static int maxcalls = runtimedef::get("MINIMIZER_MaxCalls");
+    if (maxcalls) {
+        minimizer_->setMaxFunctionCalls(maxcalls);
+        minimizer_->setMaxIterations(maxcalls);
+    }
     if (oldFallback_){
         if (optConst) minimizer_->optimizeConst(std::max(0,optConst));
         if (rooFitOffset) minimizer_->setOffsetting(std::max(0,rooFitOffset));

--- a/src/CombinedLimit_LinkDef.h
+++ b/src/CombinedLimit_LinkDef.h
@@ -22,6 +22,7 @@
 #include "../interface/RooMultiPdf.h"
 #include "../interface/RooBernsteinFast.h"
 #include "../interface/SimpleGaussianConstraint.h"
+#include "../interface/SimplePoissonConstraint.h"
 #include "../interface/AtlasPdfs.h"
 #include "../interface/HZZ4L_RooSpinZeroPdf.h"
 #include "../interface/HZZ4L_RooSpinZeroPdf_phase.h"
@@ -56,6 +57,7 @@
 #pragma link C++ class TH1Keys+;
 #pragma link C++ class RooSimultaneousOpt+;
 #pragma link C++ class SimpleGaussianConstraint+;
+#pragma link C++ class SimplePoissonConstraint+;
 #pragma link C++ class SimpleCacheSentry+;
 #pragma link C++ function th1fmorph;
 #pragma link C++ class RooqqZZPdf+;

--- a/src/FastTemplate.cc
+++ b/src/FastTemplate.cc
@@ -1,4 +1,5 @@
 #include "../interface/FastTemplate.h"
+#include <../interface/Accumulators.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -6,9 +7,9 @@
 #include <algorithm>
 
 FastTemplate::T FastTemplate::Integral() const {
-    T total = 0;
+    DefaultAccumulator total = 0;
     for (unsigned int i = 0; i < size_; ++i) total += values_[i];
-    return total;
+    return total.sum();
 }
 
 void FastTemplate::Scale(T factor) {
@@ -86,9 +87,9 @@ FastHisto::T FastHisto::GetAt(const T &x) const {
 }
 
 FastHisto::T FastHisto::IntegralWidth() const {
-    double total = 0;
+    DefaultAccumulator total = 0;
     for (unsigned int i = 0; i < size_; ++i) total += values_[i] * binWidths_[i];
-    return total;
+    return total.sum();
 }
 
 void FastHisto::Dump() const {
@@ -149,16 +150,17 @@ FastHisto2D::T FastHisto2D::GetAt(const T &x, const T &y) const {
 }
 
 FastHisto2D::T FastHisto2D::IntegralWidth() const {
-    double total = 0;
+    DefaultAccumulator total = 0;
     for (unsigned int i = 0; i < size_; ++i) total += values_[i] * binWidths_[i];
-    return total;
+    return total.sum();
 }
 
 void FastHisto2D::NormalizeXSlices() {
     for (unsigned int ix = 0, offs = 0; ix < binX_; ++ix, offs += binY_) {
        T *values = & values_[offs], *widths = & binWidths_[offs];
-       double total = 0;
-       for (unsigned int i = 0; i < binY_; ++i) total += values[i] * widths[i];
+       DefaultAccumulator totalc = 0;
+       for (unsigned int i = 0; i < binY_; ++i) totalc += values[i] * widths[i];
+       double total = totalc.sum();
        if (total > 0) {
             total = T(1.0)/total;
             for (unsigned int i = 0; i < binY_; ++i) values[i] *= total;
@@ -259,9 +261,9 @@ FastHisto3D::T FastHisto3D::GetAt(const T &x, const T &y, const T &z) const {
 
 
 FastHisto3D::T FastHisto3D::IntegralWidth() const {
-    double total = 0;
+    DefaultAccumulator total = 0;
     for (unsigned int i = 0; i < size_; ++i) total += values_[i] * binWidths_[i];
-    return total;
+    return total.sum();
 }
 
 void FastHisto3D::NormalizeXSlices() {

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -144,12 +144,6 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	}
     }
    
-
-    std::auto_ptr<RooAbsReal> nll;
-    if (algo_ != None && algo_ != Singles) {
-        nll.reset(pdf.createNLL(data, constrainCmdArg, RooFit::Extended(pdf.canBeExtended())));
-    } 
-    
     //set snapshot for best fit
     if (savingSnapshot_) w->saveSnapshot("MultiDimFit",w->allVars());
     

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -36,6 +36,7 @@ bool MultiDimFit::floatOtherPOIs_ = false;
 unsigned int MultiDimFit::nOtherFloatingPoi_ = 0;
 bool MultiDimFit::fastScan_ = false;
 bool MultiDimFit::loadedSnapshot_ = false;
+bool MultiDimFit::savingSnapshot_ = false;
 bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
 bool MultiDimFit::squareDistPoiStep_ = false;
 float MultiDimFit::maxDeltaNLLForProf_ = 200;
@@ -99,6 +100,7 @@ void MultiDimFit::applyOptions(const boost::program_options::variables_map &vm)
     squareDistPoiStep_ = (vm.count("squareDistPoiStep") > 0);
     hasMaxDeltaNLLForProf_ = !vm["maxDeltaNLLForProf"].defaulted();
     loadedSnapshot_ = !vm["snapshotName"].defaulted();
+    savingSnapshot_ = (!loadedSnapshot_) && vm.count("saveWorkspace");
 }
 
 bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
@@ -149,7 +151,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     } 
     
     //set snapshot for best fit
-    if (!loadedSnapshot_) w->saveSnapshot("MultiDimFit",w->allVars());
+    if (savingSnapshot_) w->saveSnapshot("MultiDimFit",w->allVars());
     
     if (autoRange_ > 0) {
         std::cout << "Adjusting range of POIs to +/- " << autoRange_ << " standard deviations" << std::endl;

--- a/src/ProfileLikelihood.cc
+++ b/src/ProfileLikelihood.cc
@@ -91,10 +91,10 @@ ProfileLikelihood::MinimizerSentry::MinimizerSentry(const std::string &minimizer
   if (minimizerAlgo.find(",") != std::string::npos) {
       size_t idx = minimizerAlgo.find(",");
       std::string type = minimizerAlgo.substr(0,idx), algo = minimizerAlgo.substr(idx+1);
-      if (verbose > 1) std::cout << "Set default minimizer to " << type << ", algorithm " << algo << std::endl;
+      if (verbose > 1) std::cout << "Set default minimizer to " << type << ", algorithm " << algo << ", tolerance " << tolerance << std::endl;
       ROOT::Math::MinimizerOptions::SetDefaultMinimizer(type.c_str(), algo.c_str());
   } else {
-      if (verbose > 1) std::cout << "Set default minimizer to " << minimizerAlgo << std::endl;
+      if (verbose > 1) std::cout << "Set default minimizer to " << minimizerAlgo << ", tolerance " << tolerance << std::endl;
       ROOT::Math::MinimizerOptions::SetDefaultMinimizer(minimizerAlgo.c_str());
   }
 }

--- a/src/RooCheapProduct.cc
+++ b/src/RooCheapProduct.cc
@@ -1,0 +1,47 @@
+#include "../interface/RooCheapProduct.h"
+#include <RooConstVar.h>
+
+RooCheapProduct::RooCheapProduct(const char *name, const char *title, const RooArgList &terms, bool pruneConstants) :
+    RooAbsReal(name,title),
+    terms_("!terms","Set of real product components",this),
+    offset_(1.0)
+{
+    RooFIter iter = terms.fwdIterator();
+    for (RooAbsArg *a = iter.next(); a != 0; a = iter.next()) {
+        RooAbsReal *rar = dynamic_cast<RooAbsReal *>(a);
+        if (!rar) { 
+            throw std::invalid_argument(std::string("Component ")+a->GetName()+" of RooCheapProduct is a "+a->ClassName()); 
+        }
+        if (typeid(*rar) == typeid(RooConstVar) || (pruneConstants && rar->isConstant())) {
+            offset_ *= rar->getVal();
+            continue; 
+        }
+        terms_.add(*rar);
+        vterms_.push_back(rar);
+    }
+}
+
+RooCheapProduct::RooCheapProduct(const RooCheapProduct& other, const char* name) :
+    RooAbsReal(other, name),
+    terms_("!terms",this,other.terms_),
+    vterms_(other.vterms_),
+    offset_(other.offset_)
+{
+}
+
+Double_t RooCheapProduct::evaluate() const 
+{
+    if (vterms_.empty()) {
+        RooFIter iter = terms_.fwdIterator();
+        std::vector<RooAbsReal *> & vterms = const_cast<std::vector<RooAbsReal *>&>(vterms_);
+        vterms.reserve(terms_.getSize());
+        for (RooAbsArg *a = iter.next(); a != 0; a = iter.next()) {
+            vterms.push_back(dynamic_cast<RooAbsReal *>(a));
+        }
+    }
+    double ret = offset_;
+    for (const RooAbsReal *rar : vterms_) {
+        ret *= rar->getVal();
+    }
+    return ret;
+}

--- a/src/RooMinimizerOpt.cc
+++ b/src/RooMinimizerOpt.cc
@@ -333,9 +333,14 @@ RooMinimizerFcnOpt::DoEval(const double * x) const
       RooRealVar* var ;
       Bool_t first(kTRUE) ;
       ooccoutW(_context,Minimization) << "Parameter values: " ;
+      int nparam(0);
       while((var=(RooRealVar*)iter->Next())) {
         if (first) { first = kFALSE ; } else ooccoutW(_context,Minimization) << ", " ;
         ooccoutW(_context,Minimization) << var->GetName() << "=" << var->getVal() ;
+        if (++nparam > 20)  {
+            ooccoutW(_context,Minimization) << " [... others are suppressed; change RooMinimizerOpt code to put them back]" ;
+            break;
+        }
       }
       delete iter ;
       ooccoutW(_context,Minimization) << endl ;

--- a/src/SimplePoissonConstraint.cc
+++ b/src/SimplePoissonConstraint.cc
@@ -1,0 +1,32 @@
+#include "../interface/SimplePoissonConstraint.h"
+
+#include <string>
+#include <memory>
+#include <stdexcept>
+#include <TMath.h>
+
+void SimplePoissonConstraint::init() {
+    if (!x.arg().InheritsFrom("RooRealVar") && !x.arg().InheritsFrom("RooConstVar")) {
+        throw std::invalid_argument(std::string("SimplePoissonConstraint created with non-RooRealVar non-RooConstVar sigma: ") + GetName());
+    }
+    if (!x.arg().isConstant()) {
+        throw std::invalid_argument(std::string("SimplePoissonConstraint created with non-constant x: ") + GetName());
+    }
+    Double_t observed = x;
+    logGamma_ = TMath::LnGamma(observed+1.);
+}
+
+RooPoisson * SimplePoissonConstraint::make(RooPoisson &c) {
+    if (typeid(c) == typeid(SimplePoissonConstraint)) {
+        return &c;
+    }
+    try {
+        std::unique_ptr<SimplePoissonConstraint> opt(new SimplePoissonConstraint(c));
+        opt->SetNameTitle(c.GetName(),c.GetTitle());
+        return opt.release();
+    } catch (std::invalid_argument &ex) {
+        return &c;
+    }
+}
+
+ClassImp(SimplePoissonConstraint)

--- a/src/VectorizedHistFactoryPdfs.cc
+++ b/src/VectorizedHistFactoryPdfs.cc
@@ -1,0 +1,220 @@
+#include "../interface/VectorizedHistFactoryPdfs.h"
+#include <memory>
+#include <RooRealVar.h>
+
+cacheutils::VectorizedHistFunc::VectorizedHistFunc(const RooHistFunc &pdf, bool includeZeroWeights) :
+    pdf_(&pdf), data_(0), includeZeroWeights_(includeZeroWeights)
+{
+}
+
+void
+cacheutils::VectorizedHistFunc::fill() 
+{
+    RooArgSet obs(*data_->get());
+    std::auto_ptr<RooArgSet> params(pdf_->getObservables(obs));
+
+    yvals_.reserve(data_->numEntries());
+    for (unsigned int i = 0, n = data_->numEntries(); i < n; ++i) {
+        params->assignValueOnly(*data_->get(i), true);
+        if (data_->weight() || includeZeroWeights_) {
+            yvals_.push_back(pdf_->getVal());        
+        }
+    }
+}
+
+const std::vector<Double_t> & 
+cacheutils::VectorizedHistFunc::eval(const RooAbsData &data) 
+{
+    if (data_ != &data) {
+        data_ = &data;
+        fill();
+    }
+    return yvals_;
+}
+
+#if 0
+cacheutils::VectorizedHistFunc::VectorizedHistFunc(const RooHistFunc &pdf, const RooAbsData &data, bool includeZeroWeights) 
+    
+{
+    RooArgSet obs(*data.get());
+    std::auto_ptr<RooArgSet> params(pdf.getParameters(data));
+    if (params->getSize() != 0) throw std::invalid_argument("HistFunc with parameters !?");
+
+    //const RooRealVar * x_ = dynamic_cast<const RooRealVar*>(obs.first());
+
+    yvals_.reserve(data.numEntries());
+    for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
+        obs.assignValueOnly(*data.get(i), true);
+        if (data.weight() || includeZeroWeights) {
+            //xvals_.push_back(x_->getVal());        
+            yvals_.push_back(pdf.getVal());        
+        }
+    }
+}
+
+void
+cacheutils::VectorizedHistFunc::fill(std::vector<Double_t> &out) const 
+{
+    out = yvals_;
+}
+#endif
+
+cacheutils::VectorizedParamHistFunc::VectorizedParamHistFunc(const ParamHistFunc &pdf, const RooAbsData &data, bool includeZeroWeights) 
+    
+{
+    RooArgSet obs(*data.get());
+    yvars_.reserve(data.numEntries());
+    for (unsigned int i = 0, n = data.numEntries(); i < n; ++i) {
+        obs.assignValueOnly(*data.get(i), true);
+        if (data.weight() || includeZeroWeights) {
+            RooRealVar * rrv = & pdf.getParameter();
+            yvars_.push_back(rrv);        
+        }
+    }
+}
+
+void 
+cacheutils::VectorizedParamHistFunc::fill(std::vector<Double_t> &out) const 
+{
+    out.resize(yvars_.size());
+    for (unsigned int i = 0, n = yvars_.size(); i < n; ++i) {
+        out[i] = yvars_[i]->getVal();
+    }
+}
+
+namespace {
+    class PiecewiseInterpolationWithAccessor : public PiecewiseInterpolation {
+        public:
+            PiecewiseInterpolationWithAccessor(const PiecewiseInterpolation &p) :
+                PiecewiseInterpolation(p) {}
+            const RooAbsReal & nominal() const { return _nominal.arg(); }
+            int getInterpCode(int i) const { return _interpCode[i]; }
+            bool positiveDefinite() const { return _positiveDefinite; }
+    };
+}
+
+cacheutils::CachingPiecewiseInterpolation::CachingPiecewiseInterpolation(const PiecewiseInterpolation &pdf, const RooArgSet &obs) :
+    pdf_(&pdf)
+{
+    PiecewiseInterpolationWithAccessor fixme(pdf);
+    const RooArgList & highList  = pdf.highList();
+    const RooArgList & lowList   = pdf.lowList();
+    const RooAbsReal & nominal   = fixme.nominal(); 
+    const RooArgList & coeffs = pdf.paramList();
+    std::cout << "Making a CachingPiecewiseInterpolation for " << pdf.GetName() << " with " << highList.getSize() << " pdfs, " << coeffs.getSize() << " coeffs." << std::endl;
+    positiveDefinite_ = fixme.positiveDefinite();
+    cachingPdfNominal_.reset(makeCachingPdf(const_cast<RooAbsReal*>(&nominal),&obs));
+    for (int i = 0, n = highList.getSize(); i < n; ++i) {
+        RooAbsReal *pdfiHi = (RooAbsReal*) highList.at(i);
+        cachingPdfsHi_.push_back(makeCachingPdf(pdfiHi, &obs));
+        RooAbsReal *pdfiLo = (RooAbsReal*) lowList.at(i);
+        cachingPdfsLow_.push_back(makeCachingPdf(pdfiLo, &obs));
+        coeffs_.push_back((RooAbsReal*) coeffs.at(i));
+        codes_.push_back(fixme.getInterpCode(i));
+        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
+        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
+        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Coeff : " << coeffs_.back()->ClassName() << " " << coeffs_.back()->GetName()  << std::endl;
+        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Code  : " << codes_.back()  << std::endl;
+    }
+}
+
+cacheutils::CachingPiecewiseInterpolation::~CachingPiecewiseInterpolation()
+{
+}
+
+
+const std::vector<Double_t> & cacheutils::CachingPiecewiseInterpolation::eval(const RooAbsData &data)
+{
+    const std::vector<Double_t> & nominal = cachingPdfNominal_->eval(data);
+    unsigned int size = nominal.size();
+    work_.resize(size);
+    std::copy(nominal.begin(), nominal.end(), work_.begin());
+    for (int i = 0, n =  coeffs_.size(); i < n; ++i) {
+        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+        const std::vector<Double_t> & lo = cachingPdfsLow_[i].eval(data);
+        double param = coeffs_[i]->getVal();
+        int    code  = codes_[i];
+        switch(code){
+            case 0: 
+                {
+                    if (param > 0) {
+                        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] += param * (hi[j] - nominal[j]);
+                        }
+                    } else {
+                        const std::vector<Double_t> & lo = cachingPdfsLow_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] += param * (nominal[j] - lo[j]);
+                        }
+                    }
+                } break;
+            case 2:
+                {
+                    if (param > 0) {
+                        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] *= std::pow(hi[j]/nominal[j], param);
+                        }
+                    } else {
+                        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] *= std::pow(lo[j]/nominal[j], -param);
+                        }
+                    }
+                } break;
+            case 4:
+                {
+                    if (param > 1.) {
+                        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] += param * (hi[j] - nominal[j]);
+                        }
+                    } else if (param < -1.){
+                        const std::vector<Double_t> & lo = cachingPdfsLow_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            work_[j] += param * (nominal[j] - lo[j]);
+                        }
+                    } else {
+                        const std::vector<Double_t> & hi = cachingPdfsHi_[i].eval(data);
+                        const std::vector<Double_t> & lo = cachingPdfsLow_[i].eval(data);
+                        for (unsigned int j = 0; j < size; ++j) {
+                            double eps_plus  = (hi[j]-nominal[j]);
+                            double eps_minus = (nominal[j] - lo[j]);
+                            double S = 0.5*(eps_plus+eps_minus);
+                            double A = 0.0625*(eps_plus-eps_minus);
+                            double val = nominal[j] + param * (S + param * A * ( 15 + param * param * (-10 + param * param * 3  ) ) );
+                            if (val < 0) val = 0;
+                            work_[j] += (val - nominal[j]);
+                        }
+                    }
+                } break;
+            default:
+                std::cout << "Interpolation code " << code << " not implemented. Sorry" << std::endl;
+                throw std::invalid_argument("Bad interpolation code in CachingPiecewiseInterpolation");
+        }
+    }
+    if (positiveDefinite_) {
+        for (unsigned int j = 0; j < size; ++j) {
+            if (work_[j] < 0) work_[j] = 0;
+        }
+    }
+    return work_;
+}
+
+void cacheutils::CachingPiecewiseInterpolation::setDataDirty()
+{
+    cachingPdfNominal_->setDataDirty();
+    for (CachingPdfBase &pdf : cachingPdfsHi_) pdf.setDataDirty();
+    for (CachingPdfBase &pdf : cachingPdfsLow_) pdf.setDataDirty();
+}
+
+void cacheutils::CachingPiecewiseInterpolation::setIncludeZeroWeights(bool includeZeroWeights) 
+{
+    cachingPdfNominal_->setIncludeZeroWeights(includeZeroWeights);
+    for (CachingPdfBase &pdf : cachingPdfsHi_) pdf.setIncludeZeroWeights(includeZeroWeights);
+    for (CachingPdfBase &pdf : cachingPdfsLow_) pdf.setIncludeZeroWeights(includeZeroWeights);
+}
+
+
+

--- a/src/VectorizedHistFactoryPdfs.cc
+++ b/src/VectorizedHistFactoryPdfs.cc
@@ -101,7 +101,7 @@ cacheutils::CachingPiecewiseInterpolation::CachingPiecewiseInterpolation(const P
     const RooArgList & lowList   = pdf.lowList();
     const RooAbsReal & nominal   = fixme.nominal(); 
     const RooArgList & coeffs = pdf.paramList();
-    std::cout << "Making a CachingPiecewiseInterpolation for " << pdf.GetName() << " with " << highList.getSize() << " pdfs, " << coeffs.getSize() << " coeffs." << std::endl;
+    //std::cout << "Making a CachingPiecewiseInterpolation for " << pdf.GetName() << " with " << highList.getSize() << " pdfs, " << coeffs.getSize() << " coeffs." << std::endl;
     positiveDefinite_ = fixme.positiveDefinite();
     cachingPdfNominal_.reset(makeCachingPdf(const_cast<RooAbsReal*>(&nominal),&obs));
     for (int i = 0, n = highList.getSize(); i < n; ++i) {
@@ -111,10 +111,10 @@ cacheutils::CachingPiecewiseInterpolation::CachingPiecewiseInterpolation(const P
         cachingPdfsLow_.push_back(makeCachingPdf(pdfiLo, &obs));
         coeffs_.push_back((RooAbsReal*) coeffs.at(i));
         codes_.push_back(fixme.getInterpCode(i));
-        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
-        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
-        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Coeff : " << coeffs_.back()->ClassName() << " " << coeffs_.back()->GetName()  << std::endl;
-        std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Code  : " << codes_.back()  << std::endl;
+        //std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
+        //std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Hi    : " << pdfiHi->ClassName() << " " << pdfiHi->GetName() << " using " << typeid(cachingPdfsHi_.back()).name() << std::endl;
+        //std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Coeff : " << coeffs_.back()->ClassName() << " " << coeffs_.back()->GetName()  << std::endl;
+        //std::cout << "      PiecewiseInterpolation Adding " << pdf.GetName() << "[" << i << "] Code  : " << codes_.back()  << std::endl;
     }
 }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -625,6 +625,18 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
       
     if (SetParameterRangeExpression.size() != 3) {
       std::cout << "Error parsing physics model parameter expression : " << SetParameterRangeExpressionList[p] << endl;
+    } else if (SetParameterRangeExpression[1] == "-inf" && (
+                    SetParameterRangeExpression[2] == "inf" || 
+                    SetParameterRangeExpression[2] == "+inf") ) {
+      RooRealVar *tmpParameter = (RooRealVar*)params.find(SetParameterRangeExpression[0].c_str());            
+      if (tmpParameter) {
+        cout << "Leave Parameter " << SetParameterRangeExpression[0] 
+             << " freely floating, with no range\n";
+        tmpParameter->removeRange();
+      } else {
+        std::cout << "Warning: Did not find a parameter with name " << SetParameterRangeExpression[0] << endl;
+      }
+ 
     } else {
       double PhysicsParameterRangeLow = atof(SetParameterRangeExpression[1].c_str());
       double PhysicsParameterRangeHigh = atof(SetParameterRangeExpression[2].c_str());

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -52,9 +52,6 @@ namespace {
                 return ret;
             }
     };
-    RooArgList factors(const RooProduct &prod) {
-        return RooProductWithAccessors(prod).realTerms();
-    }
 }
 
 void utils::printRDH(RooAbsData *data) {
@@ -218,6 +215,11 @@ void utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, RooArgLis
         if (!constraints.contains(pdf)) constraints.add(pdf);
     }
 }
+
+
+RooArgList utils::factors(const RooProduct &prod) {
+    return ::RooProductWithAccessors(prod).realTerms();
+}
 void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArgList &obsTerms, RooArgList &constraints, bool keepDuplicate, bool debug) {
     RooAbsPdf *pdf = dynamic_cast<RooAbsPdf *>(&func);
     if (pdf != 0) { 
@@ -227,7 +229,7 @@ void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArg
     const std::type_info & id = typeid(func);
     if (id == typeid(RooProduct)) {
         RooProduct *prod = dynamic_cast<RooProduct *>(&func);
-        RooArgList components(::factors(*prod));
+        RooArgList components(utils::factors(*prod));
         //std::cout << "Function " << func.GetName() << " is a RooProduct with " << components.getSize() << " components." << std::endl;
         std::auto_ptr<TIterator> iter(components.createIterator());
         for (RooAbsReal *funci = (RooAbsReal *) iter->Next(); funci != 0; funci = (RooAbsReal *) iter->Next()) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -85,7 +85,7 @@ void utils::printRAD(const RooAbsData *d) {
   else d->get(0)->Print("V");
 }
 
-void utils::printPdf(RooAbsPdf *pdf) {
+void utils::printPdf(const RooAbsReal *pdf) {
   std::cout << "Pdf " << pdf->GetName() << " parameters." << std::endl;
   std::auto_ptr<RooArgSet> params(pdf->getVariables());
   params->Print("V");

--- a/src/vectorized.cc
+++ b/src/vectorized.cc
@@ -1,4 +1,5 @@
 #include "vectorized.h"
+#include <../interface/Accumulators.h>
 
 void vectorized::mul_add(const uint32_t size, double coeff, double const * __restrict__ iarray, double* __restrict__ oarray) {
     for (uint32_t i = 0; i < size; ++i) {
@@ -24,12 +25,12 @@ double vectorized::nll_reduce(const uint32_t size, double* __restrict__ pdfvals,
     }
 
 
-    double ret = 0;
+    DefaultAccumulator ret = 0;
     for (uint32_t i = 0; i < size; ++i) {
         ret += pdfvals[i];
     }
 
-    return ret;
+    return ret.sum();
 }
 
 void vectorized::gaussians(const uint32_t size, double mean, double sigma, double norm, const double* __restrict__ xvals, double * __restrict__ out, double * __restrict__ workingArea, double * __restrict__ workingArea2)
@@ -67,11 +68,11 @@ void vectorized::powers(const uint32_t size, double exponent, double norm, const
 }
 
 double vectorized::dot_product(const uint32_t size, double const * __restrict__ vec1, double const *  __restrict__ vec2) {
-    double ret = 0;
+    DefaultAccumulator ret = 0;
     for (uint32_t i = 0; i < size; ++i) {
         ret += vec1[i]*vec2[i];
     }
-    return ret;
+    return ret.sum();
 }
 
 

--- a/src/vectorized.cc
+++ b/src/vectorized.cc
@@ -5,6 +5,12 @@ void vectorized::mul_add(const uint32_t size, double coeff, double const * __res
         oarray[i] += coeff * iarray[i];
     } 
 }
+void vectorized::mul_inplace(const uint32_t size, double const * __restrict__ iarray, double* __restrict__ oarray) {
+    for (uint32_t i = 0; i < size; ++i) {
+        oarray[i] *= iarray[i];
+    } 
+}
+
 double vectorized::nll_reduce(const uint32_t size, double* __restrict__ pdfvals, double const * __restrict__ weights, double sumcoeff,  double *  __restrict__ workingArea) {
     double invsum = 1.0/sumcoeff;
     for (uint32_t i = 0; i < size; ++i) {

--- a/src/vectorized.h
+++ b/src/vectorized.h
@@ -4,6 +4,9 @@ namespace vectorized {
     // oarray += coeff * iarray
     void mul_add(const uint32_t size, double coeff, double const * __restrict__ iarray, double* __restrict__ oarray) ;
 
+    // oarray *= iarray
+    void mul_inplace(const uint32_t size, double const * __restrict__ iarray, double* __restrict__ oarray) ;
+
     // nll_reduce = sum ( weights * log(pdfvals/sumCoeff) )
     double nll_reduce(const uint32_t size, double* __restrict__ pdfvals, double const * __restrict__ weights, double sumcoeff, double *  __restrict__ workingArea) ;
 

--- a/test/unit/testAccumulators.cxx
+++ b/test/unit/testAccumulators.cxx
@@ -1,0 +1,56 @@
+#include "../../interface/Accumulators.h"
+#include <cstdio>
+#include <TRandom3.h>
+
+void testTwo(int n) {
+    n /= 2;
+    std::vector<double> noise;
+    std::vector<double> signal;
+    std::vector<double> terms;
+    for (unsigned int i = 0; i < n; ++i) {
+        noise.push_back(gRandom->Gaus(0,1));
+    }
+    for (unsigned int i = 0; i < 2*n; ++i) {
+        signal.push_back(gRandom->Gaus(0.001,0.001));
+    }
+    for (unsigned int i = 0; i < n; ++i) {
+        terms.push_back(signal[i] + noise[i]);
+    }
+    for (unsigned int i = 0; i < n; ++i) {
+        terms.push_back(signal[i+n] - noise[i]);
+    }
+    double best = sumPrecise(signal);
+    printf("Naive   sum: %.7g \n", sumFast(terms)-best);
+    printf("Precise sum: %.7g \n", sumPrecise(terms)-best);
+}
+
+void testOne() {
+    double one = 1.0, eps = 1.0;
+    do {
+        double two = one + eps;
+        if (two == one) break;
+        eps /= 2;
+    } while(true);
+    printf("epsilon is %.7g\n",eps);
+    std::vector<double> terms;
+    std::vector<double> ok;
+    terms.push_back(one);
+    for (unsigned int i = 0; i < 37; ++i) { 
+        terms.push_back(eps); 
+        ok.push_back(eps); 
+        if (i % 10 == 7) terms.push_back(one);
+    }
+    terms.push_back(-one);
+    for (unsigned int i = 0; i < 37; ++i) { 
+        if (i % 10 == 7) terms.push_back(-one);
+    }
+    printf("Naive   sum/eps: %.7g \n", sumFast(terms)/eps);
+    printf("Precise sum/eps: %.7g \n", sumPrecise(terms)/eps);
+    printf("True    sum/eps: %.7g \n", sumFast(ok)/eps);
+
+}
+
+int main(int argc, char **argv) {
+    //testOne();
+    testTwo(2000);
+}


### PR DESCRIPTION
Suggested configuration with the pre-fit: `--cminApproxPreFitTolerance=25` and `--cminOldRobustMinimize=0` (perhaps some fallback options could be added, I didn't test it)

I still don't have a good way to set the number of maximum calls to something that makes better sense for combined workspaces when the requested tolerance is small (~0.1 or less). For the moment, I suggest to just do `--X-rtd MINIMIZER_MaxCalls=99999999` on the LHC combined workspace (or if you try strategy 2), better alternatives are welcome

One option is not turned on by default, `--X-rtd ADDNLL_ROOREALSUM_PRUNECONST`, I didn't check how much improvement in timing it gives. It is 100% safe as long as no parameters are changed from const to float after creating the NLL (vice-versa is ok), so it's ok in standard MultiDimFit workflows. I'm using it to run the fits, but I didn't want to turn it on always as there may be other cases where we recycle the NLL in different ways.

I realized that by default we did not have `--X-rtd ADDNLL_MULTINLL` on, but I can't recall if that was on purpose or by mistake. I'm __not__ turning it on now, but it could improve the performance on H&rarr;&gamma;&gamma; so perhaps it would be good if somebody could test it.
