### PR TITLE
Fixes for ProfileLikelihood

### DIFF
--- a/interface/utils.h
+++ b/interface/utils.h
@@ -100,6 +100,6 @@ namespace utils {
     void reorderCombinations(std::vector<std::vector<int> > &, const std::vector<int> &, const std::vector<int> &);
     std::vector<std::vector<int> > generateCombinations(const std::vector<int> &vec);
     std::vector<std::vector<int> > generateOrthogonalCombinations(const std::vector<int> &vec);
+    int countFloating(const RooArgSet &);
 }
-
 #endif

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -951,7 +951,7 @@ void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const R
     RooArgSet obsplus(obs); obsplus.add(weight);
     if (nb != int(datasets_.size())) throw std::logic_error("Number of categories changed"); // this can happen due to bugs in RooDataSet
     std::vector<int> includeZeroWeights(nb,0); bool includeZeroWeightsAny = false;
-    if (runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS")) {
+    if (runtimedef::get("ADDNLL_ROOREALSUM_BASICINT") && runtimedef::get("ADDNLL_ROOREALSUM_KEEPZEROS") && factorizedPdf_.get()) {
         for (int ib = 0; ib < nb; ++ib) {
             catClone->setBin(ib);
             RooAbsPdf *pdf = factorizedPdf_->getPdf(catClone->getLabel());

--- a/src/ProfileLikelihood.cc
+++ b/src/ProfileLikelihood.cc
@@ -259,7 +259,6 @@ bool ProfileLikelihood::runSignificance(RooWorkspace *w, RooStats::ModelConfig *
       if (q0 == -1) return false;
       limit = (q0 > 0 ? sqrt(2*q0) : (uncapped_ ? -sqrt(-2*q0) : 0));
   } else if (useMinos_) {
-      nullParamValues.Print("v");
       ProfiledLikelihoodTestStatOpt testStat(*mc_s->GetObservables(), *mc_s->GetPdf(), mc_s->GetNuisanceParameters(), 
                                                    nullParamValues, *mc_s->GetParametersOfInterest(), RooArgList(), RooArgList(), verbose-1,
                                                    uncapped_ ? ProfiledLikelihoodTestStatOpt::signFlipDef : ProfiledLikelihoodTestStatOpt::oneSidedDef);

--- a/src/ProfileLikelihood.cc
+++ b/src/ProfileLikelihood.cc
@@ -259,6 +259,7 @@ bool ProfileLikelihood::runSignificance(RooWorkspace *w, RooStats::ModelConfig *
       if (q0 == -1) return false;
       limit = (q0 > 0 ? sqrt(2*q0) : (uncapped_ ? -sqrt(-2*q0) : 0));
   } else if (useMinos_) {
+      nullParamValues.Print("v");
       ProfiledLikelihoodTestStatOpt testStat(*mc_s->GetObservables(), *mc_s->GetPdf(), mc_s->GetNuisanceParameters(), 
                                                    nullParamValues, *mc_s->GetParametersOfInterest(), RooArgList(), RooArgList(), verbose-1,
                                                    uncapped_ ? ProfiledLikelihoodTestStatOpt::signFlipDef : ProfiledLikelihoodTestStatOpt::oneSidedDef);

--- a/src/ProfiledLikelihoodRatioTestStatExt.cc
+++ b/src/ProfiledLikelihoodRatioTestStatExt.cc
@@ -227,11 +227,14 @@ Double_t ProfiledLikelihoodTestStatOpt::Evaluate(RooAbsData& data, RooArgSet& /*
         utils::setAllConstant(poiParams_,true);
     }
     double thisNLL = nullNLL;
+
+    // Check number of floating paramters 
+    int nfloatingpars = utils::countFloating(*(nll_->getParameters( (const RooArgSet*) 0)));
     if (initialR == 0 || oneSided_ != oneSidedDef || bestFitR < initialR) { 
         // must do constrained fit (if there's something to fit besides XS)
         //std::cout << "PERFORMING CONSTRAINED FIT " << r->GetName() << " == " << r->getVal() << std::endl;
         if (do_debug) std::cout << "NLL shift from unconstrained fit before re-profiling: " << nll_->getVal() - nullNLL << std::endl;    
-        thisNLL = (nuisances_.getSize() > 0 ? minNLL(/*constrained=*/true, r) : nll_->getVal());
+        thisNLL = (nfloatingpars > 0 ? minNLL(/*constrained=*/true, r) : nll_->getVal());
         if (thisNLL - nullNLL < -0.02) { 
             DBG(DBG_PLTestStat_main, (printf("  --> constrained fit is better... will repeat unconstrained fit\n")))
             utils::setAllConstant(poiParams_,false);
@@ -338,10 +341,12 @@ std::vector<Double_t> ProfiledLikelihoodTestStatOpt::Evaluate(RooAbsData& data, 
         r->setVal(initialR); 
         r->setConstant(true);
         double thisNLL = nullNLL, sign = +1.0;
+    	int nfloatingpars = utils::countFloating(*(nll_->getParameters( (const RooArgSet*) 0)));
         if (initialR == 0 || oneSided_ != oneSidedDef || bestFitR < initialR) { 
             // must do constrained fit (if there's something to fit besides XS)
             //std::cout << "PERFORMING CONSTRAINED FIT " << r->GetName() << " == " << r->getVal() << std::endl;
-            thisNLL = (nuisances_.getSize() > 0 ? minNLL(/*constrained=*/true, r) : nll_->getVal());
+            thisNLL = (nfloatingpars > 0 ? minNLL(/*constrained=*/true, r) : nll_->getVal());
+            //thisNLL = (nuisances_.getSize() > 0 ? minNLL(/*constrained=*/true, r) : nll_->getVal());
             if (thisNLL - nullNLL < 0 && thisNLL - nullNLL >= -EPS) {
                 thisNLL = nullNLL;
             } else if (thisNLL - nullNLL < 0) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -763,3 +763,12 @@ bool utils::anyParameterAtBoundaries( const RooArgSet &params, int verbosity ){
     
     return isAnyBad;
 }
+
+int utils::countFloating(const RooArgSet &params){
+	int count=0;
+        RooLinkedListIter iter = params.iterator(); int i = 0;
+        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next(), ++i) {
+		if (!a->isConstant()) count++;
+        }
+	return count;
+}


### PR DESCRIPTION
After much discussion and code sleuthing with @adavidzh ....
Fixed two issues with -M ProfileLikelihood

1) seg fault occurs when running shape datacards with no systematics. Protection added in CachingNLL to avoid using factorizedPdf when it doesn't exist.
Actually this also causes errors for other methods (i.e whenever using the CachingNLL) but was noticed using ProfileLikelihood

2) Erroneous significance reported in cases where there are no constrained nuisances but still floating parameters in the model. This was due to the test statistic only running a profiled fit if the size of mc_s.GetNuisances() > 0 rather than counting the number of floating parameters.