### PR TITLE
fix for compilation error: call of overloaded 'abs(Double_t&)' is ambiguous

### DIFF
--- a/interface/SimplePoissonConstraint.h
+++ b/interface/SimplePoissonConstraint.h
@@ -1,6 +1,7 @@
 #ifndef SimplePoissonConstraint_h
 #define SimplePoissonConstraint_h
 
+#include <cmath>
 #include <RooPoisson.h>
 
 class SimplePoissonConstraint : public RooPoisson {


### PR DESCRIPTION
with the head of lhchcg-run1-couplings ( d0939cc ) I get compilation errors like the following:
```
src/HiggsAnalysis/CombinedLimit/src/../interface/../interface/SimplePoissonConstraint.h: In member function 'double SimplePoissonConstraint::getLogValFast() const':
src/HiggsAnalysis/CombinedLimit/src/../interface/../interface/SimplePoissonConstraint.h:23:38: error: call of overloaded 'abs(Double_t&)' is ambiguous
```
with CMSSW_7_1_5 .

added #include<cmath> to as suggested here: http://stackoverflow.com/a/1374361/288875 to fix these.