### PR TITLE
Add Kolmogorov–Smirnov and Anderson–Darling test statistics to GoodnessOfFit

### DIFF
--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -8,12 +8,10 @@
  *
  *
  */
-#ifndef ROOT_Rtypes
-#include "Rtypes.h"
-#endif
-
 #include "../interface/LimitAlgo.h"
 #include "../interface/ProfileLikelihood.h"
+
+class TDirectory;
 
 class GoodnessOfFit : public LimitAlgo {
 public:
@@ -26,10 +24,8 @@ public:
   virtual void applyOptions(const boost::program_options::variables_map &vm) ;
 
   virtual bool runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual bool runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo);
-
-  void initKS(RooStats::ModelConfig *mc_s);
-
+  virtual bool runKSandAD(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo);
+  void initKSandAD(RooStats::ModelConfig *mc_s);
   double EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, bool kolmo);
  
 protected:
@@ -41,9 +37,9 @@ protected:
 
   static float mu_;
   static bool  fixedMu_;
+
   static bool  makePlots_;
   static TDirectory *plotDir_;
-
   static std::vector<std::string>  binNames_;
   static std::vector<float>        qVals_;
 

--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -28,7 +28,9 @@ public:
   virtual bool runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   virtual bool runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo);
 
-  Double_t EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& limit, bool kolmo);
+  void initKS(RooStats::ModelConfig *mc_s);
+
+  double EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, bool kolmo);
  
 protected:
   static std::string algo_;
@@ -39,8 +41,12 @@ protected:
 
   static float mu_;
   static bool  fixedMu_;
-  static bool  nofit_;
-  static bool  makeplot_;
+  static bool  makePlots_;
+  static TDirectory *plotDir_;
+
+  static std::vector<std::string>  binNames_;
+  static std::vector<float>        qVals_;
+
 
   // Return a pdf that matches this data perfectly.
   RooAbsPdf *makeSaturatedPdf(RooAbsData &data);

--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -8,6 +8,10 @@
  *
  *
  */
+#ifndef ROOT_Rtypes
+#include "Rtypes.h"
+#endif
+
 #include "../interface/LimitAlgo.h"
 #include "../interface/ProfileLikelihood.h"
 
@@ -22,6 +26,9 @@ public:
   virtual void applyOptions(const boost::program_options::variables_map &vm) ;
 
   virtual bool runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  virtual bool runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo);
+
+  Double_t EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& limit, bool kolmo);
  
 protected:
   static std::string algo_;
@@ -32,6 +39,7 @@ protected:
 
   static float mu_;
   static bool  fixedMu_;
+  static bool  nofit_;
 
   // Return a pdf that matches this data perfectly.
   RooAbsPdf *makeSaturatedPdf(RooAbsData &data);

--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -40,6 +40,7 @@ protected:
   static float mu_;
   static bool  fixedMu_;
   static bool  nofit_;
+  static bool  makeplot_;
 
   // Return a pdf that matches this data perfectly.
   RooAbsPdf *makeSaturatedPdf(RooAbsData &data);

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -227,7 +227,7 @@ typedef std::pair<Double_t, Double_t> double_pair;
 
 bool sort_pairs (double_pair i, double_pair j) {return (i.first < j.first);}
 
-Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& limit, bool kolmo) {
+Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& oldlimit, bool kolmo) {
 
     std::vector<double_pair > data_points;
     Int_t n_data = data.numEntries();
@@ -275,7 +275,11 @@ Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, Ro
         }
     }
 
-    if (kolmo == 0) test_stat += limit;
+    if (kolmo){
+        if (test_stat < oldlimit) test_stat = oldlimit; // The test statistic of the Kolmogorov-Smirnov test is the maximum of the test statistics of all individual PDFs.
+    }else{
+        test_stat += oldlimit; // The test statistic of the Anderson-Darling test is the sum of the test statistics of all individual PDFs.
+    }
     return test_stat;
 }
 

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -12,6 +12,7 @@
 #include <RooDataHist.h>
 #include <RooHistPdf.h>
 #include <TCanvas.h>
+#include <TLegend.h>
 #include <TStyle.h>
 #include <TH2.h>
 #include <TFile.h>
@@ -23,6 +24,7 @@
 #include "../interface/CloseCoutSentry.h"
 #include "../interface/RooSimultaneousOpt.h"
 #include "../interface/utils.h"
+#include <fstream>
 
 
 #include <Math/MinimizerOptions.h>
@@ -36,6 +38,7 @@ int         GoodnessOfFit::minimizerStrategy_  = 1;
 float       GoodnessOfFit::mu_ = 0.0;
 bool        GoodnessOfFit::fixedMu_ = false;
 bool        GoodnessOfFit::nofit_ = false;
+bool        GoodnessOfFit::makeplot_ = false;
 
 GoodnessOfFit::GoodnessOfFit() :
     LimitAlgo("GoodnessOfFit specific options")
