### PR TITLE
Adding global flag to combine for Tree Fill

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -13,7 +13,8 @@ class RooWorkspace;
 class RooAbsData;
 namespace RooStats { class ModelConfig; }
 
-extern Float_t t_cpu_, t_real_, g_quantileExpected_;
+extern Float_t t_cpu_, t_real_, g_quantileExpected_; 
+extern bool g_fillTree_; 
 //RooWorkspace *writeToysHere = 0;
 extern TDirectory *outputFile;
 extern TDirectory *writeToysHere;
@@ -39,6 +40,9 @@ public:
   
   void run(TString hlfFile, const std::string &dataset, double &limit, double &limitErr, int &iToy, TTree *tree, int nToys);
  
+  /// Stop combine from fillint the tree (some algos need control)
+  static void toggleGlobalFillTree(bool flag=false);
+
   /// Save a point into the output tree. Usually if expected = false, quantile should be set to -1 (except e.g. for saveGrid option of HybridNew)
   static void commitPoint(bool expected, float quantile);
 

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -75,6 +75,7 @@ bool doSignificance_ = 0;
 bool lowerLimit_ = 0;
 float cl = 0.95;
 bool bypassFrequentistFit_ = false;
+bool g_fillTree_ = true;
 TTree *Combine::tree_ = 0;
 
 std::string setPhysicsModelParameterExpression_ = "";
@@ -651,7 +652,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     std::cout << "Computing limit starting from " << (iToy == 0 ? "observation" : "expected outcome") << std::endl;
     if (MH) MH->setVal(mass_);    
     if (verbose > (isExtended ? 3 : 2)) utils::printRAD(dobs);
-    if (mklimit(w,mc,mc_bonly,*dobs,limit,limitErr)) tree->Fill();
+    if (mklimit(w,mc,mc_bonly,*dobs,limit,limitErr)) commitPoint(0,g_quantileExpected_); //tree->Fill();
   }
   
   std::vector<double> limitHistory;
@@ -731,7 +732,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       w->loadSnapshot("clean");
       //if (verbose > 1) utils::printPdf(w, "model_b");
       if (mklimit(w,mc,mc_bonly,*absdata_toy,limit,limitErr)) {
-	tree->Fill();
+	commitPoint(0,g_quantileExpected_);//tree->Fill();
 	++nLimits;
 	expLimit += limit; 
         limitHistory.push_back(limit);
@@ -774,10 +775,14 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 
 }
 
+void Combine::toggleGlobalFillTree(bool flag){
+   g_fillTree_ = flag;
+}
+
 void Combine::commitPoint(bool expected, float quantile) {
     Float_t saveQuantile =  g_quantileExpected_;
     g_quantileExpected_ = quantile;
-    tree_->Fill();
+    if (g_fillTree_) tree_->Fill();
     g_quantileExpected_ = saveQuantile;
 }
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -157,7 +157,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
 		specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
 	}
-	Combine::commitPoint(/*expected=*/false, /*quantile=*/1.); // otherwise we get it multiple times
+	Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
 	//}
     }
    

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -112,6 +112,8 @@ void MultiDimFit::applyOptions(const boost::program_options::variables_map &vm)
 
 bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
     // one-time initialization of POI variables, TTree branches, ...
+    Combine::toggleGlobalFillTree(true);
+
     static int isInit = false;
     if (!isInit) { initOnce(w, mc_s); isInit = true; }
 
@@ -192,10 +194,14 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
         case Impact: if (res.get()) doImpact(*res, *nll); break;
     }
     
+    Combine::toggleGlobalFillTree(false);
     return true;
 }
 
 void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
+
+    // Tell combine not to Fill its tree, we'll do it here;
+
     RooArgSet mcPoi(*mc_s->GetParametersOfInterest());
     if (poi_.empty()) {
         RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();


### PR DESCRIPTION
Avoids the Algo and Combine both calling Fill() and therefore
duplicating the entries in the tree.

@adavidzh , currenly only MultiDimFit toggles this flag, can you check that this will not disrupt any desired behaviour?