### PR TITLE
Initialize currentToy_ in MaxLikelihoodFit

### DIFF
--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -72,7 +72,7 @@ MaxLikelihoodFit::MaxLikelihoodFit() :
    ;
 
     // setup a few defaults
-    nToys=0; fitStatus_=0; mu_=0; muLoErr_=0; muHiErr_=0; numbadnll_=-1; nll_nll0_=-1; nll_bonly_=-1; nll_sb_=-1;
+    currentToy_=0; nToys=0; fitStatus_=0; mu_=0; muLoErr_=0; muHiErr_=0; numbadnll_=-1; nll_nll0_=-1; nll_bonly_=-1; nll_sb_=-1;
 }
 
 MaxLikelihoodFit::~MaxLikelihoodFit(){


### PR DESCRIPTION
Otherwise MaxLikelihoodFit may crash because it does not initialize the nll if `currentToys_` is by chance a number larger than zero.