### PR TITLE
More generation features

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -55,6 +55,7 @@ private:
  
   // statistics-related variables
   bool unbinned_, generateBinnedWorkaround_, newGen_, guessGenMode_; 
+  std::string genAsBinned_, genAsUnbinned_;
   float rMin_, rMax_;
   std::string prior_;
   bool hintUsesStatOnly_;

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -43,7 +43,7 @@ protected:
   static bool squareDistPoiStep_;
   static bool fastScan_;
   static bool hasMaxDeltaNLLForProf_;
-  static bool loadedSnapshot_, savingSnapshot_;
+  static bool loadedSnapshot_, forceFirstFit_, savingSnapshot_;
   static float maxDeltaNLLForProf_;
   static float autoRange_;
   static bool  startFromPreFit_;

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -69,6 +69,7 @@ namespace utils {
     void copyAttributes(const RooAbsArg &from, RooAbsArg &to) ;
 
     void guessChannelMode(RooSimultaneous &simPdf, RooAbsData &simData, bool verbose=false) ;
+    void setChannelGenModes(RooSimultaneous &simPdf, const std::string &binned, const std::string &unbinned, int verbose) ;
 
     /// set style for plots
     void tdrStyle() ;

--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -106,7 +106,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                     throw std::runtime_error(Form("AsimovUtils: can't find nuisance for constraint term %s", cterm->GetName()));
                 }
                 std::string pdfName(cterm->ClassName());
-                if (pdfName == "RooGaussian" || pdfName == "SimpleGaussianConstraint"  || pdfName == "RooBifurGauss" || pdfName == "RooPoisson" || pdfName == "RooGenericPdf") {
+                if (pdfName == "RooGaussian" || pdfName == "SimpleGaussianConstraint"  || pdfName == "RooBifurGauss" || pdfName == "RooPoisson"  || pdfName == "SimplePoissonConstraint" || pdfName == "RooGenericPdf") {
                     // this is easy
                     rrv.setVal(match->getVal());
                 } else if (pdfName == "RooGamma") {

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -657,6 +657,11 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     }
     if (saveToys_) {
 	writeToysHere->WriteTObject(dobs, "toy_asimov");
+        if (toysFrequentist_ && newGen_ && mc->GetGlobalObservables()) { 
+            RooAbsCollection *snap = mc->GetGlobalObservables()->snapshot();
+            if (snap) writeToysHere->WriteTObject(snap, "toy_asimov_snapshot");
+            // to be seen whether I can delete it or not
+        }
     }
     std::cout << "Computing limit starting from " << (iToy == 0 ? "observation" : "expected outcome") << std::endl;
     if (MH) MH->setVal(mass_);    
@@ -737,6 +742,16 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	  readToysFromHere->ls();
 	  return;
 	}
+        if (toysFrequentist_ && newGen_ && mc->GetGlobalObservables()) {
+            RooAbsCollection *snap = dynamic_cast<RooAbsCollection *>(readToysFromHere->Get(TString::Format("toys/toy_%d_snapshot",iToy)));
+            if (!snap) {
+                std::cerr << "Snapshot of global observables toy_"<<iToy<<"_snapshot not found in " << readToysFromHere->GetName() << ". List follows:\n";
+                readToysFromHere->ls();
+                return;
+            }
+            vars->assignValueOnly(*snap);
+            w->saveSnapshot("clean", w->allVars());
+        }
       }
       if (verbose > (isExtended ? 3 : 2)) utils::printRAD(absdata_toy);
       w->loadSnapshot("clean");
@@ -749,6 +764,11 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       }
       if (saveToys_) {
 	writeToysHere->WriteTObject(absdata_toy, TString::Format("toy_%d", iToy));
+        if (toysFrequentist_ && newGen_ && mc->GetGlobalObservables()) { 
+            RooAbsCollection *snap = mc->GetGlobalObservables()->snapshot();
+            writeToysHere->WriteTObject(snap, TString::Format("toy_%d_snapshot", iToy));
+            // to be seen whether I can delete it or not
+        }
       }
       delete absdata_toy;
     }

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -680,14 +680,15 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           if (mc->GetGlobalObservables() == 0) throw std::logic_error("Cannot use toysFrequentist with no global observables");
           w->saveSnapshot("reallyClean", w->allVars());
           utils::setAllConstant(*mc->GetParametersOfInterest(), true); 
