### PR TITLE
Feature to extend bounds if the fit ends too close to them

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -124,6 +124,7 @@ class CachingAddNLL : public RooAbsReal {
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
         void clearZeroPoint() ;
+        void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
         /// note: setIncludeZeroWeights(true) won't have effect unless you also re-call setData
         virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         RooSetProxy & params() { return params_; }
@@ -165,6 +166,7 @@ class CachingSimNLL  : public RooAbsReal {
         static void setNoDeepLogEvalError(bool noDeep) { noDeepLEE_ = noDeep; }
         void setZeroPoint() ; 
         void clearZeroPoint() ;
+        void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
         static void forceUnoptimizedConstraints() { optimizeContraints_ = false; }
         friend class CachingAddNLL;
         // trap this call, since we don't care about propagating it to the sub-components

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -34,6 +34,7 @@ class CascadeMinimizer {
         void trivialMinimize(const RooAbsReal &nll, RooRealVar &r, int points=100) const ;
         //void collectIrrelevantNuisances(RooAbsCollection &irrelevant) const ;
         void setAutoBounds(const RooArgSet *pois) ; 
+        void setAutoMax(const RooArgSet *pois) ; 
     private:
         RooAbsReal & nll_;
         std::auto_ptr<RooMinimizerOpt> minimizer_;
@@ -43,7 +44,7 @@ class CascadeMinimizer {
         const RooArgSet *nuisances_;
         /// automatically enlarge bounds for POIs if they're within 10% from the boundary
         bool autoBounds_;
-        const RooArgSet *poisForAutoBounds_;
+        const RooArgSet *poisForAutoBounds_, *poisForAutoMax_;
 
         bool improveOnce(int verbose, bool noHesse=false);
         bool autoBoundsOk(int verbose) ;

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -18,6 +18,8 @@ class CascadeMinimizer {
         bool minimize(int verbose=0, bool cascade=true);
         // run minos
         bool minos(const RooArgSet &, int verbose = 0 );
+        // run hesse
+        bool hesse(int verbose = 0 );
         // do a new minimization, assuming a plausible initial state
         bool improve(int verbose=0, bool cascade=true);
         // declare nuisance parameters for pre-fit
@@ -39,7 +41,7 @@ class CascadeMinimizer {
         RooRealVar * poi_; 
         const RooArgSet *nuisances_;
 
-        bool improveOnce(int verbose);
+        bool improveOnce(int verbose, bool noHesse=false);
 
 	bool multipleMinimize(const RooArgSet &,bool &,double &,int,bool,int
 		,std::vector<std::vector<bool> > & );
@@ -75,6 +77,8 @@ class CascadeMinimizer {
         static bool setZeroPoint_;
         /// don't do old fallback using robustMinimize 
         static bool oldFallback_;
+        /// call Hesse before or after the minimization 
+        static bool firstHesse_, lastHesse_;
         /// storage level for minuit2 (toggles storing of intermediate covariances)
         static int minuit2StorageLevel_;
 

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -33,6 +33,7 @@ class CascadeMinimizer {
         static const boost::program_options::options_description & options() { return options_; }
         void trivialMinimize(const RooAbsReal &nll, RooRealVar &r, int points=100) const ;
         //void collectIrrelevantNuisances(RooAbsCollection &irrelevant) const ;
+        void setAutoBounds(const RooArgSet *pois) ; 
     private:
         RooAbsReal & nll_;
         std::auto_ptr<RooMinimizerOpt> minimizer_;
@@ -40,8 +41,12 @@ class CascadeMinimizer {
         int          strategy_;
         RooRealVar * poi_; 
         const RooArgSet *nuisances_;
+        /// automatically enlarge bounds for POIs if they're within 10% from the boundary
+        bool autoBounds_;
+        const RooArgSet *poisForAutoBounds_;
 
         bool improveOnce(int verbose, bool noHesse=false);
+        bool autoBoundsOk(int verbose) ;
 
 	bool multipleMinimize(const RooArgSet &,bool &,double &,int,bool,int
 		,std::vector<std::vector<bool> > & );

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -43,8 +43,8 @@ protected:
   RooArgSet parametersToFreeze_;
 
   static bool  saveNLL_, keepFailures_, protectUnbinnedChannels_;
-  static std::string autoBoundsPOIs_;
-  RooArgSet autoBoundsPOISet_;
+  static std::string autoBoundsPOIs_, autoMaxPOIs_;
+  RooArgSet autoBoundsPOISet_, autoMaxPOISet_;
   static double nllValue_, nll0Value_;
   std::auto_ptr<RooAbsReal> nll;
   // method that is implemented in the subclass

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -43,6 +43,8 @@ protected:
   RooArgSet parametersToFreeze_;
 
   static bool  saveNLL_, keepFailures_, protectUnbinnedChannels_;
+  static std::string autoBoundsPOIs_;
+  RooArgSet autoBoundsPOISet_;
   static double nllValue_, nll0Value_;
   std::auto_ptr<RooAbsReal> nll;
   // method that is implemented in the subclass

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -288,6 +288,8 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
  
             CascadeMinimizer minim2(*nll, CascadeMinimizer::Constrained);
             minim2.setStrategy(minimizerStrategyForMinos_);
+            if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+            if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
 
             std::auto_ptr<RooArgSet> allpars(nll->getParameters((const RooArgSet *)0));
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -368,6 +368,8 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
 
 
     CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
+    if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+    if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
     minim.setStrategy(minimizerStrategy_);
     std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
     RooArgSet snap; params->snapshot(snap);
@@ -638,6 +640,8 @@ void MultiDimFit::doRandomPoints(RooWorkspace *w, RooAbsReal &nll)
     }
 
     CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
+    if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+    if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
     minim.setStrategy(minimizerStrategy_);
     unsigned int n = poi_.size();
     for (unsigned int j = 0; j < points_; ++j) {
@@ -675,6 +679,8 @@ void MultiDimFit::doFixedPoint(RooWorkspace *w, RooAbsReal &nll)
     }
 
     CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
+    if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+    if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
     minim.setStrategy(minimizerStrategy_);
     unsigned int n = poi_.size();
 
@@ -746,6 +752,8 @@ void MultiDimFit::doContour2D(RooWorkspace *, RooAbsReal &nll)
         // ===== Get the best fit x (could also do without profiling??) =====
         xv->setConstant(false);  xv->setVal(x0);
         CascadeMinimizer minimXI(nll, CascadeMinimizer::Unconstrained, xv);
+        if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+        if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
         minimXI.setStrategy(minimizerStrategy_);
         {
             CloseCoutSentry sentry(verbose < 3);    
@@ -755,6 +763,8 @@ void MultiDimFit::doContour2D(RooWorkspace *, RooAbsReal &nll)
         if (verbose>-1) std::cout << "Best fit " << xv->GetName() << " for  " << yv->GetName() << " = " << yv->getVal() << " is at " << xc << std::endl;
         // ===== Then get the range =====
         CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
+        if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+        if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
         double xup = findCrossing(minim, nll, *xv, threshold, xc, xMax);
         if (!std::isnan(xup)) { 
             x = xup; y = yv->getVal(); Combine::commitPoint(true, /*quantile=*/1-cl);
@@ -838,6 +848,8 @@ void MultiDimFit::doBox(RooAbsReal &nll, double cl, const char *name, bool commi
         RooRealVar *xv = poiVars_[i];
         xv->setConstant(true);
         CascadeMinimizer minimX(nll, CascadeMinimizer::Constrained);
+        if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+        if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
         minimX.setStrategy(minimizerStrategy_);
 
         for (unsigned int j = 0; j < n; ++j) poiVars_[j]->setVal(p0[j]);


### PR DESCRIPTION
Supports both two-sided bounds and one-sided upper bounds for positive-definite quantities
Works well with `--cminApproxPreFitTolerance` set to a largish value (e.g. 50 or 25) so that already after the fast prefit the code adjusts the boundaries.