### PR TITLE
Add support for external files for rate params

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -54,11 +54,15 @@ def isIncluded(name,includeList):
 def addRateParam(lsyst,f,ret):
 
     if len(f) > 6 or len(f) < 5: raise RuntimeError, "Error, directives of type 'rateParam' should be of form .. name rateParam channel process initial value OR name rateParam channel process formula args"
-
-    if len(f)==5  : tmp_exp = [[lsyst,f[4],0],""]    # Case for free parameter with no range
+    if len(f)==5  :
+        if ".root" in f[4] and ":" in f[4]: ty = 2
+	else: ty=0
+    	tmp_exp = [[lsyst,f[4],ty],""]    # Case for free parameter with no range
     elif len(f)==6: 
     	if '[' in f[-1] and ']' in f[-1]: tmp_exp = [[lsyst,f[4],0],f[-1]]
     	else: tmp_exp = [[lsyst,f[4],f[5],1],""]
+    # check for malformed bin/process 
+    if f[2] not in ret.bins or f[3] not in ret.processes: raise RuntimeError, " No such channel/process '%s/%s', malformed line:\n   %s" % (f[2],f[3], ' '.join(f))
     if ("%sAND%s"%(f[2],f[3])) in ret.rateParams.keys(): ret.rateParams["%sAND%s"%(f[2],f[3])].append(tmp_exp)
     else: ret.rateParams["%sAND%s"%(f[2],f[3])] = [tmp_exp]
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -97,6 +97,23 @@ class ModelBuilder(ModelBuilderBase):
                 print "Wrote GraphVizTree of model_s to ",self.options.out+".dot"
 
     def doRateParams(self):
+
+    	# First support external functions/parameters 
+	for rp in self.DC.rateParams.keys():
+	 for rk in range(len(self.DC.rateParams[rp])):
+	  type = self.DC.rateParams[rp][rk][0][-1]
+	  if type!=2: continue
+	  argu,argv = self.DC.rateParams[rp][rk][0][0],self.DC.rateParams[rp][rk][0][1]
+	  if self.out.arg(argu): continue
+	  fin,wsn = argv.split(":")
+	  try:
+	    fitmp = ROOT.TFile.Open(fin)
+	    wstmp = fitmp.Get(wsn)
+	    self.out._import(wstmp.arg(argu))
+	    fitmp.Close()
+	  except: 
+	    raise RuntimeError, "No File '%s' found for rateParam, or workspace '%s' not in file "%(fin,wsn)
+
 	# First do independant parameters, then expressions
 	for rp in self.DC.rateParams.keys():
 	 for rk in range(len(self.DC.rateParams[rp])):


### PR DESCRIPTION
new rate parameter directive supported to use multiplicative factors from external sources
`name rateParam channel process file.root:wspace`

RooFit object `name` will be imported from `wspace` and applied as rateParam. Useful for
parameteric signal cross-sections built from Splines.