### PR TITLE
add covariance between bins for total shape

### DIFF
--- a/interface/MaxLikelihoodFit.h
+++ b/interface/MaxLikelihoodFit.h
@@ -38,6 +38,7 @@ protected:
   static std::string out_; 
   static bool        makePlots_;
   static float       rebinFactor_;
+  static int         numToysForShapes_;
   static std::string signalPdfNames_, backgroundPdfNames_;
   static bool        saveNormalizations_;
   static bool        oldNormNames_;

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -624,7 +624,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
             TH2 *covar2 = h->second;
             for (int b = 1, nb = covar2->GetNbinsX(); b <= nb; ++b) {
               for (int bj = 1, nbj = covar2->GetNbinsY(); bj <= nbj; ++bj) {    
-                h->second->SetBinContent(b,bj, std::sqrt(covar2->GetBinContent(b,bj)/ntoys));
+                h->second->SetBinContent(b,bj, (covar2->GetBinContent(b,bj)/ntoys));
 	      }
             }
 	}

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -517,6 +517,9 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
                     htot2->SetDirectory(0);
                     totByCh2[pair->second.channel] = htot2;
 		    TH2F *htot2covar = new TH2F("total_covar","Covariance signal+background",bins[i],0,bins[i],bins[i],0,bins[i]);
+		    htot2covar->GetXaxis()->SetTitle("Bin number");
+		    htot2covar->GetYaxis()->SetTitle("Bin number");
+		    htot2covar->GetZaxis()->SetTitle(Form("covar (%s)",hist->GetYaxis()->GetTitle()));
 		    htot2covar->SetDirectory(0);
 		    totByCh2Covar[pair->second.channel] = htot2covar; 
             } else {


### PR DESCRIPTION
Add covariance matrix to mlfit.root output for "total" shapes when running `--saveShapes --saveWithUncertainties` 

Covariance is between bins in the distributions, definition is the same as for the shapes themselves, i.e event count if shape is TH1 or /GeV (or whichever unit) if using RooDataHists. 

Also added option for number of toys to sample to calculate covariance (uncertainties), defaulted to 200 as before