### PR TITLE
Adjust behaviour of --expectSignal in asimov gen.

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -61,6 +61,7 @@ private:
   bool toysNoSystematics_;
   bool toysFrequentist_;
   float expectSignal_;
+  bool expectSignalSet_;  // keep track of whether or not expectSignal was defaulted
   float expectSignalMass_;
   std::string redefineSignalPOIs_;
   std::string freezeNuisances_;


### PR DESCRIPTION
 - Fixes the issue where the default value of r, `0.5*(r->getMin() +
   r->getMax())`, would persist to the toy generation step in certain
   cases. Now r is always set to the value of expectSignal when nToys !=
   0.
 - Prints a warning if the expectSignal option is used but the model
   doesn't contain the POI r
 - When generating frequntist toys in models without r, or where r is
   not first in the list of POIs, the first POI is no longer fixed to
   the value of expectSignal