### PR TITLE
count of floating parameters not based on Nuisances

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -765,7 +765,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     unsigned int nLimits = 0;
     w->loadSnapshot("clean");
     RooDataSet *systDs = 0;
-    if (withSystematics && !toysNoSystematics_ && (readToysFromHere == 0)) {
+    RooArgSet allFloatingParameters = w->allVars(); 
+    allFloatingParameters.remove(*mc->GetParametersOfInterest());
+    int nFloatingNonPoiParameters = utils::countFloating(allFloatingParameters); 
+    if (nFloatingNonPoiParameters && !toysNoSystematics_ && (readToysFromHere == 0)) {
       if (nuisances == 0) throw std::logic_error("Running with systematics enabled, but nuisances not defined.");
       nuisancePdf.reset(utils::makeNuisancePdf(expectSignal_ ||  setPhysicsModelParameterExpression_ != "" || noMCbonly_ ? *mc : *mc_bonly));
       if (toysFrequentist_) {


### PR DESCRIPTION
In cases (eg with rate/flat Params) post-fit toys would not be generated from correct place. 