### PR TITLE
Possible to mask channels in NLL evaluation

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -163,6 +163,7 @@ class CachingSimNLL  : public RooAbsReal {
         void setZeroPoint() ; 
         void clearZeroPoint() ;
         static void forceUnoptimizedConstraints() { optimizeContraints_ = false; }
+        void setChannelMasks(RooArgList const& args);
         friend class CachingAddNLL;
     private:
         void setup_();
@@ -183,6 +184,7 @@ class CachingSimNLL  : public RooAbsReal {
         static bool optimizeContraints_;
         std::vector<double> constrainZeroPoints_;
         std::vector<double> constrainZeroPointsFast_;
+        std::vector<RooAbsReal*> channelMasks_;
 };
 
 }

--- a/interface/RooSimultaneousOpt.h
+++ b/interface/RooSimultaneousOpt.h
@@ -10,15 +10,21 @@ class RooSimultaneousOpt : public RooSimultaneous {
 public:
 	RooSimultaneousOpt(){};
   RooSimultaneousOpt(const char* name, const char* title, RooAbsCategoryLValue& indexCat) :
-        RooSimultaneous(name, title, indexCat), _extraConstraints("extraConstraints", "Extra constraint terms independent on the category",this)  {}
+        RooSimultaneous(name, title, indexCat),
+        _extraConstraints("extraConstraints", "Extra constraint terms independent on the category",this),
+        _channelMasks("channelMasks", "Terms or expressions that mask particular channels", this)  {}
   RooSimultaneousOpt(const RooSimultaneous &any, const char* name=0) :
-        RooSimultaneous(any, name), _extraConstraints("extraConstraints", "Extra constraint terms independent on the category",this)  
+        RooSimultaneous(any, name),
+        _extraConstraints("extraConstraints", "Extra constraint terms independent on the category",this),
+        _channelMasks("channelMasks", "Terms or expressions that mask particular channels", this)
         {
             const RooSimultaneousOpt * opt = dynamic_cast<const RooSimultaneousOpt *>(&any);
             if (opt) _extraConstraints.add(opt->extraConstraints(), true);
         }
   RooSimultaneousOpt(const RooSimultaneousOpt &other, const char* name=0) :
-        RooSimultaneous(other, name), _extraConstraints("extraConstraints", this, other._extraConstraints)  {}
+        RooSimultaneous(other, name),
+        _extraConstraints("extraConstraints", this, other._extraConstraints),
+        _channelMasks("channelMasks", this, other._channelMasks)  {}
 
   virtual RooSimultaneousOpt *clone(const char* name=0) const { return new RooSimultaneousOpt(*this, name); }
 
@@ -27,13 +33,16 @@ public:
   virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) ;
 
   const RooArgList & extraConstraints() const { return _extraConstraints; }
+  const RooArgList & channelMasks() const { return _channelMasks; }
 
   void addExtraConstraint(const RooAbsPdf &pdf) ;
   void addExtraConstraints(const RooAbsCollection &pdfs) ;
+  void addChannelMasks(const RooArgList &args);
 private:
-  ClassDef(RooSimultaneousOpt,2) // Variant of RooSimultaneous that can put together binned and unbinned stuff 
+  ClassDef(RooSimultaneousOpt,3) // Variant of RooSimultaneous that can put together binned and unbinned stuff 
 
   RooListProxy _extraConstraints;  //  List of extra constraint terms
+  RooListProxy _channelMasks;
 
 };
 

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -20,6 +20,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("--no-optimize-pdfs",    dest="noOptimizePdf", default=False, action="store_true", help="Do not save the RooSimultaneous as RooSimultaneousOpt and Gaussian constraints as SimpleGaussianConstraint")
     parser.add_option("--optimize-simpdf-constraints",    dest="moreOptimizeSimPdf", default=False, action="store_true", help="Deeper optimization of RooSimultaneous: add the constraints only at the end (RooFit-incompatible!)")
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
+    parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")
     parser.add_option("--X-rescale-nuisance", dest="nuisancesToRescale", type="string", action="append", nargs=2, default=[], help="Rescale by this factor the nuisances that match these regular expressions (the rescaling is applied to the sigma of the gaussian constraint term).")

--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -35,6 +35,14 @@ class PhysicsModel:
     def getYieldScale(self,bin,process):
         "Return the name of a RooAbsReal to scale this yield by or the two special values 1 and 0 (don't scale, and set to zero)"
         return "r" if self.DC.isSignal[process] else 1;
+    def getChannelMask(self, bin):
+        "Return the name of a RooAbsReal to mask the given bin (args != 0 => masked)"
+        name = 'mask_%s' % bin
+        # Check that the mask expression does't exist already, it might do
+        # if it was already defined in the datacard
+        if not self.modelBuilder.out.arg(name):
+            self.modelBuilder.doVar('%s[0]' % name)
+        return name
     def done(self):
         "Called after creating the model, except for the ModelConfigs"
         pass

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -112,16 +112,16 @@ class ShapeBuilder(ModelBuilder):
         ## Contrary to Number-counting models, here each channel PDF already contains the nuisances
         ## So we just have to build the combined pdf
         if len(self.DC.bins) > 1 or not self.options.forceNonSimPdf:
