### PR TITLE
Fix for constraints not being dropped when redefining signal POI

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -483,6 +483,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(arg);
         if (rrv == 0) { std::cerr << "MultiDimFit: Parameter of interest " << arg->GetName() << " which is not a RooRealVar will be ignored" << std::endl; continue; }
 	arg->setConstant(0);
+	// also set ignoreConstraint flag for constraint PDF 
+	if ( w->pdf(Form("%s_Pdf",arg->GetName())) ) w->pdf(Form("%s_Pdf",arg->GetName()))->setAttribute("ignoreConstraint");
       }
       if (verbose > 0) std::cout << "Redefining the POIs to be: "; newPOIs.Print("");
       mc->SetParametersOfInterest(newPOIs);

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -125,14 +125,21 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 
     // Process POI not in list
     nOtherFloatingPoi_ = 0;
+    int nConstPoi=0;
     RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();
+    std::string setConstPOI;
     for (RooAbsArg *a = (RooAbsArg*) iterP.Next(); a != 0; a = (RooAbsArg*) iterP.Next()) {
         if (poiList_.contains(*a)) continue;
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv == 0) { std::cerr << "MultiDimFit: Parameter of interest " << a->GetName() << " which is not a RooRealVar will be ignored" << std::endl; continue; }
         rrv->setConstant(!floatOtherPOIs_);
+	if (!floatOtherPOIs_) {
+		setConstPOI+=std::string(rrv->GetName())+", ";
+		nConstPoi++;
+	}
         if (floatOtherPOIs_) nOtherFloatingPoi_++;
     }
+    if (nConstPoi>0) std::cout << "Following POIs have been set constant (use --floatOtherPOIs to let them float): " << setConstPOI << std::endl;
  
     // start with a best fit
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -133,7 +133,10 @@ RooAbsPdf *utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, Roo
             RooLinkedListIter iter = o.extraConstraints().iterator();
             if (o.extraConstraints().getSize() > 0) needNew = true;
             for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
-                if (!constraints.contains(*a)) constraints.add(*a);
+                if (!constraints.contains(*a) && (!a->getAttribute("ignoreConstraint")) ) {
+			constraints.add(*a);
+
+		}
             }
         }
         RooSimultaneous *ret = sim;
@@ -156,7 +159,9 @@ RooAbsPdf *utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, Roo
     } else if (pdf.dependsOn(observables)) {
         return &pdf;
     } else {
-        if (!constraints.contains(pdf)) constraints.add(pdf);
+        if (!constraints.contains(pdf) && (!pdf.getAttribute("ignoreConstraint"))) {
+		constraints.add(pdf);
+	}
         return 0;
     }
 
@@ -180,7 +185,9 @@ void utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, RooArgLis
             RooSimultaneousOpt &o = dynamic_cast<RooSimultaneousOpt &>(pdf);
             RooLinkedListIter iter = o.extraConstraints().iterator();
             for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
-                if (!constraints.contains(*a)) constraints.add(*a);
+                if (!constraints.contains(*a) && (!a->getAttribute("ignoreConstraint"))  ) {
+			constraints.add(*a);
+		}
             }
         }
         RooSimultaneous *sim  = dynamic_cast<RooSimultaneous *>(&pdf);
@@ -194,7 +201,9 @@ void utils::factorizePdf(const RooArgSet &observables, RooAbsPdf &pdf, RooArgLis
     } else if (pdf.dependsOn(observables)) {
         if (!obsTerms.contains(pdf)) obsTerms.add(pdf);
     } else {
-        if (!constraints.contains(pdf)) constraints.add(pdf);
+        if (!constraints.contains(pdf) && (!pdf.getAttribute("ignoreConstraint")) ) {
+		constraints.add(pdf);
+	}
     }
 }
 void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArgList &obsTerms, RooArgList &constraints, bool debug) {
@@ -216,7 +225,7 @@ void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArg
     } else if (func.dependsOn(observables)) {
         if (!obsTerms.contains(func)) obsTerms.add(func);
     } else {
-        if (!constraints.contains(func)) constraints.add(func);
+        if (!constraints.contains(func) && (!func.getAttribute("ignoreConstraint"))) constraints.add(func);
     }
 }
 


### PR DESCRIPTION
`--redefineSignalPOI` should now drop constraints (assuming name is always "X_Pdf" for nuisance X) for parameters in that list