### PR TITLE
Option for default frozen nuisances

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -69,6 +69,7 @@ private:
   float expectSignalMass_;
   std::string redefineSignalPOIs_;
   std::string freezeNuisances_;
+  std::string floatNuisances_;
   std::string freezeNuisanceGroups_;
   
   // input-output related variables

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -32,6 +32,8 @@ class Datacard():
         self.flatParamNuisances = {}
         self.rateParams = {}
         self.rateParamsOrder = [] # important to maintain order user puts in datacard
+        ## dirct of {name of uncert, boolean to indicate whether this nuisance is floating or not}
+        self.frozenNuisances = set()
 
     def list_of_bins(self) :
         """

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -175,7 +175,6 @@ class ModelBuilder(ModelBuilderBase):
         for cpar in self.DC.discretes: self.addDiscrete(cpar)
         for (n,nofloat,pdf,args,errline) in self.DC.systs: 
             if pdf == "lnN" or (pdf.startswith("shape") and pdf != 'shapeU'):
-            if pdf == "lnN" or pdf.startswith("shape"):
                 r = "-4,4" if pdf == "shape" else "-7,7"
                 sig = 1.0;
                 for pn,pf in self.options.nuisancesToRescale:

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -175,6 +175,7 @@ class ModelBuilder(ModelBuilderBase):
         for cpar in self.DC.discretes: self.addDiscrete(cpar)
         for (n,nofloat,pdf,args,errline) in self.DC.systs: 
             if pdf == "lnN" or (pdf.startswith("shape") and pdf != 'shapeU'):
+            if pdf == "lnN" or pdf.startswith("shape"):
                 r = "-4,4" if pdf == "shape" else "-7,7"
                 sig = 1.0;
                 for pn,pf in self.options.nuisancesToRescale:
@@ -311,7 +312,7 @@ class ModelBuilder(ModelBuilderBase):
                 #if self.options.optimizeBoundNuisances: self.out.var(n).setAttribute("optimizeBounds")
             else: raise RuntimeError, "Unsupported pdf %s" % pdf
             if nofloat: 
-              self.out.var("%s" % n).setAttribute("globalConstrained",True)
+              self.out.var(n).setAttribute("globalConstrained",True)
             # set an attribute related to the group(s) this nuisance belongs to
             if n in groupsFor:
                 groupNames = groupsFor[n]
@@ -320,6 +321,8 @@ class ModelBuilder(ModelBuilderBase):
                 for groupName in groupNames:
                     self.out.var(n).setAttribute('group_'+groupName,True)
             #self.out.var(n).Print('V')
+            if n in self.DC.frozenNuisances:
+                self.out.var(n).setConstant(True)
         if self.options.bin:
             nuisPdfs = ROOT.RooArgList()
             nuisVars = ROOT.RooArgSet()

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -198,6 +198,23 @@ def doSplitNuisance(datacard, args):
         else:
             sys.stderr.write("Warning2: nuisance edit split %s found nothing\n" % (args))
 
+def doFreezeNuisance(datacard, args):
+    if len(args) < 1:
+        raise RuntimeError, "Missing arguments: the syntax is: nuisance edit freeze name [ifexists] (name can be a pattern)"
+    pat = re.compile("^"+args[0]+"$")
+    opts = args[1:]
+    found = []
+    for lsyst,nofloat,pdf,args0,errline in datacard.systs:
+        if re.match(pat,lsyst):
+            datacard.frozenNuisances.add(lsyst)
+            found.append(lsyst)
+    if not found:
+        if "ifexists" not in opts:
+            raise RuntimeError, "Error: nuisance edit freeze %s found nothing" % args[0]
+        else:
+            sys.stderr.write("Warning2: nuisance edit freeze %s found nothing\n" % args[0])
+
+
 def doEditNuisance(datacard, command, args):
     if command == "add":
         doAddNuisance(datacard, args)
@@ -209,5 +226,7 @@ def doEditNuisance(datacard, command, args):
         doChangeNuisancePdf(datacard, args)
     elif command == "split":
         doSplitNuisance(datacard, args)
+    elif command == "freeze":
+        doFreezeNuisance(datacard, args)
     else:
         raise RuntimeError, "Error, unknown nuisance edit command %s (args %s)" % (command, args)

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -123,6 +123,7 @@ Combine::Combine() :
       ("validateModel,V", "Perform some sanity checks on the model and abort if they fail.")
       ("saveToys",   "Save results of toy MC in output file")
       ("floatAllNuisances", po::value<bool>(&floatAllNuisances_)->default_value(false), "Make all nuisance parameters floating")
+      ("floatNuisances", po::value<string>(&floatNuisances_)->default_value(""), "Set to floating these nuisance parameters (note freeze will take priority over float)")
       ("freezeAllGlobalObs", po::value<bool>(&freezeAllGlobalObs_)->default_value(true), "Make all global observables constant")
       ;
     miscOptions_.add_options()
@@ -493,6 +494,12 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   TIterator *pois = POI->createIterator();
   while (RooRealVar *arg = (RooRealVar*)pois->Next()) {
       arg->setConstant(0);
+  }
+
+  if (floatNuisances_ != "") {
+      RooArgSet toFloat((floatNuisances_=="all")?*nuisances:(w->argSet(floatNuisances_.c_str())));
+      if (verbose > 0) std::cout << "Set floating the following nuisance parameters: "; toFloat.Print("");
+      utils::setAllConstant(toFloat, false);
   }
   
   if (freezeNuisances_ != "") {

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -122,7 +122,7 @@ Combine::Combine() :
 
       ("validateModel,V", "Perform some sanity checks on the model and abort if they fail.")
       ("saveToys",   "Save results of toy MC in output file")
-      ("floatAllNuisances", po::value<bool>(&floatAllNuisances_)->default_value(true), "Make all nuisance parameters floating")
+      ("floatAllNuisances", po::value<bool>(&floatAllNuisances_)->default_value(false), "Make all nuisance parameters floating")
       ("freezeAllGlobalObs", po::value<bool>(&freezeAllGlobalObs_)->default_value(true), "Make all global observables constant")
       ;
     miscOptions_.add_options()


### PR DESCRIPTION
Nuisances can be set to frozen in Datacard using 
`nuisance edit freeze name_of_nuisance`

as in LHC couplings branch. User can also specify option in combine (`--floatNuisances`) to unfreeze nuisances which are frozen by default. This will be superseded by `--freezeNuisances` or `--freezeNuisanceGroups`