### PR TITLE
Fix toys in multi dim fit

### DIFF
--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -34,7 +34,7 @@ protected:
 
   static float preFitValue_;
 
-  static bool robustFit_, do95_;
+  static bool robustFit_, do95_, forceRecreateNLL_;
   static float stepSize_;
   static int   maxFailedSteps_;
 

--- a/interface/MaxLikelihoodFit.h
+++ b/interface/MaxLikelihoodFit.h
@@ -48,7 +48,7 @@ protected:
   static bool        customStartingPoint_;
   int currentToy_, nToys;
   int fitStatus_, numbadnll_;
-  double mu_, muLoErr_, muHiErr_, nll_nll0_, nll_bonly_, nll_sb_;
+  double mu_, muErr_, muLoErr_, muHiErr_, nll_nll0_, nll_bonly_, nll_sb_;
   std::auto_ptr<TFile> fitOut;
   double* globalObservables_;
   double* nuisanceParameters_;

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -929,7 +929,7 @@ cacheutils::CachingSimNLL::setData(const RooAbsData &data)
     //utils::printRAD(&data);
     //dataSets_.reset(dataOriginal_->split(pdfOriginal_->indexCat(), true));
     if (!(RooCategory*)data.get()->find("CMS_channel")) { 
-    	throw  std::logic_error("Error: no category in dataset. You should try to recreate your datacard as a Fake shape -- combineCards.py mycard.txt -S > myshapecard.txt");
+    	throw  std::logic_error("Error: no category in dataset. You should try to recreate your datacard as a Fake shape -- combineCards.py mycard.txt -S > myshapecard.txt OR rerun with option --forceRecreateNLL");
 	assert(0);
     }
     splitWithWeights(*dataOriginal_, pdfOriginal_->indexCat(), true);

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -928,6 +928,10 @@ cacheutils::CachingSimNLL::setData(const RooAbsData &data)
     //std::cout << "combined data has " << data.numEntries() << " dataset entries (sumw " << data.sumEntries() << ", weighted " << data.isWeighted() << ")" << std::endl;
     //utils::printRAD(&data);
     //dataSets_.reset(dataOriginal_->split(pdfOriginal_->indexCat(), true));
+    if (!(RooCategory*)data.get()->find("CMS_channel")) { 
+    	throw  std::logic_error("Error: no category in dataset. You should try to recreate your datacard as a Fake shape -- combineCards.py mycard.txt -S > myshapecard.txt");
+	assert(0);
+    }
     splitWithWeights(*dataOriginal_, pdfOriginal_->indexCat(), true);
     for (int ib = 0, nb = pdfs_.size(); ib < nb; ++ib) {
         CachingAddNLL *canll = pdfs_[ib];

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -663,7 +663,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     RooDataSet *systDs = 0;
     if (withSystematics && !toysNoSystematics_ && (readToysFromHere == 0)) {
       if (nuisances == 0) throw std::logic_error("Running with systematics enabled, but nuisances not defined.");
-      nuisancePdf.reset(utils::makeNuisancePdf(expectSignal_ ? *mc : *mc_bonly));
+      nuisancePdf.reset(utils::makeNuisancePdf(expectSignal_ || noMCbonly_ ? *mc : *mc_bonly));
       if (toysFrequentist_) {
           if (mc->GetGlobalObservables() == 0) throw std::logic_error("Cannot use toysFrequentist with no global observables");
           w->saveSnapshot("reallyClean", w->allVars());

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -193,7 +193,7 @@ bool MaxLikelihoodFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s,
     // skip b-only fit
   } else if (minos_ != "all") {
     RooArgList minos; 
-    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/true,/*reuseNLL*/ true); 
+    res_b = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/true,/*ndim*/1,/*reuseNLL*/ true); 
     nll_bonly_=nll->getVal()-nll0;   
   } else {
     CloseCoutSentry sentry(verbose < 2);
@@ -264,7 +264,7 @@ bool MaxLikelihoodFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s,
   r->setVal(preFitValue_); r->setConstant(false); 
   if (minos_ != "all") {
     RooArgList minos; if (minos_ == "poi") minos.add(*r);
-    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/!noErrors_,/*reuseNLL*/ true); 
+    res_s = doFit(*mc_s->GetPdf(), data, minos, constCmdArg_s, /*hesse=*/!noErrors_,/*ndim*/1,/*reuseNLL*/ true); 
     nll_sb_ = nll->getVal()-nll0;
   } else {
     CloseCoutSentry sentry(verbose < 2);

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -69,7 +69,7 @@ MaxLikelihoodFit::MaxLikelihoodFit() :
    ;
 
     // setup a few defaults
-    nToys=0; fitStatus_=0; mu_=0; muLoErr_=0; muHiErr_=0; numbadnll_=-1; nll_nll0_=-1; nll_bonly_=-1; nll_sb_=-1;
+    nToys=0; fitStatus_=0; mu_=0; muErr_=0; muLoErr_=0; muHiErr_=0; numbadnll_=-1; nll_nll0_=-1; nll_bonly_=-1; nll_sb_=-1;
 }
 
 MaxLikelihoodFit::~MaxLikelihoodFit(){
@@ -346,6 +346,7 @@ bool MaxLikelihoodFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s,
 
       muLoErr_=loErr;
       muHiErr_=hiErr;
+      muErr_  =rf->getError();
 
       double hiErr95 = +(do95_ && rf->hasRange("err95") ? rf->getMax("err95") - bestFitVal : 0);
       double loErr95 = -(do95_ && rf->hasRange("err95") ? rf->getMin("err95") - bestFitVal : 0);
@@ -678,6 +679,9 @@ void MaxLikelihoodFit::createFitResultTrees(const RooStats::ModelConfig &mc, boo
 
 	 t_fit_b_->Branch("mu",&mu_,"mu/Double_t");
 	 t_fit_sb_->Branch("mu",&mu_,"mu/Double_t");
+
+	 t_fit_b_->Branch("muErr",&muErr_,"muErr/Double_t");
+	 t_fit_sb_->Branch("muErr",&muErr_,"muErr/Double_t");
 
 	 t_fit_b_->Branch("muLoErr",&muLoErr_,"muLoErr/Double_t");
 	 t_fit_sb_->Branch("muLoErr",&muLoErr_,"muLoErr/Double_t");


### PR DESCRIPTION
2 issues found fitting toys with MultiDimFit...

The first was that a non-existent background only ModelConfig was being accessed to grab pdf and generate toys, now there is a check in case its not there to resort again to the mc_s.

The second is only effecting counting experiments. There is an issue calling ```CachingSimNLL::setData()``` when there is no category object of the pdf. Now the object CMS_channel is explicitly checked for in the data and if not present, an exception is thrown with a message to the user for how to remedy the issue by either 
a) recreate the datacard as a fake shape
b) add option --forceRecreateNLL to avoid the call 
