### PR TITLE
Abort if PDF is missing

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -583,6 +583,12 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   
   tree_ = tree;
 
+  // Should have the PDF at this point, if not something is really odd?
+  if (!genPdf){
+	std::cerr << " FATAL ERROR! PDF not found in ModelConfig (this could be due to having no systematics and running -M MaxLikelihood). \n Try to build the workspace first with text2workspace.py and run with the binary output." << std::endl;
+	assert(0);
+  }
+
   bool isExtended = mc->GetPdf()->canBeExtended();
   RooRealVar *MH = w->var("MH");
   RooAbsData *dobs = w->data(dataset.c_str());


### PR DESCRIPTION
Very odd occurance of a seg-fault with -M MaxLikelihoodFit and no
systematics. Appears that the PDF is missing from the ModelConfig

Now the code will abort with a suggestion rather than seg fault but this
is not a solution