### PR TITLE
Add Skip Initial fit option,

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -41,6 +41,7 @@ protected:
   static unsigned int points_, firstPoint_, lastPoint_;
   static bool floatOtherPOIs_;
   static bool squareDistPoiStep_;
+  static bool skipInitialFit_;
   static bool fastScan_;
   static bool hasMaxDeltaNLLForProf_;
   static bool loadedSnapshot_;


### PR DESCRIPTION
It seems the only reason not to do the first initial fit in MultiDimFit would be for running "algo grid" on the dataset "data_obs" after loading a snapshot 
Even algo grid on toys would need this first fit. PR would change [this line](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/slc6-root5.34.17/src/MultiDimFit.cc#L135)  to 
```
if ( ! skipInitialFit ){ 
...
```
and add the option  --skipInitialFit to save time where necessary 

can @ajgilbert  and @adavidzh confirm this is ok ?