-          {
+          if (!bypassFrequentistFit_) {
               if (dobs == 0) throw std::logic_error("Cannot use toysFrequentist with no input dataset");
               CloseCoutSentry sentry(verbose < 3);
               //genPdf->fitTo(*dobs, RooFit::Save(1), RooFit::Minimizer("Minuit2","minimize"), RooFit::Strategy(0), RooFit::Hesse(0), RooFit::Constrain(*(expectSignal_ ?mc:mc_bonly)->GetNuisanceParameters()));	
                 std::auto_ptr<RooAbsReal> nll(genPdf->createNLL(*dobs, RooFit::Constrain(*(expectSignal_ ?mc:mc_bonly)->GetNuisanceParameters()), RooFit::Extended(genPdf->canBeExtended())));
                 CascadeMinimizer minim(*nll, CascadeMinimizer::Constrained);
                 minim.setStrategy(1);
-                if (!bypassFrequentistFit_) minim.minimize();
+                minim.minimize();
+                w->saveSnapshot("frequentistPreFit", w->allVars());
           }
           utils::setAllConstant(*mc->GetParametersOfInterest(), false); 
           w->saveSnapshot("clean", w->allVars());

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -137,7 +137,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();
     std::auto_ptr<RooFitResult> res;
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-    if ( algo_ == Singles || !loadedSnapshot_ ){
+    if ( algo_ == Singles || algo_ == None || !loadedSnapshot_ ){
     	res.reset(doFit(pdf, data, (algo_ == Singles ? poiList_ : RooArgList()), constrainCmdArg, false, 1, true, false)); 
     } else {
         // must create the NLL

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -37,6 +37,7 @@ bool MultiDimFit::floatOtherPOIs_ = false;
 unsigned int MultiDimFit::nOtherFloatingPoi_ = 0;
 bool MultiDimFit::fastScan_ = false;
 bool MultiDimFit::loadedSnapshot_ = false;
+bool MultiDimFit::forceFirstFit_ = false;
 bool MultiDimFit::savingSnapshot_ = false;
 bool MultiDimFit::startFromPreFit_ = false;
 bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
@@ -82,6 +83,7 @@ MultiDimFit::MultiDimFit() :
 	("saveSpecifiedIndex",   boost::program_options::value<std::string>(&saveSpecifiedIndex_)->default_value(""), "Save specified indexes/discretes (default = none)")
 	("saveInactivePOI",   boost::program_options::value<bool>(&saveInactivePOI_)->default_value(saveInactivePOI_), "Save inactive POIs in output (1) or not (0, default)")
 	("startFromPreFit",   boost::program_options::value<bool>(&startFromPreFit_)->default_value(startFromPreFit_), "Start each point of the likelihood scan from the pre-fit values")
+        ("forceFirstFit", "Force the first fit even if it wouldn't normally happen (e.g. for algo=grid when loading a snapshot)")
        ;
 }
 
@@ -112,6 +114,7 @@ void MultiDimFit::applyOptions(const boost::program_options::variables_map &vm)
     hasMaxDeltaNLLForProf_ = !vm["maxDeltaNLLForProf"].defaulted();
     loadedSnapshot_ = !vm["snapshotName"].defaulted();
     savingSnapshot_ = (!loadedSnapshot_) && vm.count("saveWorkspace");
+    forceFirstFit_ = (vm.count("forceFirstFit") > 0);
 }
 
 bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
@@ -137,7 +140,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();
     std::auto_ptr<RooFitResult> res;
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-    if ( algo_ == Singles || algo_ == None || !loadedSnapshot_ ){
+    if ( algo_ == Singles || algo_ == None || forceFirstFit_ || !loadedSnapshot_ ){
     	res.reset(doFit(pdf, data, (algo_ == Singles ? poiList_ : RooArgList()), constrainCmdArg, false, 1, true, false)); 
     } else {
         // must create the NLL

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -364,7 +364,7 @@ toymcoptutils::SimPdfGenInfo::generate(RooRealVar *&weightVar, const RooDataSet*
                 RooDataSet *wdata = new RooDataSet(data->GetName(), "", obs, "_weight_");
                 for (int i = 0, n = data->numEntries(); i < n; ++i) {
                     obs = *data->get(i);
-                    if (data->weight()) wdata->add(obs, data->weight());
+                    wdata->add(obs, data->weight());
                 }
                 //std::cout << "DataHist was " << std::endl; utils::printRAD(data);
                 delete data;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -31,6 +31,7 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <regex>
 
 #include "../interface/CloseCoutSentry.h"
 #include "../interface/ProfilingTools.h"
@@ -488,6 +489,41 @@ void utils::guessChannelMode(RooSimultaneous &simPdf, RooAbsData &simData, bool 
         } else {
             if (verbose) std::cout << " - " << cat.getLabel() << " has " << spl->numEntries() << " num entries of sum " << spl->sumEntries() << ", mark as unbinned" << std::endl;
             pdf->setAttribute("forceGenUnbinned");
+        }
+    }
+}
+
+void
+utils::setChannelGenModes(RooSimultaneous &simPdf, const std::string &binned, const std::string &unbinned, int verbose) {
+    std::regex r_binned(binned, std::regex::ECMAScript);
+    std::regex r_unbinned(unbinned, std::regex::ECMAScript);
+    std::smatch match;
+
+    RooAbsCategoryLValue &cat = const_cast<RooAbsCategoryLValue &>(simPdf.indexCat());
+    for (int i = 0, n = cat.numBins((const char *)0); i < n; ++i) {
+        cat.setBin(i);
+        const std::string & label = cat.getLabel();
+        RooAbsPdf *pdf = simPdf.getPdf(label.c_str());
+        if (!binned.empty() && std::regex_match(label, match, r_binned)) {
+            if (pdf->getAttribute("forceGenUnbinned")) {
+                if (verbose) std::cout << "Overriding generation mode for " << pdf->GetName() << " in " << label << " from unbinned to binned." << std::endl;
+                pdf->setAttribute("forceGenUnbinned", false);
+            } else {
+                if (verbose) std::cout << "Setting generation mode for " << pdf->GetName() << " in " << label << " to binned." << std::endl;
+            }
+            pdf->setAttribute("forceGenBinned");
+        }
+        if (!unbinned.empty() && std::regex_match(label, match, r_unbinned)) {
+            if (pdf->getAttribute("forceGenBinned")) {
+                if (verbose) std::cout << "Overriding generation mode for " << pdf->GetName() << " in " << label << " from binned to unbinned." << std::endl;
+                pdf->setAttribute("forceGenBinned", false);
+            } else {
+                if (verbose) std::cout << "Setting generation mode for " << pdf->GetName() << " in " << label << " to unbinned." << std::endl;
+            }
+            pdf->setAttribute("forceGenUnbinned");
+        }
+        if (!pdf->getAttribute("forceGenUnbinned") && !pdf->getAttribute("forceGenBinned")) {
+            if (verbose > -1) std::cout << "Warning: pdf generation mode for " << pdf->GetName() << " in " << label << " is not set" << std::endl;
         }
     }
 }


### PR DESCRIPTION
As discussed in the Comb meeting:
* support for flagging by hand which channels to generate binned or unbinned (for LHC-HCG combination, use ` --genBinnedChannels "ATLAS_.*[^z]_atlas" --genUnbinnedChannels "ATLAS_.*_zz_atlas" ` )
* saving snapshots in addition to toys whe running with `--toysFreq`, so that two-step generation with `--saveToys` and `--toysFile` reproduce the same results as running in a single job. Tested that it works on a very simple case (signal strength fit on the counting-B5p5-Obs20-Syst30B.txt)