### PR TITLE
Fix apparent ggZH bug

### DIFF
--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -115,7 +115,7 @@ class SMHiggsBuilder:
         elif what.startswith('ggZH'):
             for sqrts in ('7TeV', '8TeV'):
                 scalingName = 'Scaling_'+what+'_'+sqrts
-                rooExpr = 'expr::%(scalingName)s( "(@0*@0)*2.27  + (@1*@1)*0.37 - (@0*@1)*1.44", %(CZ)s, %(Ctop)s)'%locals()
+                rooExpr = 'expr::%(scalingName)s( "(@0*@0)*2.27  + (@1*@1)*0.37 - (@0*@1)*1.64", %(CZ)s, %(Ctop)s)'%locals()
                 self.modelBuilder.factory_(rooExpr)
         elif what.startswith('tHq'):
             for sqrts in ('7TeV', '8TeV'):


### PR DESCRIPTION
@gpetruc can you please check that this was indeed an unintended typo when getting the numbers from [this table](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/CONFNOTES/ATLAS-CONF-2015-007/tab_06.png), rather than a feature to compensate something else? @nucleosynthesis and I think this may be a typo.