@@ -46,7 +49,8 @@ GoodnessOfFit::GoodnessOfFit() :
         ("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
         ("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
         ("fixedSignalStrength", boost::program_options::value<float>(&mu_)->default_value(mu_),  "Compute the goodness of fit for a fixed signal strength. If not specified, it's left floating")
-        ("nofit", boost::program_options::value<bool>(&nofit_)->default_value(nofit_),  "Don't take the NLL values directly from the fits (for saturated model)")
+        ("nofit", boost::program_options::value<bool>(&nofit_)->default_value(nofit_),  "Doesn't take the NLL values directly from the fits (for saturated model). Default: False")
+        ("makeplot", boost::program_options::value<bool>(&makeplot_)->default_value(makeplot_),  "Make a plot containing information of the computation of the Anderson-Darling or Kolmogorov-Smirnov test statistic")
     ;
 }
 
@@ -180,7 +184,7 @@ bool GoodnessOfFit::runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *
   RemoveConstantParameters(pdfParams);
   fPdf->fitTo(data, RooFit::Constrain(*pdfParams), RooFit::PrintLevel(-1), RooFit::Verbose(kFALSE));
 
-  // unet POI constant so the fit doesn't adjust them
+  // Unset POI constant so the fit doesn't adjust them
   // param_iter = params.createIterator();
   // while (1) {
   //     param = dynamic_cast<RooRealVar*>(param_iter->Next());
@@ -254,6 +258,66 @@ Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, Ro
     //CDF of the PDF
     RooAbsReal* cdf;
 
+    // Declarations for the saveplot option
+    Int_t count=-1;
+    gStyle->SetOptStat(0);
+    gStyle->SetPadLeftMargin(0.14);
+    gStyle->SetPadBottomMargin(0.14);
+    TCanvas* c = new TCanvas("c","c",600,600);
+    TH1F* hcdf = new TH1F("cdf","",n_data-1,0,n_data-1);
+    TH1F* hedf = new TH1F("edf","",n_data-1,0,n_data-1);
+    TH1F* hcdif = new TH1F("cdif","",n_data-1,0,n_data-1);
+    TH1F* hpdif = new TH1F("pdif","",n_data-1,0,n_data-1);
+    TH1F* hADadd = new TH1F("ADadd","",n_data-1,0,n_data-1);
+    TH1F* hADtrend = new TH1F("ADtrend","",n_data-1,0,n_data-1);
+    TLegend* leg1 = new TLegend(0.14,0.91,0.9,1.0);
+    TLegend* leg2 = new TLegend(0.14,0.91,0.9,1.0);
+    TPad* pad1 = new TPad("pad1","pad1",0,0.22,1,0.98);
+    TPad* pad2 = new TPad("pad2","pad2",0,0.15,1,0.3);
+    TPad* pad3 = new TPad("pad3","pad3",0,0,1,0.15);
+
+    if (makeplot_){
+        pad1->SetFillStyle(4000);
+        pad1->Draw();
+        pad2->SetFillStyle(4000);
+        pad2->Draw();
+        pad3->SetFillStyle(4000);
+        pad3->Draw();
+        pad1->cd();
+
+        hcdf->SetMinimum(0);
+        hedf->SetMinimum(0);
+        leg1->AddEntry(hcdf,"Cumulative distribution function","l");
+        leg1->AddEntry(hedf,"Empirical distribution function","l");
+        leg1->SetTextSize(0.04);
+
+        hcdif->SetOption("P0");
+        hcdif->SetMarkerStyle(20);
+        hcdif->SetMarkerSize(1);
+        hcdif->SetYTitle("CDF-EDF");
+        hcdif->GetYaxis()->SetTitleSize(0.20);
+        hcdif->GetYaxis()->SetTitleOffset(0.25);
+        hcdif->GetYaxis()->SetNdivisions(306);
+        hcdif->GetYaxis()->SetLabelSize(0.15);
+        hcdif->GetXaxis()->SetLabelSize(0.15);
+
+        hpdif->SetOption("P0");
+        hpdif->SetMarkerStyle(20);
+        hpdif->SetMarkerSize(1);
+        hpdif->SetYTitle("Data/MC");
+        hpdif->GetYaxis()->SetTitleSize(0.20);
+        hpdif->GetYaxis()->SetTitleOffset(0.25);
+        hpdif->GetYaxis()->SetNdivisions(306);
+        hpdif->GetYaxis()->SetLabelSize(0.15);
+        hpdif->GetXaxis()->SetLabelSize(0.15);
+
+        hADadd->SetMinimum(0);
+        hADtrend->SetMinimum(0);
+        leg2->AddEntry(hADadd,"Gets added to the test statistic","l");
+        leg2->AddEntry(hADtrend,"Trend of the test statistic","l");
+        leg2->SetTextSize(0.04);
+    }
+
     for(std::vector<double_pair>::const_iterator d = data_points.begin(); d != data_points.end()-1; d++) {
         observableval = ((d+1)->first + d->first)/2.; // d->first is middle of bin, want upper edge.
         observable.setVal(observableval);
@@ -261,19 +325,79 @@ Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, Ro
         current_cdf_val = cdf->getVal();
         empirical_df += d->second/s_data;
 
-        if (current_cdf_val >= 1.0)
-            break;
+        count++;
+        hcdif->Fill(count,current_cdf_val-empirical_df);
+        hpdif->Fill(count,(d->second/s_data)/(current_cdf_val-last_cdf_val));
 
         if (kolmo){
             distance = std::abs(empirical_df-current_cdf_val);
+            hcdf->Fill(count,current_cdf_val);
+            hedf->Fill(count,empirical_df);
             if (distance > test_stat) test_stat = distance;
         }else{
             bin_prob = current_cdf_val-last_cdf_val;
             // from L. Demortier, CDF/ANAL/JET/CDFR/3419
             test_stat += s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob;
-            last_cdf_val = current_cdf_val;
+            hADadd->Fill(count,s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob);
+            hADtrend->Fill(count,test_stat);
         }
+        last_cdf_val = current_cdf_val;
+
+        if (last_cdf_val >= 1.0)
+            break;
     }
+
+    if(makeplot_){
+        if (hcdif->GetMaximum() > std::abs(hcdif->GetMinimum())){
+            hcdif->SetMinimum(-1.0*(hcdif->GetMaximum()));//hcdif->GetYaxis()->SetRange(-1.05*(hcdif->GetMaximum()),1.05*(hcdif->GetMaximum()));//
+        }else{
+            hcdif->SetMaximum(-1.0*(hcdif->GetMinimum()));//hcdif->GetYaxis()->SetRange(1.05*(hcdif->GetMinimum()),-1.05*(hcdif->GetMinimum()));//
+        }
+        if ((hpdif->GetMaximum())-1 > 1-(hpdif->GetMinimum())){
+            hpdif->SetMinimum(2-(hpdif->GetMaximum()));//hpdif->GetYaxis()->SetRange(-1.05*(hpdif->GetMaximum())+2,1.05*(hpdif->GetMaximum()));//
+        }else{
+            hpdif->SetMaximum(2-(hpdif->GetMinimum()));//hpdif->GetYaxis()->SetRange(1.05*(hpdif->GetMinimum()),-1.05*(hpdif->GetMinimum())+2);//
+        }
+
+        if (kolmo){
+            hcdf->Draw();
+            hedf->SetLineColor(kRed);
+            hedf->Draw("sames");
+            leg1->Draw();
+        }else{
+            hADtrend->Draw();
+            hADadd->SetLineColor(kRed);
+            hADadd->Draw("sames");
+            leg2->Draw();
+        }
+        pad2->cd();
+        gPad->SetGridy();
+        hcdif->Draw();
+        pad3->cd();
+        gPad->SetGridy();
+        hpdif->Draw();
+
+        Int_t filecount=0;
+        std::string filename;
+        std::fstream ifile;
+        do{
+            if (ifile != 0) ifile.close();
+            filecount++;
+            filename = "Gof_plot_"+std::to_string(filecount)+".png";
+            ifile.open(filename);
+        }while(ifile != 0);
+        ifile.close();
+        TString tfilename=filename;
+        c->SaveAs(tfilename);
+    }
+
+    delete c;
+    delete hcdf;
+    delete hedf;
+    delete hcdif;
+    delete hpdif;
+    delete hADadd;
+    delete hADtrend;
 
     if (kolmo){
         if (test_stat < oldlimit) test_stat = oldlimit; // The test statistic of the Kolmogorov-Smirnov test is the maximum of the test statistics of all individual PDFs.

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -25,6 +25,7 @@
 #include "../interface/RooSimultaneousOpt.h"
 #include "../interface/utils.h"
 #include <fstream>
+#include <numeric>
 
 
 #include <Math/MinimizerOptions.h>
@@ -37,30 +38,37 @@ float       GoodnessOfFit::minimizerTolerance_ = 1e-4;
 int         GoodnessOfFit::minimizerStrategy_  = 1;
 float       GoodnessOfFit::mu_ = 0.0;
 bool        GoodnessOfFit::fixedMu_ = false;
-bool        GoodnessOfFit::nofit_ = false;
-bool        GoodnessOfFit::makeplot_ = false;
+bool        GoodnessOfFit::makePlots_ = false;
+TDirectory* GoodnessOfFit::plotDir_ = nullptr;
+std::vector<std::string>  GoodnessOfFit::binNames_;
+std::vector<float>        GoodnessOfFit::qVals_;
 
 GoodnessOfFit::GoodnessOfFit() :
     LimitAlgo("GoodnessOfFit specific options")
 {
     options_.add_options()
-        ("algorithm",          boost::program_options::value<std::string>(&algo_), "Goodness of fit algorithm. Supported algorithms are 'saturated', 'kolmogorovsmirnov' and 'andersondarling'.")
+        ("algorithm",          boost::program_options::value<std::string>(&algo_), "Goodness of fit algorithm. Supported algorithms are 'saturated', 'KS' and 'AD'.")
         ("minimizerAlgo",      boost::program_options::value<std::string>(&minimizerAlgo_)->default_value(minimizerAlgo_), "Choice of minimizer (Minuit vs Minuit2)")
         ("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
         ("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
         ("fixedSignalStrength", boost::program_options::value<float>(&mu_)->default_value(mu_),  "Compute the goodness of fit for a fixed signal strength. If not specified, it's left floating")
-        ("nofit", boost::program_options::value<bool>(&nofit_)->default_value(nofit_),  "Doesn't take the NLL values directly from the fits (for saturated model). Default: False")
-        ("makeplot", boost::program_options::value<bool>(&makeplot_)->default_value(makeplot_),  "Make a plot containing information of the computation of the Anderson-Darling or Kolmogorov-Smirnov test statistic")
+        ("plots",  "Make plots containing information of the computation of the Anderson-Darling or Kolmogorov-Smirnov test statistic")
     ;
 }
 
 void GoodnessOfFit::applyOptions(const boost::program_options::variables_map &vm) 
 {
     fixedMu_ = !vm["fixedSignalStrength"].defaulted();
-    if (algo_ == "saturated") std::cout << "Will use saturated models to compute goodness of fit for a binned likelihood" << std::endl;
-    else if (algo_ == "andersondarling") std::cout << "Will use the Anderson-Darling test to compute goodness of fit for a binned likelihood" << std::endl;
-else if (algo_ == "kolmogorovsmirnov") std::cout << "Will use the Kolmogorov-Smirnov test to compute goodness of fit for a binned likelihood" << std::endl;
-    else throw std::invalid_argument("GoodnessOfFit: algorithm "+algo_+" not supported");
+    if (algo_ == "saturated") {
+      std::cout << "Will use saturated models to compute goodness of fit for a binned likelihood" << std::endl;
+    } else if (algo_ == "AD") {
+      std::cout << "Will use the Anderson-Darling test to compute goodness of fit for a binned likelihood" << std::endl;
+    } else if (algo_ == "KS") {
+      std::cout << "Will use the Kolmogorov-Smirnov test to compute goodness of fit for a binned likelihood" << std::endl;
+    } else {
+      throw std::invalid_argument("GoodnessOfFit: algorithm "+algo_+" not supported");
+    }
+    makePlots_ = vm.count("plots");
 }
 
 bool GoodnessOfFit::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
@@ -69,10 +77,39 @@ bool GoodnessOfFit::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
   RooRealVar *r = dynamic_cast<RooRealVar *>(mc_s->GetParametersOfInterest()->first());
   if (fixedMu_) { r->setVal(mu_); r->setConstant(true); }
   if (algo_ == "saturated") return runSaturatedModel(w, mc_s, mc_b, data, limit, limitErr, hint);
-  if (algo_ == "andersondarling") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 0);
-  if (algo_ == "kolmogorovsmirnov") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 1);
+  static bool is_init = false;
+  if (algo_ == "AD" || algo_ == "KS") {
+    if (!is_init) {
+      initKS(mc_s);
+      if (makePlots_) {
+        plotDir_ = outputFile ? outputFile->mkdir("GoodnessOfFit") : 0;
+      }
+      is_init = true;
+    }
+    if (algo_ == "AD") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 0);
+    if (algo_ == "KS") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 1);
+  }
+
   return false;  
 }
