### PR TITLE
%g -> %f in text2workspace call

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -239,7 +239,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     isBinary = true;
   } else {
     TString txtFile = fileToLoad.Data();
-    TString options = TString::Format(" -m %g -D %s", mass_, dataset.c_str());
+    TString options = TString::Format(" -m %f -D %s", mass_, dataset.c_str());
     if (!withSystematics) options += " --stat ";
     if (compiledExpr_)    options += " --compiled ";
     if (verbose > 1)      options += TString::Format(" --verbose %d", verbose-1);


### PR DESCRIPTION
Changing %g to %f in the call inside Combine of text2workspace. recently found example where `-m 2000001` was being processed correctly when running text2workspace (,e .txt -> binary externally) but interpreted as 2000000 when running from inside combine.