### PR TITLE
Modify MultiDimFit --algo=fixed to add an option --fixedPointPOIs

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -47,6 +47,7 @@ protected:
   static float maxDeltaNLLForProf_;
   static float autoRange_;
   static bool  startFromPreFit_;
+  static std::string fixedPointPOIs_;
 
   static std::string saveSpecifiedFuncs_;
   static std::string saveSpecifiedNuis_;

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -43,6 +43,7 @@ bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
 bool MultiDimFit::squareDistPoiStep_ = false;
 float MultiDimFit::maxDeltaNLLForProf_ = 200;
 float MultiDimFit::autoRange_ = -1.0;
+std::string MultiDimFit::fixedPointPOIs_ = "";
 
   std::string MultiDimFit::saveSpecifiedFuncs_;
   std::string MultiDimFit::saveSpecifiedIndex_;
@@ -73,6 +74,7 @@ MultiDimFit::MultiDimFit() :
         ("firstPoint",  boost::program_options::value<unsigned int>(&firstPoint_)->default_value(firstPoint_), "First point to use")
         ("lastPoint",  boost::program_options::value<unsigned int>(&lastPoint_)->default_value(lastPoint_), "Last point to use")
         ("autoRange", boost::program_options::value<float>(&autoRange_)->default_value(autoRange_), "Set to any X >= 0 to do the scan in the +/- X sigma range (where the sigma is from the initial fit, so it may be fairly approximate)")
+	("fixedPointPOIs",   boost::program_options::value<std::string>(&fixedPointPOIs_)->default_value(""), "Parameter space point for --algo=fixed")
         ("fastScan", "Do a fast scan, evaluating the likelihood without profiling it.")
         ("maxDeltaNLLForProf",  boost::program_options::value<float>(&maxDeltaNLLForProf_)->default_value(maxDeltaNLLForProf_), "Last point to use")
 	("saveSpecifiedNuis",   boost::program_options::value<std::string>(&saveSpecifiedNuis_)->default_value(""), "Save specified parameters (default = none)")
@@ -676,7 +678,10 @@ void MultiDimFit::doFixedPoint(RooWorkspace *w, RooAbsReal &nll)
     //for (unsigned int i = 0; i < n; ++i) {
     //        std::cout<<" Before setting fixed point "<<poiVars_[i]->GetName()<<"= "<<poiVals_[i]<<std::endl;
     //}
-    if (setPhysicsModelParameterExpression_ != "") {
+    if (fixedPointPOIs_ != "") {
+	    utils::setModelParameters( fixedPointPOIs_, w->allVars());
+    } else if (setPhysicsModelParameterExpression_ != "") {
+            std::cout << " --fixedPointPOIs option not used, so will use the argument of --setPhysicsModelParameters instead" << std::endl;
 	    utils::setModelParameters( setPhysicsModelParameterExpression_, w->allVars());
     }   
 


### PR DESCRIPTION
Modify MultiDimFit `--algo=fixed` to add an option `--fixedPointPOIs`.
The option is used to specify the point, instead of relying on the `--setPhyiscsModelParameters` one.
This helps when one wants to generate toys at one value and test them at another one.
If the new option is not present but `--setPhyiscsModelParameters` is, the code will print a message and use the old.