### PR TITLE
Update RooParametricHist.cxx

### DIFF
--- a/src/RooParametricHist.cxx
+++ b/src/RooParametricHist.cxx
@@ -6,7 +6,7 @@
 
 #include "RooAbsData.h"
 #include "RooAbsPdf.h"
-#include "HiggsAnalysis/CombinedLimit/interface/RooParametricHist.h" 
+#include "../interface/RooParametricHist.h" 
 
 #include <math.h> 
 #include "TMath.h" 


### PR DESCRIPTION
Previous include path was preventing standalone (`Makefile`) compilation.
This relative path is also what is used in every other piece of code.