### PR TITLE
Fix nuisance parameter scan

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -192,10 +192,17 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
     }
     for (std::vector<std::string>::const_iterator it = poi_.begin(), ed = poi_.end(); it != ed; ++it) {
         RooAbsArg *a = mcPoi.find(it->c_str());
-        if (a == 0) a = w->arg(it->c_str());  // look for the parameter elsewhere
+	bool isPoi=true;
+        if (a == 0) { 
+		a = w->arg(it->c_str());  // look for the parameter elsewhere, but remember to clear its optimizeBounds attribute 
+		isPoi = false;
+	}
         if (a == 0) throw std::invalid_argument(std::string("Parameter of interest ")+*it+" not in model.");
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv == 0) throw std::invalid_argument(std::string("Parameter of interest ")+*it+" not a RooRealVar.");
+	if (!isPoi) {
+		if (rrv->getAttribute("optimizeBounds") ) rrv->setAttribute("optimizeBounds",false);
+	}
         poiVars_.push_back(rrv);
         poiVals_.push_back(rrv->getVal());
         poiList_.add(*rrv);

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -192,6 +192,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
     }
     for (std::vector<std::string>::const_iterator it = poi_.begin(), ed = poi_.end(); it != ed; ++it) {
         RooAbsArg *a = mcPoi.find(it->c_str());
+        if (a == 0) a = w->arg(it->c_str());  // look for the parameter elsewhere
         if (a == 0) throw std::invalid_argument(std::string("Parameter of interest ")+*it+" not in model.");
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv == 0) throw std::invalid_argument(std::string("Parameter of interest ")+*it+" not a RooRealVar.");


### PR DESCRIPTION
MultiDimFit now looks beyond the ModelConfig parameters of interest when
using command --poi

This allows the user to perform a MultiDimFit scan of a nuisance (or any) parameter
ithout first promoting it to a parameter of interest and causing the
Gaussian constraint to be dropped.

note, this required to turn off the optimize bounds (using --X-rtd
OPTIMIZE_BOUNDS=0) at runtime or the parameter range will not be set before running the scan

EDIT: Now also removing "optimizeBounds" attribute if parameter is picked up outside of POI list so that runtime argument is not needed 