### PR TITLE
Fix for segfault when running too many toys in one job

### DIFF
--- a/src/CloseCoutSentry.cc
+++ b/src/CloseCoutSentry.cc
@@ -56,7 +56,6 @@ void CloseCoutSentry::reallyClear()
         sprintf(buf, "/dev/fd/%d", fdErr_); freopen(buf, "w", stderr);
         open_   = true;
         owner_ = 0;
-        fdOut_ = fdErr_ = 0; 
     }
 }
 


### PR DESCRIPTION
This fixed the segfault, which is caused by having too many opened file-descriptors when running too many toys in one job (see #281 ).
With this change the file-descriptors for stdout and stderr are initialised once and reused afterwards. The previous behaviour was to get a new duplication of the current file-descriptors for stdout and stderr every time the CoutCentry was initialised. Currently I do not see any side-effect from reusing them. @gpetruc can you comment on if originally there was any concern when reusing the (not closed) file-descriptors which motivated getting new ones every time?