+
+void GoodnessOfFit::initKS(RooStats::ModelConfig *mc_s) {
+  RooSimultaneous *sim = dynamic_cast<RooSimultaneous *>(mc_s->GetPdf());
+  if (sim) {
+    std::auto_ptr<RooAbsCategoryLValue> cat(
+        static_cast<RooAbsCategoryLValue *>(sim->indexCat().Clone()));
+    int nbins = cat->numBins((const char *)0);
+    binNames_.resize(nbins);
+    qVals_.resize(nbins);
+    for (int i = 0; i < nbins; ++i) {
+      cat->setBin(i);
+      binNames_[i] = cat->getLabel();
+      qVals_[i] = 0.;
+      Combine::addBranch(binNames_[i].c_str(), &qVals_[i], (binNames_[i]+"/F").c_str());
+    }
+  }
+}
+
 
 bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
   RooAbsPdf *pdf_nominal = mc_s->GetPdf();
@@ -129,17 +166,9 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
   std::auto_ptr<RooFitResult> result_saturated(saturated->fitTo(data, RooFit::Save(1), minim, RooFit::Strategy(minimizerStrategy_), RooFit::Hesse(0), RooFit::Constrain(*mc_s->GetNuisanceParameters())));
   sentry.clear();
 
-  if(nofit_){
-    std::auto_ptr<RooAbsReal> nominal_nll(pdf_nominal->createNLL(data, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
-    std::auto_ptr<RooAbsReal> saturated_nll(saturated->createNLL(data, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
-    //if (nominal_nll.get()   == 0 or saturated_nll.get() == 0) return false;
-    nll_nominal = nominal_nll->getVal();
-    nll_saturated = saturated_nll->getVal();
-  }else{
-    if (result_nominal.get()   == 0 or result_saturated.get() == 0) return false;
-    nll_nominal   = result_nominal->minNll();
-    nll_saturated = result_saturated->minNll();
-  }
+  if (result_nominal.get()   == 0 or result_saturated.get() == 0) return false;
+  nll_nominal   = result_nominal->minNll();
+  nll_saturated = result_saturated->minNll();
 
   saturated.reset();
   for (int i = 0, n = tempData_.size(); i < n; ++i) delete tempData_[i]; 
@@ -155,255 +184,165 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
 
 // Code for the Anderson-Darling test originates from https://gist.github.com/neggert/4586791
 bool GoodnessOfFit::runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo) { 
-   /*
-  Find the Anderson-Darling difference between fPdf and the data. This is just
-  the maximum over data points of the distance between the CDF and the emprical
-  distribution function of the data.
-  */
+  RooAbsPdf *pdf = mc_s->GetPdf();
 
-  const RooArgSet * POI = mc_s->GetParametersOfInterest();
-  RooRealVar* poi = dynamic_cast<RooRealVar*>(POI->first());
-  RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
-  RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
-
-  // Set POI constant so the fit doesn't adjust them
-  // RooRealVar* param;
-  // TIterator *param_iter = params.createIterator();
-  // while (1) {
-  //     param = dynamic_cast<RooRealVar*>(param_iter->Next());
-  //     if (!param) break;
-  //     param->setConstant(kTRUE);
-  // }
+  // Don't want the constraints here
+  RooArgList constraints;
+  RooAbsPdf *obsOnlyPdf = utils::factorizePdf(*mc_s->GetObservables(), *pdf, constraints);
 
   //First, find the best fit values
-  RooAbsPdf *fPdf = mc_s->GetPdf();
-  RooArgSet* pdfParams = fPdf->getParameters(data);
-  RooRealVar* pdfPOI= dynamic_cast<RooRealVar*>(pdfParams->find(poi->GetName()));
-  pdfPOI->setVal(poi->getVal());
-  pdfPOI->setConstant();
-  RemoveConstantParameters(pdfParams);
-  fPdf->fitTo(data, RooFit::Constrain(*pdfParams), RooFit::PrintLevel(-1), RooFit::Verbose(kFALSE));
+  CloseCoutSentry sentry(verbose < 2);
+  const RooCmdArg &minim = RooFit::Minimizer(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str(),
+                                             ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
+  std::auto_ptr<RooFitResult> result(pdf->fitTo(data, RooFit::Save(1), minim, RooFit::Strategy(minimizerStrategy_), RooFit::Hesse(0), RooFit::Constrain(*mc_s->GetNuisanceParameters())));
+  sentry.clear();
 
-  // Unset POI constant so the fit doesn't adjust them
-  // param_iter = params.createIterator();
-  // while (1) {
-  //     param = dynamic_cast<RooRealVar*>(param_iter->Next());
-  //     if (!param) break;
-  //     param->setConstant(kFALSE);
-  // }
+  RooSimultaneous *sim = dynamic_cast<RooSimultaneous *>(obsOnlyPdf);
 
   limit = 0;
-  RooSimultaneous *sim = dynamic_cast<RooSimultaneous *>(fPdf);
 
   // now check if we have categories to deal with
-  if (sim) {
-      const RooCategory* cat = dynamic_cast<const RooCategory*>(&(sim->indexCat()));
-      // split the data
-      TList* datasets = data.split(*cat);
-      Int_t num_cats = datasets->GetEntries();
-      for(Int_t i= 0; i < num_cats; i++) {
-          // set to current category
-          const Text_t* cat_name = cat->lookupType(i)->GetName();
-          RooAbsData *cat_data = dynamic_cast<RooAbsData*>(datasets->At(i));
-          RooAbsPdf *cat_pdf = sim->getPdf(cat_name);
-          RooArgSet* observables = cat_pdf->getObservables(cat_data);
-          RooRealVar* x = dynamic_cast<RooRealVar*>(observables->first());
-          limit = EvaluateADDistance(*cat_pdf, *cat_data, *x, limit, kolmo);
+  if (binNames_.size()) {
+    RooAbsCategoryLValue const &cat = sim->indexCat();    
+    // Split the data using the option "true" to include empty datasets
+    std::auto_ptr<TList> datasets(data.split(cat, true));
+    
+    // Number of categories should always equal the number of datasets
+    if (datasets->GetSize() != int(binNames_.size())) {
+      throw std::runtime_error(
+          "Numbers of categories and datasets do not match");
+    }
+
+    for (unsigned i = 0; i < binNames_.size(); i++) {
+      RooAbsData *cat_data = dynamic_cast<RooAbsData *>(datasets->At(i));
+      RooAbsPdf *cat_pdf = sim->getPdf(binNames_[i].c_str());
+      std::auto_ptr<RooArgSet> observables(cat_pdf->getObservables(cat_data));
+      if (observables->getSize() > 1) {
+        std::cout << "Warning, KS and AD statistics are not well defined for "
+                     "models with more than one observable\n";
       }
+      RooRealVar *x = dynamic_cast<RooRealVar *>(observables->first());
+      qVals_[i] = EvaluateADDistance(*cat_pdf, *cat_data, *x, kolmo);
+    }
+    limit = std::accumulate(qVals_.begin(), qVals_.end(), 0.);
   } else {
-      RooRealVar* obs = dynamic_cast<RooRealVar*>(fPdf->getObservables(data)->first());
-      limit = EvaluateADDistance(*fPdf, data, *obs, limit, kolmo);
+    RooRealVar *obs = dynamic_cast<RooRealVar *>(
+        std::auto_ptr<RooArgSet>(pdf->getObservables(data))->first());
+    limit = EvaluateADDistance(*pdf, data, *obs, kolmo);
   }
+
 
   std::cout << "\n --- GoodnessOfFit --- " << std::endl;
   if(kolmo){
-      std::cout << "Kolmogorov-Smirlov test statistic: " << limit << std::endl;
+      std::cout << "Kolmogorov-Smirnov test statistic: " << limit << std::endl;
   }else{
       std::cout << "Anderson-Darling test statistic: " << limit << std::endl;
   }
 
-  RooMsgService::instance().setGlobalKillBelow(msglevel);
+  makePlots_ = false;
+
   return true;
 }
 
-
-typedef std::pair<Double_t, Double_t> double_pair;
-
-bool sort_pairs (double_pair i, double_pair j) {return (i.first < j.first);}
-
-Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& oldlimit, bool kolmo) {
-
-    std::vector<double_pair > data_points;
+Double_t GoodnessOfFit::EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, bool kolmo) {
+    typedef std::pair<double, double> double_pair;
+    std::vector<double_pair> data_points;
     Int_t n_data = data.numEntries();
     Double_t s_data = data.sumEntries();
 
     const RooArgSet* datavals;
     RooRealVar* observable_val;
-
     for (int i = 0; i < n_data; i++) {
         datavals = data.get(i);
         observable_val = (RooRealVar*)(datavals->find(observable.GetName()));
-        data_points.push_back(double_pair(observable_val->getVal(), data.weight()));
+        data_points.push_back(std::make_pair(observable_val->getVal(), data.weight()));
     }
 
-    sort(data_points.begin(), data_points.end(), sort_pairs);
+    std::stable_sort(data_points.begin(), data_points.end(),
+         [](double_pair i, double_pair j) {
+           return i.first < j.first;
+         });
 
-    Double_t test_stat = 0.;
-    Double_t current_cdf_val = 0.;
-    Double_t last_cdf_val = 0.;
-    Double_t empirical_df = 0.;
-    Double_t observableval, bin_prob;
-    Double_t distance = 0.;
+    double test_stat = 0.;
+    double current_cdf_val = 0.;
+    double last_cdf_val = 0.;
+    double empirical_df = 0.;
+    double observableval = 0.;
+    double bin_prob = 0.;
+    double distance = 0.;
 
-    //CDF of the PDF
-    RooAbsReal* cdf;
+    // CDF of the PDF
+    // If RooFit needs to use the scanning technique then increase the number
+    // of sampled bins from 1000 to 10000
+    std::auto_ptr<RooAbsReal> cdf(pdf.createCdf(observable, RooFit::ScanParameters(10000, 2)));
 
-    // Declarations for the saveplot option
-    Int_t count=-1;
-    gStyle->SetOptStat(0);
-    gStyle->SetPadLeftMargin(0.14);
-    gStyle->SetPadBottomMargin(0.14);
-    TCanvas* c = new TCanvas("c","c",600,600);
-    TH1F* hcdf = new TH1F("cdf","",n_data-1,0,n_data-1);
-    TH1F* hedf = new TH1F("edf","",n_data-1,0,n_data-1);
-    TH1F* hcdif = new TH1F("cdif","",n_data-1,0,n_data-1);
-    TH1F* hpdif = new TH1F("pdif","",n_data-1,0,n_data-1);
-    TH1F* hADadd = new TH1F("ADadd","",n_data-1,0,n_data-1);
-    TH1F* hADtrend = new TH1F("ADtrend","",n_data-1,0,n_data-1);
-    TLegend* leg1 = new TLegend(0.14,0.91,0.9,1.0);
-    TLegend* leg2 = new TLegend(0.14,0.91,0.9,1.0);
-    TPad* pad1 = new TPad("pad1","pad1",0,0.22,1,0.98);
-    TPad* pad2 = new TPad("pad2","pad2",0,0.15,1,0.3);
-    TPad* pad3 = new TPad("pad3","pad3",0,0,1,0.15);
-
-    if (makeplot_){
-        pad1->SetFillStyle(4000);
-        pad1->Draw();
-        pad2->SetFillStyle(4000);
-        pad2->Draw();
-        pad3->SetFillStyle(4000);
-        pad3->Draw();
-        pad1->cd();
-
-        hcdf->SetMinimum(0);
-        hedf->SetMinimum(0);
-        leg1->AddEntry(hcdf,"Cumulative distribution function","l");
-        leg1->AddEntry(hedf,"Empirical distribution function","l");
-        leg1->SetTextSize(0.04);
-
-        hcdif->SetOption("P0");
-        hcdif->SetMarkerStyle(20);
-        hcdif->SetMarkerSize(1);
-        hcdif->SetYTitle("CDF-EDF");
-        hcdif->GetYaxis()->SetTitleSize(0.20);
-        hcdif->GetYaxis()->SetTitleOffset(0.25);
-        hcdif->GetYaxis()->SetNdivisions(306);
-        hcdif->GetYaxis()->SetLabelSize(0.15);
-        hcdif->GetXaxis()->SetLabelSize(0.15);
-
-        hpdif->SetOption("P0");
-        hpdif->SetMarkerStyle(20);
-        hpdif->SetMarkerSize(1);
-        hpdif->SetYTitle("Data/MC");
-        hpdif->GetYaxis()->SetTitleSize(0.20);
-        hpdif->GetYaxis()->SetTitleOffset(0.25);
-        hpdif->GetYaxis()->SetNdivisions(306);
-        hpdif->GetYaxis()->SetLabelSize(0.15);
-        hpdif->GetXaxis()->SetLabelSize(0.15);
-
-        hADadd->SetMinimum(0);
-        hADtrend->SetMinimum(0);
-        leg2->AddEntry(hADadd,"Gets added to the test statistic","l");
-        leg2->AddEntry(hADtrend,"Trend of the test statistic","l");
-        leg2->SetTextSize(0.04);
+    TH1 * hCdf = nullptr;
+    TH1 * hEdf = nullptr;
+    TH1 * hDiff = nullptr;
+    if (plotDir_ && makePlots_) {
+      hCdf = observable.createHistogram("cdf");
+      hEdf = observable.createHistogram("edf");
+      hDiff = observable.createHistogram("diff");
+      hCdf->SetName((std::string(data.GetName())+"_cdf").c_str());
+      hEdf->SetName((std::string(data.GetName())+"_edf").c_str());
+      hDiff->SetName((std::string(data.GetName())+"_diff").c_str());
     }
 
-    for(std::vector<double_pair>::const_iterator d = data_points.begin(); d != data_points.end()-1; d++) {
-        observableval = ((d+1)->first + d->first)/2.; // d->first is middle of bin, want upper edge.
+    int bin = 0;
+    for (std::vector<double_pair>::const_iterator d = data_points.begin();
+         d != data_points.end() - 1; d++, ++bin) {
+        // observableval = ((d+1)->first + d->first)/2.; // d->first is middle of bin, want upper edge.
+      
+        // This is a better way to get the upper bin edge in the case where we
+        // have variable bin widths (I hope)
+        observableval = observable.getBinning().binHigh(
+            observable.getBinning().binNumber(d->first));
         observable.setVal(observableval);
-        cdf = pdf.createCdf(observable, RooFit::ScanAllCdf());
+        // observable.bin
         current_cdf_val = cdf->getVal();
         empirical_df += d->second/s_data;
 
-        count++;
-        hcdif->Fill(count,current_cdf_val-empirical_df);
-        hpdif->Fill(count,(d->second/s_data)/(current_cdf_val-last_cdf_val));
+        if (plotDir_ && makePlots_) {
+          hCdf->SetBinContent(bin+1, current_cdf_val);
+          hEdf->SetBinContent(bin+1, empirical_df);
+        }
 
         if (kolmo){
             distance = std::abs(empirical_df-current_cdf_val);
-            hcdf->Fill(count,current_cdf_val);
-            hedf->Fill(count,empirical_df);
+            if (verbose >= 3) {
+              std::cout << "Observable: " << observableval << "\tdata: " << d->second << "\tedf: " << empirical_df << "\tcdf: " << current_cdf_val << "\tdistance: " << distance << "\n";
+            }
             if (distance > test_stat) test_stat = distance;
         }else{
             bin_prob = current_cdf_val-last_cdf_val;
+            distance = s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob;
+            if (verbose >= 3) {
+              std::cout << "Observable: " << observableval << "\tdata: " << d->second << "\tedf: " << empirical_df << "\tcdf: " << current_cdf_val << "\tdistance: " << distance << "\n";
+            }
             // from L. Demortier, CDF/ANAL/JET/CDFR/3419
-            test_stat += s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob;
-            hADadd->Fill(count,s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob);
-            hADtrend->Fill(count,test_stat);
+            test_stat += distance;
         }
+        if (plotDir_ && makePlots_) {
+          hDiff->SetBinContent(bin+1, distance);
+        }
+
         last_cdf_val = current_cdf_val;
-
-        if (last_cdf_val >= 1.0)
-            break;
     }
 
-    if(makeplot_){
-        if (hcdif->GetMaximum() > std::abs(hcdif->GetMinimum())){
-            hcdif->SetMinimum(-1.0*(hcdif->GetMaximum()));//hcdif->GetYaxis()->SetRange(-1.05*(hcdif->GetMaximum()),1.05*(hcdif->GetMaximum()));//
-        }else{
-            hcdif->SetMaximum(-1.0*(hcdif->GetMinimum()));//hcdif->GetYaxis()->SetRange(1.05*(hcdif->GetMinimum()),-1.05*(hcdif->GetMinimum()));//
-        }
-        if ((hpdif->GetMaximum())-1 > 1-(hpdif->GetMinimum())){
-            hpdif->SetMinimum(2-(hpdif->GetMaximum()));//hpdif->GetYaxis()->SetRange(-1.05*(hpdif->GetMaximum())+2,1.05*(hpdif->GetMaximum()));//
-        }else{
-            hpdif->SetMaximum(2-(hpdif->GetMinimum()));//hpdif->GetYaxis()->SetRange(1.05*(hpdif->GetMinimum()),-1.05*(hpdif->GetMinimum())+2);//
-        }
-
-        if (kolmo){
-            hcdf->Draw();
-            hedf->SetLineColor(kRed);
-            hedf->Draw("sames");
-            leg1->Draw();
-        }else{
-            hADtrend->Draw();
-            hADadd->SetLineColor(kRed);
-            hADadd->Draw("sames");
-            leg2->Draw();
-        }
-        pad2->cd();
-        gPad->SetGridy();
-        hcdif->Draw();
-        pad3->cd();
-        gPad->SetGridy();
-        hpdif->Draw();
-
-        Int_t filecount=0;
-        std::string filename;
-        std::fstream ifile;
-        do{
-            if (ifile != 0) ifile.close();
-            filecount++;
-            filename = "Gof_plot_"+std::to_string(filecount)+".png";
-            ifile.open(filename);
-        }while(ifile != 0);
-        ifile.close();
-        TString tfilename=filename;
-        c->SaveAs(tfilename);
+    if (plotDir_ && makePlots_) {
+      plotDir_->WriteTObject(hCdf);
+      plotDir_->WriteTObject(hEdf);
+      plotDir_->WriteTObject(hDiff);
+      delete hCdf;
+      delete hEdf;
+      delete hDiff;
     }
 
-    delete c;
-    delete hcdf;
-    delete hedf;
-    delete hcdif;
-    delete hpdif;
-    delete hADadd;
-    delete hADtrend;
-
-    if (kolmo){
-        if (test_stat < oldlimit) test_stat = oldlimit; // The test statistic of the Kolmogorov-Smirnov test is the maximum of the test statistics of all individual PDFs.
-    }else{
-        test_stat += oldlimit; // The test statistic of the Anderson-Darling test is the sum of the test statistics of all individual PDFs.
-    }
+    // if (kolmo){
+    //     if (test_stat < oldlimit) test_stat = oldlimit; // The test statistic of the Kolmogorov-Smirnov test is the maximum of the test statistics of all individual PDFs.
+    // }else{
+    //     test_stat += oldlimit; // The test statistic of the Anderson-Darling test is the sum of the test statistics of all individual PDFs.
+    // }
     return test_stat;
 }
 

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -285,7 +285,7 @@ Double_t GoodnessOfFit::EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, Roo
 
     int bin = 0;
     for (std::vector<double_pair>::const_iterator d = data_points.begin();
-         d != data_points.end() - 1; d++, ++bin) {
+         d != data_points.end(); d++, ++bin) {
         // observableval = ((d+1)->first + d->first)/2.; // d->first is middle of bin, want upper edge.
       
         // This is a better way to get the upper bin edge in the case where we
@@ -311,6 +311,9 @@ Double_t GoodnessOfFit::EvaluateADDistance(RooAbsPdf& pdf, RooAbsData& data, Roo
         }else{
             bin_prob = current_cdf_val-last_cdf_val;
             distance = s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob;
+            if (current_cdf_val >= 1.0) {
+              distance = 0.;
+            }
             if (verbose >= 3) {
               std::cout << "Observable: " << observableval << "\tdata: " << d->second << "\tedf: " << empirical_df << "\tcdf: " << current_cdf_val << "\tdistance: " << distance << "\n";
             }

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -9,7 +9,6 @@
 #include <RooSimultaneous.h>
 #include <RooAddPdf.h>
 #include <RooConstVar.h>
-#include <RooDataSet.h>
 #include <RooDataHist.h>
 #include <RooHistPdf.h>
 #include <TCanvas.h>
@@ -17,6 +16,8 @@
 #include <TH2.h>
 #include <TFile.h>
 #include <RooStats/ModelConfig.h>
+#include "RooStats/RooStatsUtils.h"
+#include "RooCategory.h"
 #include "../interface/Combine.h"
 #include "../interface/ProfileLikelihood.h"
 #include "../interface/CloseCoutSentry.h"
@@ -34,16 +35,18 @@ float       GoodnessOfFit::minimizerTolerance_ = 1e-4;
 int         GoodnessOfFit::minimizerStrategy_  = 1;
 float       GoodnessOfFit::mu_ = 0.0;
 bool        GoodnessOfFit::fixedMu_ = false;
+bool        GoodnessOfFit::nofit_ = false;
 
 GoodnessOfFit::GoodnessOfFit() :
     LimitAlgo("GoodnessOfFit specific options")
 {
     options_.add_options()
-        ("algorithm",          boost::program_options::value<std::string>(&algo_), "Goodness of fit algorithm. Currently, the only option is 'saturated' (which works for binned models only)")
+        ("algorithm",          boost::program_options::value<std::string>(&algo_), "Goodness of fit algorithm. Supported algorithms are 'saturated', 'kolmogorovsmirnov' and 'andersondarling'.")
         ("minimizerAlgo",      boost::program_options::value<std::string>(&minimizerAlgo_)->default_value(minimizerAlgo_), "Choice of minimizer (Minuit vs Minuit2)")
         ("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
         ("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
         ("fixedSignalStrength", boost::program_options::value<float>(&mu_)->default_value(mu_),  "Compute the goodness of fit for a fixed signal strength. If not specified, it's left floating")
+        ("nofit", boost::program_options::value<bool>(&nofit_)->default_value(nofit_),  "Don't take the NLL values directly from the fits (for saturated model)")
     ;
 }
 
@@ -51,6 +54,8 @@ void GoodnessOfFit::applyOptions(const boost::program_options::variables_map &vm
 {
     fixedMu_ = !vm["fixedSignalStrength"].defaulted();
     if (algo_ == "saturated") std::cout << "Will use saturated models to compute goodness of fit for a binned likelihood" << std::endl;
+    else if (algo_ == "andersondarling") std::cout << "Will use the Anderson-Darling test to compute goodness of fit for a binned likelihood" << std::endl;
+else if (algo_ == "kolmogorovsmirnov") std::cout << "Will use the Kolmogorov-Smirnov test to compute goodness of fit for a binned likelihood" << std::endl;
     else throw std::invalid_argument("GoodnessOfFit: algorithm "+algo_+" not supported");
 }
 
@@ -60,6 +65,8 @@ bool GoodnessOfFit::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
   RooRealVar *r = dynamic_cast<RooRealVar *>(mc_s->GetParametersOfInterest()->first());
   if (fixedMu_) { r->setVal(mu_); r->setConstant(true); }
   if (algo_ == "saturated") return runSaturatedModel(w, mc_s, mc_b, data, limit, limitErr, hint);
+  if (algo_ == "andersondarling") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 0);
+  if (algo_ == "kolmogorovsmirnov") return runAndeDarlKolmSmir(w, mc_s, mc_b, data, limit, limitErr, hint, 1);
   return false;  
 }
 
@@ -108,6 +115,8 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
       saturated.reset(saturatedPdfi);
   }
 
+  double nll_nominal, nll_saturated;
+
   CloseCoutSentry sentry(verbose < 2);
   // let's assume fits converge, for a while
   const RooCmdArg &minim = RooFit::Minimizer(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str(),
@@ -116,21 +125,158 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
   std::auto_ptr<RooFitResult> result_saturated(saturated->fitTo(data, RooFit::Save(1), minim, RooFit::Strategy(minimizerStrategy_), RooFit::Hesse(0), RooFit::Constrain(*mc_s->GetNuisanceParameters())));
   sentry.clear();
 
+  if(nofit_){
+    std::auto_ptr<RooAbsReal> nominal_nll(pdf_nominal->createNLL(data, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
+    std::auto_ptr<RooAbsReal> saturated_nll(saturated->createNLL(data, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
+    //if (nominal_nll.get()   == 0 or saturated_nll.get() == 0) return false;
+    nll_nominal = nominal_nll->getVal();
+    nll_saturated = saturated_nll->getVal();
+  }else{
+    if (result_nominal.get()   == 0 or result_saturated.get() == 0) return false;
+    nll_nominal   = result_nominal->minNll();
+    nll_saturated = result_saturated->minNll();
+  }
+
   saturated.reset();
   for (int i = 0, n = tempData_.size(); i < n; ++i) delete tempData_[i]; 
   tempData_.clear();
 
-  if (result_nominal.get()   == 0) return false;
-  if (result_saturated.get() == 0) return false;
-
-  double nll_nominal   = result_nominal->minNll();
-  double nll_saturated = result_saturated->minNll();
   if (fabs(nll_nominal) > 1e10 || fabs(nll_saturated) > 1e10) return false;
   limit = 2*(nll_nominal-nll_saturated);
 
   std::cout << "\n --- GoodnessOfFit --- " << std::endl;
   std::cout << "Best fit test statistic: " << limit << std::endl;
   return true;
+}
+
+// Code for the Anderson-Darling test originates from https://gist.github.com/neggert/4586791
+bool GoodnessOfFit::runAndeDarlKolmSmir(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo) { 
+   /*
+  Find the Anderson-Darling difference between fPdf and the data. This is just
+  the maximum over data points of the distance between the CDF and the emprical
+  distribution function of the data.
+  */
+
+  const RooArgSet * POI = mc_s->GetParametersOfInterest();
+  RooRealVar* poi = dynamic_cast<RooRealVar*>(POI->first());
+  RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
+  RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
+
+  // Set POI constant so the fit doesn't adjust them
+  // RooRealVar* param;
+  // TIterator *param_iter = params.createIterator();
+  // while (1) {
+  //     param = dynamic_cast<RooRealVar*>(param_iter->Next());
+  //     if (!param) break;
+  //     param->setConstant(kTRUE);
+  // }
+
+  //First, find the best fit values
+  RooAbsPdf *fPdf = mc_s->GetPdf();
+  RooArgSet* pdfParams = fPdf->getParameters(data);
+  RooRealVar* pdfPOI= dynamic_cast<RooRealVar*>(pdfParams->find(poi->GetName()));
+  pdfPOI->setVal(poi->getVal());
+  pdfPOI->setConstant();
+  RemoveConstantParameters(pdfParams);
+  fPdf->fitTo(data, RooFit::Constrain(*pdfParams), RooFit::PrintLevel(-1), RooFit::Verbose(kFALSE));
+
+  // unet POI constant so the fit doesn't adjust them
+  // param_iter = params.createIterator();
+  // while (1) {
+  //     param = dynamic_cast<RooRealVar*>(param_iter->Next());
+  //     if (!param) break;
+  //     param->setConstant(kFALSE);
+  // }
+
+  limit = 0;
+  RooSimultaneous *sim = dynamic_cast<RooSimultaneous *>(fPdf);
+
+  // now check if we have categories to deal with
+  if (sim) {
+      const RooCategory* cat = dynamic_cast<const RooCategory*>(&(sim->indexCat()));
+      // split the data
+      TList* datasets = data.split(*cat);
+      Int_t num_cats = datasets->GetEntries();
+      for(Int_t i= 0; i < num_cats; i++) {
+          // set to current category
+          const Text_t* cat_name = cat->lookupType(i)->GetName();
+          RooAbsData *cat_data = dynamic_cast<RooAbsData*>(datasets->At(i));
+          RooAbsPdf *cat_pdf = sim->getPdf(cat_name);
+          RooArgSet* observables = cat_pdf->getObservables(cat_data);
+          RooRealVar* x = dynamic_cast<RooRealVar*>(observables->first());
+          limit = EvaluateADDistance(*cat_pdf, *cat_data, *x, limit, kolmo);
+      }
+  } else {
+      RooRealVar* obs = dynamic_cast<RooRealVar*>(fPdf->getObservables(data)->first());
+      limit = EvaluateADDistance(*fPdf, data, *obs, limit, kolmo);
+  }
+
+  std::cout << "\n --- GoodnessOfFit --- " << std::endl;
+  if(kolmo){
+      std::cout << "Kolmogorov-Smirlov test statistic: " << limit << std::endl;
+  }else{
+      std::cout << "Anderson-Darling test statistic: " << limit << std::endl;
+  }
+
+  RooMsgService::instance().setGlobalKillBelow(msglevel);
+  return true;
+}
+
+
+typedef std::pair<Double_t, Double_t> double_pair;
+
+bool sort_pairs (double_pair i, double_pair j) {return (i.first < j.first);}
+
+Double_t GoodnessOfFit::EvaluateADDistance( RooAbsPdf& pdf, RooAbsData& data, RooRealVar& observable, double& limit, bool kolmo) {
+
+    std::vector<double_pair > data_points;
+    Int_t n_data = data.numEntries();
+    Double_t s_data = data.sumEntries();
+
+    const RooArgSet* datavals;
+    RooRealVar* observable_val;
+
+    for (int i = 0; i < n_data; i++) {
+        datavals = data.get(i);
+        observable_val = (RooRealVar*)(datavals->find(observable.GetName()));
+        data_points.push_back(double_pair(observable_val->getVal(), data.weight()));
+    }
+
+    sort(data_points.begin(), data_points.end(), sort_pairs);
+
+    Double_t test_stat = 0.;
+    Double_t current_cdf_val = 0.;
+    Double_t last_cdf_val = 0.;
+    Double_t empirical_df = 0.;
+    Double_t observableval, bin_prob;
+    Double_t distance = 0.;
+
+    //CDF of the PDF
+    RooAbsReal* cdf;
+
+    for(std::vector<double_pair>::const_iterator d = data_points.begin(); d != data_points.end()-1; d++) {
+        observableval = ((d+1)->first + d->first)/2.; // d->first is middle of bin, want upper edge.
+        observable.setVal(observableval);
+        cdf = pdf.createCdf(observable, RooFit::ScanAllCdf());
+        current_cdf_val = cdf->getVal();
+        empirical_df += d->second/s_data;
+
+        if (current_cdf_val >= 1.0)
+            break;
+
+        if (kolmo){
+            distance = std::abs(empirical_df-current_cdf_val);
+            if (distance > test_stat) test_stat = distance;
+        }else{
+            bin_prob = current_cdf_val-last_cdf_val;
+            // from L. Demortier, CDF/ANAL/JET/CDFR/3419
+            test_stat += s_data*pow((empirical_df-current_cdf_val), 2)/current_cdf_val/(1.-current_cdf_val)*bin_prob;
+            last_cdf_val = current_cdf_val;
+        }
+    }
+
+    if (kolmo == 0) test_stat += limit;
+    return test_stat;
 }
 
 RooAbsPdf * GoodnessOfFit::makeSaturatedPdf(RooAbsData &data) {


### PR DESCRIPTION
Work done by Dennis Roy (KIT, @DennRoy) as part of his masters project.

Only makes sense for 1D analyses, and currently only supports models with binned data. For models with multiple categories will save the test statistic for each category in a branch in the limit tree, and there's an option for saving TH1s of the EDF, CDF and the distance measures of both algos to visualise where any disagreement is coming from.