### PR TITLE
Fix some issues with toy-gen /fitting

### DIFF
--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -136,7 +136,7 @@ def getHiggsProdDecMode(bin,process,options):
     if not foundDecay: raise RuntimeError, "Validation Error: decay string %s does not contain any known decay name" % decaySource
     #
     foundEnergy = None
-    for D in [ '7TeV', '8TeV', '13TeV, '14TeV' ]:
+    for D in [ '7TeV', '8TeV', '13TeV', '14TeV' ]:
         if D in decaySource:
             if foundEnergy: raise RuntimeError, "Validation Error: decay string %s contains multiple known energies" % decaySource
             foundEnergy = D

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -344,8 +344,9 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (w->genobj("discreteParams")) allParams.add(*(RooArgSet*)w->genobj("discreteParams"));
       utils::setModelParameters( setPhysicsModelParameterExpression_, allParams);
       // also allow for "discrete" parameters to be set 
+      // Possible that MH value was re-set above, so make sure mass is set to the correct value and not over-ridden later.
+      if (w->var("MH")) mass_ = w->var("MH")->getVal();
   }
-
 
   } else {
     hlf.reset(new RooStats::HLFactory("factory", fileToLoad));
@@ -487,6 +488,12 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           }
       } 
   }
+  // Always reset the POIs to floating (post-fit workspaces can actually have them frozen in some cases, in any case they can be re-frozen in the next step 
+  TIterator *pois = POI->createIterator();
+  while (RooRealVar *arg = (RooRealVar*)pois->Next()) {
+      arg->setConstant(0);
+  }
+  
   if (freezeNuisances_ != "") {
       RooArgSet toFreeze((freezeNuisances_=="all")?*nuisances:(w->argSet(freezeNuisances_.c_str())));
       if (verbose > 0) std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print("");


### PR DESCRIPTION
1) Fixed an issue where making a post-fit workspace with --freezeNuisances on POI  will keep them frozen
2) Fixed issue where -m will overwrite --setPhysicsModelParameters MH=X, even when -m is just defaulted (fixes #98)
3) also fixed small issue in PhysicsModel with 13TeV string