-            maskList = ROOT.RooArgList()
-            for b in self.DC.bins:
-                maskList.add(self.out.arg(self.physics.getChannelMask(b)))
+            if self.options.doMasks:
+                maskList = ROOT.RooArgList()
+                for b in self.DC.bins:
+                    maskList.add(self.out.arg(self.physics.getChannelMask(b)))
             for (postfixIn,postfixOut) in [ ("","_s"), ("_bonly","_b") ]:
                 simPdf = ROOT.RooSimultaneous("model"+postfixOut, "model"+postfixOut, self.out.binCat) if self.options.noOptimizePdf else ROOT.RooSimultaneousOpt("model"+postfixOut, "model"+postfixOut, self.out.binCat)
                 for b in self.DC.bins:
                     pdfi = self.out.pdf("pdf_bin%s%s" % (b,postfixIn))
                     simPdf.addPdf(pdfi, b)
-                if not self.options.noOptimizePdf:
-                    # maskList.Print()
+                if (not self.options.noOptimizePdf) and self.options.doMasks:
                     simPdf.addChannelMasks(maskList)
                 if len(self.DC.systs) and (not self.options.noOptimizePdf) and self.options.moreOptimizeSimPdf:
                     simPdf.addExtraConstraints(self.out.nuisPdfs)

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -112,11 +112,17 @@ class ShapeBuilder(ModelBuilder):
         ## Contrary to Number-counting models, here each channel PDF already contains the nuisances
         ## So we just have to build the combined pdf
         if len(self.DC.bins) > 1 or not self.options.forceNonSimPdf:
+            maskList = ROOT.RooArgList()
+            for b in self.DC.bins:
+                maskList.add(self.out.arg(self.physics.getChannelMask(b)))
             for (postfixIn,postfixOut) in [ ("","_s"), ("_bonly","_b") ]:
                 simPdf = ROOT.RooSimultaneous("model"+postfixOut, "model"+postfixOut, self.out.binCat) if self.options.noOptimizePdf else ROOT.RooSimultaneousOpt("model"+postfixOut, "model"+postfixOut, self.out.binCat)
                 for b in self.DC.bins:
                     pdfi = self.out.pdf("pdf_bin%s%s" % (b,postfixIn))
                     simPdf.addPdf(pdfi, b)
+                if not self.options.noOptimizePdf:
+                    # maskList.Print()
+                    simPdf.addChannelMasks(maskList)
                 if len(self.DC.systs) and (not self.options.noOptimizePdf) and self.options.moreOptimizeSimPdf:
                     simPdf.addExtraConstraints(self.out.nuisPdfs)
                 if self.options.verbose:

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -596,6 +596,15 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	assert(0);
   }
 
+  // Print list of channel masks
+  if (verbose >= 2) {
+    RooSimultaneousOpt *simopt = dynamic_cast<RooSimultaneousOpt*>(mc->GetPdf());
+    if (simopt && simopt->channelMasks().getSize() > 0) {
+      std::cout << ">>> Channel masks:\n";
+      simopt->channelMasks().Print("v");
+    }
+  }
+
   bool isExtended = mc->GetPdf()->canBeExtended();
   RooRealVar *MH = w->var("MH");
   RooAbsData *dobs = w->data(dataset.c_str());

--- a/src/RooSimultaneousOpt.cc
+++ b/src/RooSimultaneousOpt.cc
@@ -8,7 +8,9 @@ RooSimultaneousOpt::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     RooCmdConfig pc(Form("RooSimultaneousOpt::createNLL(%s)",GetName())) ;
     pc.defineSet("cPars","Constrain",0,0);
     RooArgSet *cPars = pc.getSet("cPars");
-    return new cacheutils::CachingSimNLL(this, &data, cPars);
+    cacheutils::CachingSimNLL *nll =  new cacheutils::CachingSimNLL(this, &data, cPars);
+    nll->setChannelMasks(this->channelMasks());
+    return nll;
 }
 
 RooSimultaneousOpt::~RooSimultaneousOpt()
@@ -34,4 +36,15 @@ RooSimultaneousOpt::addExtraConstraints(const RooAbsCollection &pdfs)
             if (!_extraConstraints.contains(*a)) _extraConstraints.add(*a);
         }
     }
+}
+
+void
+RooSimultaneousOpt::addChannelMasks(const RooArgList &args)
+{
+    if (args.getSize() != indexCat().numTypes()) {
+        std::cerr << "RooSimultaneousOpt: number of channel masks must equal number of channels\n";
+        return;
+    }
+    _channelMasks.removeAll();
+    _channelMasks.add(args);
 }


### PR DESCRIPTION
 - CachingSimNLL can now be given a list of RooAbsReals (one for each
   component pdf) which cause the corresponding channel to be skipped in
   the NLL evaluation when the value is != 0.
 - RooSimultaneousOpt can also hold on to this RooArgList, and will hand
   it over to the CachingSimNLL in the createNLL step
 - These parameters can be defined by the user in the PhysicsModel via
   the new method getChannelMask(bin). By default a RooRealVar named
   `mask_[CHANNEL]` will be created with a value of zero and set
   constant.
 - The RooArgList is created and passed to RooSimultaneousOpt after the
   latter is created in ShapeTools.py
 - It is then possible to mask a channel at runtime with
   `--setPhysicsModelParameters mask_CHANNEL1=1,mask_CHANNEL2=1,...`

Only done basic testing of this so far with single fits in MultDimFit, but seems to work as intended: masking all but one channel gives identical results to just fitting a datacard with only that channel. But should check a wider range of cases to make sure there's no odd behaviour.

