### PR TITLE
Add "impact" algo to MultiDimFit

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -24,7 +24,7 @@ public:
 protected:
   virtual bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
 
-  enum Algo { None, Singles, Cross, Grid, RandomPoints, Contour2D, Stitch2D, FixedPoint };
+  enum Algo { None, Singles, Cross, Grid, RandomPoints, Contour2D, Stitch2D, FixedPoint, Impact };
   static Algo algo_;
 
   enum GridType { G1x1, G3x3 };
@@ -72,6 +72,7 @@ protected:
   void doFixedPoint(RooWorkspace *w,RooAbsReal &nll) ;
   void doContour2D(RooAbsReal &nll) ;
   void doStitch2D(RooAbsReal &nll) ;
+  void doImpact(RooFitResult &res, RooAbsReal &nll) ;
 
   // utilities
   /// for each RooRealVar, set a range 'box' from the PL profiling all other parameters

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -101,6 +101,8 @@ void MultiDimFit::applyOptions(const boost::program_options::variables_map &vm)
         algo_ = Stitch2D;
     } else if (algo == "impact") {
         algo_ = Impact;
+        if (vm["floatOtherPOIs"].defaulted()) floatOtherPOIs_ = true;
+        if (vm["saveInactivePOI"].defaulted()) saveInactivePOI_ = true;
     } else throw std::invalid_argument(std::string("Unknown algorithm: "+algo));
     fastScan_ = (vm.count("fastScan") > 0);
     squareDistPoiStep_ = (vm.count("squareDistPoiStep") > 0);


### PR DESCRIPTION
Uses the same machinery as "singles" to determine the range on some NP
specified with -P [NP]. Then performs two further fits at the +/- 1
sigma bounds to determine shift in POI values. Only makes sense to run
this mode with --saveInactivePOI 1 and --floatOtherPOIs 1.

Better than the previous implementation as it doesn't touch any of the FitterAlgoBase code or the other MultiDimFit methods. 

@nucleosynthesis: regarding the issue with the removed bounds when -P is a NP, I found I needed to explicitly put the range back in `MultiDimFit::initOnce` since `FitterAlgoBase::optimizeBounds` has already run before this.