### PR TITLE
Nckw parametric rates

### DIFF
--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -30,6 +30,8 @@ class Datacard():
         self.hasShape = False
         ## dirct of {name of uncert, boolean to indicate whether it is a flat parametric uncertainty or not}
         self.flatParamNuisances = {}
+        self.rateParams = {}
+        self.rateParamsOrder = [] # important to maintain order user puts in datacard
 
     def list_of_bins(self) :
         """

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -177,6 +177,11 @@ def parseCard(file, options):
                 ret.flatParamNuisances[lsyst] = True
                 #for flat parametric uncertainties, code already does the right thing as long as they are non-constant RooRealVars linked to the model
                 continue
+            elif pdf == "rateParam":
+                if len(args) > 6: raise RuntimeError, "Directives of type 'rateParam' can only have a single channel. name rateParam channel process [init / expression vars]. repeat if rate is to affect multiple channels"
+		if len(f)==5: ret.rateParams["%sAND%s"%(f[2],f[3])] = [lsyst,f[4],0]
+		elif len(f)==6: ret.rateParams["%sAND%s"%(f[2],f[3])] = [lsyst,f[4],f[5],1]
+                continue
             elif pdf=="discrete":
                 args = f[2:]
                 ret.discretes.append(lsyst)
@@ -255,7 +260,7 @@ def parseCard(file, options):
     syst2 = []
     for lsyst,nofloat,pdf,args,errline in ret.systs:
         nonNullEntries = 0 
-        if pdf == "param" or pdf=="discrete": # this doesn't have an errline
+        if pdf == "param" or pdf=="discrete" or pdf=="rateParam": # this doesn't have an errline
             syst2.append((lsyst,nofloat,pdf,args,errline))
             continue
         for (b,p,s) in ret.keyline:

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -337,7 +337,7 @@ class ModelBuilder(ModelBuilderBase):
                     raise RuntimeError, "Physics model returned something which is neither a name, nor 0, nor 1."
 
 		# look for rate param for this bin 
-		if "%s_%s"%(b,p) in self.DC.rateParams.keys():
+		if "%sAND%s"%(b,p) in self.DC.rateParams.keys():
 		    argu = self.DC.rateParams["%sAND%s"%(b,p)][0]
 		    if self.out.arg(argu): factors.append(argu)
 		    else: raise RuntimeError, "No rate parameter found %s, are you sure you defined it correctly in the datacard?"%(argu)

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -49,6 +49,9 @@ class ModelBuilderBase():
     def doVar(self,vardef):
         if self.options.bin: self.factory_(vardef);
         else: self.out.write(vardef+";\n");
+    def doExp(self,name,expression,vars):
+        if self.options.bin: self.factory_('expr::%s("%s",%s)'%(name,expression,vars));
+        else: self.out.write('%s = expr::%s("%s",%s)'%(name,name,expression,vars)+";\n");
     def doSet(self,name,vars):
         if self.options.bin: self.out.defineSet(name,vars)
         else: self.out.write("%s = set(%s);\n" % (name,vars));
@@ -81,6 +84,7 @@ class ModelBuilder(ModelBuilderBase):
 
         self.physics.preProcessNuisances(self.DC.systs)
         self.doNuisances()
+	self.doRateParams()
         self.doExpectedEvents()
         self.doIndividualModels()
         self.doCombination()
@@ -91,6 +95,28 @@ class ModelBuilder(ModelBuilderBase):
             if self.options.verbose > 2: 
                 self.out.pdf("model_s").graphVizTree(self.options.out+".dot", "\\n")
                 print "Wrote GraphVizTree of model_s to ",self.options.out+".dot"
+
+    def doRateParams(self):
+	# First do independant parameters, then expressions
+	for rp in self.DC.rateParams.keys():
+	  type = self.DC.rateParams[rp][-1]
+	  if type!=0: continue
+	  argu,argv = self.DC.rateParams[rp][0],self.DC.rateParams[rp][1]
+	  if self.out.arg(argu): continue
+
+	  self.doVar("%s[%s,0,1]"%(argu,argv))
+	  self.out.var(argu).removeRange()
+	  self.out.var(argu).setConstant(False)
+	  self.out.var(argu).setAttribute("flatParam")
+
+	for rp in self.DC.rateParams.keys():
+	  type = self.DC.rateParams[rp][-1]
+	  if type!=1: continue
+	  argu,arge,argv = self.DC.rateParams[rp][0],self.DC.rateParams[rp][1],self.DC.rateParams[rp][2]
+	  if self.out.arg(argu): continue
+	  self.doExp(argu,arge,argv)
+
+
     def doObservables(self):
         """create pdf_bin<X> and pdf_bin<X>_bonly for each bin"""
         raise RuntimeError, "Not implemented in ModelBuilder"
@@ -309,8 +335,16 @@ class ModelBuilder(ModelBuilderBase):
                     factors.append(scale)
                 else:
                     raise RuntimeError, "Physics model returned something which is neither a name, nor 0, nor 1."
+
+		# look for rate param for this bin 
+		if "%s_%s"%(b,p) in self.DC.rateParams.keys():
+		    argu = self.DC.rateParams["%sAND%s"%(b,p)][0]
+		    if self.out.arg(argu): factors.append(argu)
+		    else: raise RuntimeError, "No rate parameter found %s, are you sure you defined it correctly in the datacard?"%(argu)
+
                 for (n,nofloat,pdf,args,errline) in self.DC.systs:
                     if pdf == "param":continue
+                    if pdf == "rateParam":continue
                     if not errline[b].has_key(p): continue
                     if errline[b][p] == 0.0: continue
                     if pdf.startswith("shape") and pdf.endswith("?"): # might be a lnN in disguise
@@ -346,7 +380,9 @@ class ModelBuilder(ModelBuilderBase):
                     procNorm = ROOT.ProcessNormalization("n_exp_bin%s_proc_%s" % (b,p), "", nominal)
                     for kappa, thetaName in logNorms: procNorm.addLogNormal(kappa, self.out.function(thetaName))
                     for kappaLo, kappaHi, thetaName in alogNorms: procNorm.addAsymmLogNormal(kappaLo, kappaHi, self.out.function(thetaName))
-                    for factorName in factors: procNorm.addOtherFactor(self.out.function(factorName))
+                    for factorName in factors:
+		    	if self.out.function(factorName): procNorm.addOtherFactor(self.out.function(factorName))
+			else: procNorm.addOtherFactor(self.out.var(factorName))
                     self.out._import(procNorm)
     def doIndividualModels(self):
         """create pdf_bin<X> and pdf_bin<X>_bonly for each bin"""

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -34,7 +34,7 @@ from HiggsAnalysis.CombinedLimit.DatacardParser import *
 obsline = []; obskeyline = [] ;
 keyline = []; expline = []; systlines = {}
 signals = []; backgrounds = []; shapeLines = []
-paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}
+paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {};
 cmax = 5 # column width
 if not args:
     raise RuntimeError, "No input datacards specified."
@@ -111,12 +111,15 @@ for ich,fname in enumerate(args):
     # flat params
     for K in DC.flatParamNuisances.iterkeys(): 
         flatParamNuisances[K] = True
+    # rate params
+    for K in DC.rateParams.iterkeys():
+	tbin,tproc = K.split("AND")[0],K.split("AND")[1]
+	tbin = label+tbin; nK = tbin+"AND"+tproc
+	rateParams[nK] = DC.rateParams[K]
     # discrete nuisance
     for K in DC.discretes: 
-        if discreteNuisances.has_key(K):
-					raise RuntimeError, "Cannot currently correlate discrete nuisances across categories. Rename %s in one."%K
-        else:
-					discreteNuisances[K] = True
+        if discreteNuisances.has_key(K): raise RuntimeError, "Cannot currently correlate discrete nuisances across categories. Rename %s in one."%K
+        else: discreteNuisances[K] = True
     # put shapes, if available
     if len(DC.shapeMap):
         for b in DC.bins:
@@ -222,6 +225,10 @@ for (pname, pargs) in paramSysts.items():
 
 for pname in flatParamNuisances.iterkeys(): 
     print "%-12s  flatParam" % pname
+for pname in rateParams.iterkeys(): 
+    print "%-12s  rateParam %s"% (rateParams[pname][0],pname.replace("AND"," ")),
+    for p in rateParams[pname][1:-1]: print p,
+    print "\n",
 for dname in discreteNuisances.iterkeys(): 
     print "%-12s  discrete" % dname
 for groupName,nuisanceNames in groups.iteritems():


### PR DESCRIPTION
Datacards support adding multiplicative factors for a bin+process using `rateParam`

* Floating parameter (created on the fly) for flat normalisation
* Expressions for rates which are functions of existing parameters

`combineCards.py` also handles properly renaming of bin segment in directive.

Concrete example datacard implementing an ABCD method is given below 

```
Datacard to demonstrate the ABCD method with combine using the rateParam
directive. 
name rateParam bin process init       --> floating multiplicative factor initialised to "init"
name rateParam bin process expr args  --> scaling factor given by expression "expr" (function of "args")

imax 4  number of channels
jmax 0  number of processes -1
kmax *  number of nuisance parameters (sources of systematical uncertainties)
-------
bin 		B	C	D       A	
observation 	50	100	500     10
-------                                         
bin		B 	C 	D       A 	
process 	bkg	bkg	bkg     bkg	
process 	1	1	1       1	
rate	 	1	1	1       1	
-------                                         
DummySys        lnN 	-	-	1.0001  -		

alpha rateParam A bkg (@0*@1/@2) beta,gamma,delta
beta  rateParam B bkg 50
gamma rateParam C bkg 100 
delta rateParam D bkg 500 
```