### PR TITLE
Linear -> quadratic scaling in kappa_VBF

### DIFF
--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -55,7 +55,7 @@ class SMHiggsBuilder:
                 scalingName = 'Scaling_'+what+'_'+sqrts
 #                print 'Building '+ scalingName
                 rooExpr = 'expr::%(scalingName)s(\
-"(@0+ @1 * @2 )/(1+@2)",\
+"(@0*@0 + @1*@1 * @2 )/(1+@2)",\
  %(CW)s, %(CZ)s,\
  %(rooName)s\
 )'%locals()


### PR DESCRIPTION
Fix scaling that introduced issues for lambda_WZ < 0.
Caveat emptor: this is not enough to fix some hard-wired models.