### PR TITLE
add a protection for the 0 dataset that factorized pdf exists

### DIFF
--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -815,9 +815,6 @@ cacheutils::CachingSimNLL::setup_()
     RooArgList constraints;
     factorizedPdf_.reset(dynamic_cast<RooSimultaneous *>(utils::factorizePdf(*dataOriginal_->get(), *pdfclone, constraints)));
 
-    std::cout<<"[cacheutils]::[CachingSimNLL]::[setup_]::[DEBUG] factorizedPDF"<<endl;
-    factorizedPdf_->Print("V");
-    
     RooSimultaneous *simpdf = factorizedPdf_.get();
     constrainPdfs_.clear(); 
     if (constraints.getSize()) {
@@ -847,7 +844,6 @@ cacheutils::CachingSimNLL::setup_()
         params->Print("V");
         std::cout << "Obs: " << std::endl;
         dataOriginal_->get()->Print("V");
-	std::cout<<" WARNING RELEASE !!!"<<std::endl;
         factorizedPdf_.release();
         simpdf = dynamic_cast<RooSimultaneous *>(pdfclone);
     }
@@ -857,7 +853,6 @@ cacheutils::CachingSimNLL::setup_()
     pdfs_.resize(catClone->numBins(NULL), 0);
     //dataSets_.reset(dataOriginal_->split(pdfOriginal_->indexCat(), true));
     datasets_.resize(pdfs_.size(), 0);
-    std::cout<<" AGAIN BEFORE SPLIT"<<endl;
     splitWithWeights(*dataOriginal_, simpdf->indexCat(), true);
     //std::cout << "Pdf " << simpdf->GetName() <<" is a SimPdf over category " << catClone->GetName() << ", with " << pdfs_.size() << " bins" << std::endl;
     for (int ib = 0, nb = pdfs_.size(); ib < nb; ++ib) {

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -814,6 +814,9 @@ cacheutils::CachingSimNLL::setup_()
 
     RooArgList constraints;
     factorizedPdf_.reset(dynamic_cast<RooSimultaneous *>(utils::factorizePdf(*dataOriginal_->get(), *pdfclone, constraints)));
+
+    std::cout<<"[cacheutils]::[CachingSimNLL]::[setup_]::[DEBUG] factorizedPDF"<<endl;
+    factorizedPdf_->Print("V");
     
     RooSimultaneous *simpdf = factorizedPdf_.get();
     constrainPdfs_.clear(); 
@@ -844,6 +847,7 @@ cacheutils::CachingSimNLL::setup_()
         params->Print("V");
         std::cout << "Obs: " << std::endl;
         dataOriginal_->get()->Print("V");
+	std::cout<<" WARNING RELEASE !!!"<<std::endl;
         factorizedPdf_.release();
         simpdf = dynamic_cast<RooSimultaneous *>(pdfclone);
     }
@@ -853,6 +857,7 @@ cacheutils::CachingSimNLL::setup_()
     pdfs_.resize(catClone->numBins(NULL), 0);
     //dataSets_.reset(dataOriginal_->split(pdfOriginal_->indexCat(), true));
     datasets_.resize(pdfs_.size(), 0);
+    std::cout<<" AGAIN BEFORE SPLIT"<<endl;
     splitWithWeights(*dataOriginal_, simpdf->indexCat(), true);
     //std::cout << "Pdf " << simpdf->GetName() <<" is a SimPdf over category " << catClone->GetName() << ", with " << pdfs_.size() << " bins" << std::endl;
     for (int ib = 0, nb = pdfs_.size(); ib < nb; ++ib) {
@@ -951,7 +956,7 @@ void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const R
     RooArgSet obsplus(obs); obsplus.add(weight);
     if (nb != int(datasets_.size())) throw std::logic_error("Number of categories changed"); // this can happen due to bugs in RooDataSet
     std::vector<int> includeZeroWeights(nb,0); bool includeZeroWeightsAny = false;
-    if (runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS")) {
+    if (runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS") and factorizedPdf_.get() != NULL ) {
         for (int ib = 0; ib < nb; ++ib) {
             catClone->setBin(ib);
             RooAbsPdf *pdf = factorizedPdf_->getPdf(catClone->getLabel());


### PR DESCRIPTION
The 0 weights datasets accessed the fact pdf without protection.
Now enters there iff is not NULL.

Tested on a TH1 datacard:

53X
 -- Asymptotic -- 
Expected  2.5%: r < 1771087.6250
Expected 16.0%: r < 2613384.0000
Expected 50.0%: r < 4140625.0000
Expected 84.0%: r < 6682350.0000
Expected 97.5%: r < 10236794.0000

new:
 -- Asymptotic -- 
Expected  2.5%: r < 1771087.6250
Expected 16.0%: r < 2613384.0000
Expected 50.0%: r < 4140625.0000
Expected 84.0%: r < 6682350.0000
Expected 97.5%: r < 10236794.0000

