### PR TITLE
binned dijet pdf for use in MET+X Combo 2016

### DIFF
--- a/interface/RooDijetBinPdf.h
+++ b/interface/RooDijetBinPdf.h
@@ -1,0 +1,114 @@
+//---------------------------------------------------------------------------
+#ifndef HiggsAnalysis_CombinedLimit_RooDijetBinPdf_h
+#define HiggsAnalysis_CombinedLimit_RooDijetBinPdf_h
+//---------------------------------------------------------------------------
+#include "RooAbsPdf.h"
+#include "RooConstVar.h"
+#include "RooRealProxy.h"
+//---------------------------------------------------------------------------
+class RooRealVar;
+class RooAbsReal;
+
+#include "Riostream.h"
+#include "TMath.h"
+#include <TH1.h>
+#include "Math/SpecFuncMathCore.h"
+#include "Math/SpecFuncMathMore.h"
+#include "Math/Functor.h"
+#include "Math/WrappedFunction.h"
+#include "Math/IFunction.h"
+#include "Math/Integrator.h"
+
+//---------------------------------------------------------------------------
+class RooDijetBinPdf : public RooAbsPdf
+{
+public:
+   RooDijetBinPdf() {} ;
+   RooDijetBinPdf(const char *name, const char *title,
+		    RooAbsReal& _th1x, RooAbsReal& _p1,
+		  RooAbsReal& _p2, RooAbsReal& _p3,
+		  RooAbsReal& _sqrts, RooAbsReal& _meff, RooAbsReal& _seff);
+   RooDijetBinPdf(const char *name, const char *title,
+		    RooAbsReal& _th1x, RooAbsReal& _p1,
+		  RooAbsReal& _p2, RooAbsReal& _p3,
+		  RooAbsReal& _sqrts);
+   RooDijetBinPdf(const RooDijetBinPdf& other,
+      const char* name = 0);
+   void setTH1Binning(TH1* _Hnominal);
+   void setAbsTol(double _absTol);
+   void setRelTol(double _relTol);
+   virtual TObject* clone(const char* newname) const { return new RooDijetBinPdf(*this,newname); }
+   inline virtual ~RooDijetBinPdf() { }
+
+   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
+   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+
+protected:   
+
+   RooRealProxy th1x;        // dependent variable
+   RooRealProxy p1;       // p1
+   RooRealProxy p2;        // p2
+   RooRealProxy p3;        // p3
+   RooRealProxy sqrts;        // sqrts
+   RooRealProxy meff;        // meff
+   RooRealProxy seff;        // seff
+   Int_t xBins;        // X bins
+   Double_t xArray[2000]; // xArray[xBins+1]
+   Double_t xMax;        // X max
+   Double_t xMin;        // X min
+   Double_t relTol;      //relative tolerance for numerical integration
+   Double_t absTol;      //absolute tolerance for numerical integration
+
+   Double_t evaluate() const;
+private:
+   ClassDef(RooDijetBinPdf,1) // RazorDijetBinPdf function
+    
+};
+//---------------------------------------------------------------------------
+#endif
+
+#include "Math/IFunction.h"
+#include "Math/IParamFunction.h"
+ 
+class DijetFunction: public ROOT::Math::IParametricFunctionOneDim
+{
+private:
+   const double *pars;
+ 
+public:
+   double DoEvalPar(double x,const double* p) const
+   {
+     double pdf = pow(1-x/p[0],p[1])/pow(x/p[0],p[2]+p[3]*log(x/p[0]));
+     double eff = 1.;
+     if (p[4]>0 && p[5]>0) eff = 0.5 * (1.0 + TMath::Erf((x - p[4])/p[5])) ;
+     return pdf*eff;
+   }
+   
+   double DoEval(double x) const
+   {
+     double pdf = pow(1-x/pars[0],pars[1])/pow(x/pars[0],pars[2]+pars[3]*log(x/pars[0]));
+     double eff = 1.;
+     if (pars[4]>0 && pars[5]>0) eff = 0.5 * (1.0 + TMath::Erf((x - pars[4])/pars[5]));
+     return pdf*eff;
+   }
+ 
+   ROOT::Math::IBaseFunctionOneDim* Clone() const
+   {
+      return new DijetFunction();
+   }
+ 
+   const double* Parameters() const
+   {
+      return pars;
+   }
+ 
+   void SetParameters(const double* p)
+   {
+      pars = p;
+   }
+ 
+   unsigned int NPar() const
+   {
+      return 6;
+   }
+};

--- a/src/RooDijetBinPdf.cc
+++ b/src/RooDijetBinPdf.cc
@@ -1,0 +1,201 @@
+//---------------------------------------------------------------------------
+#include "RooFit.h"
+
+#include "Riostream.h"
+#include <TMath.h>
+#include <cassert>
+#include <cmath>
+#include <math.h>
+
+#include "../interface/RooDijetBinPdf.h"
+#include "RooRealVar.h"
+#include "RooConstVar.h"
+#include "Math/Functor.h"
+#include "Math/WrappedFunction.h"
+#include "Math/IFunction.h"
+#include "Math/Integrator.h"
+#include "Math/GSLIntegrator.h"
+
+using namespace std;
+using namespace RooFit;
+
+ClassImp(RooDijetBinPdf)
+//---------------------------------------------------------------------------
+RooDijetBinPdf::RooDijetBinPdf(const char *name, const char *title,
+				   RooAbsReal& _th1x,  
+				   RooAbsReal& _p1, RooAbsReal& _p2, 
+			           RooAbsReal& _p3, RooAbsReal& _sqrts,
+			           RooAbsReal& _meff, RooAbsReal& _seff) : RooAbsPdf(name, title), 
+//TH3* _Hnominal) : RooAbsPdf(name, title), 
+  th1x("th1x", "th1x Observable", this, _th1x),
+  p1("p1", "p1", this, _p1),
+  p2("p2", "p2", this, _p2),
+  p3("p3", "p3", this, _p3),
+  sqrts("sqrts", "sqrts", this, _sqrts),
+  meff("meff", "meff", this, _meff),
+  seff("seff", "seff", this, _seff),
+  xBins(0),
+  xMax(0),
+  xMin(0),
+  relTol(1E-12),
+  absTol(1E-12)
+{
+  memset(&xArray, 0, sizeof(xArray));
+}
+//---------------------------------------------------------------------------
+RooDijetBinPdf::RooDijetBinPdf(const char *name, const char *title,
+				   RooAbsReal& _th1x,  
+				   RooAbsReal& _p1, RooAbsReal& _p2, 
+				   RooAbsReal& _p3, RooAbsReal& _sqrts) : RooAbsPdf(name, title), 
+//TH3* _Hnominal) : RooAbsPdf(name, title), 
+  th1x("th1x", "th1x Observable", this, _th1x),
+  p1("p1", "p1", this, _p1),
+  p2("p2", "p2", this, _p2),
+  p3("p3", "p3", this, _p3),
+  sqrts("sqrts", "sqrts", this, _sqrts),
+  meff("meff", "meff", this, RooConst(-1) ),
+  seff("seff", "seff", this, RooConst(-1) ),
+  xBins(0),
+  xMax(0),
+  xMin(0),
+  relTol(1E-12),
+  absTol(1E-12)
+{
+  memset(&xArray, 0, sizeof(xArray));
+}
+//---------------------------------------------------------------------------
+RooDijetBinPdf::RooDijetBinPdf(const RooDijetBinPdf& other, const char* name) :
+   RooAbsPdf(other, name), 
+   th1x("th1x", this, other.th1x),  
+   p1("p1", this, other.p1),
+   p2("p2", this, other.p2),
+   p3("p3", this, other.p3),
+   sqrts("sqrts", this, other.sqrts),
+   meff("meff", this, other.meff),
+   seff("seff", this, other.seff),
+   xBins(other.xBins),
+   xMax(other.xMax),
+   xMin(other.xMin),
+   relTol(other.relTol),
+   absTol(other.absTol)
+{
+  //memset(&xArray, 0, sizeof(xArray));
+  for (Int_t i=0; i<xBins+1; i++){
+    xArray[i] = other.xArray[i];
+  }
+}
+//---------------------------------------------------------------------------
+void RooDijetBinPdf::setTH1Binning(TH1* _Hnominal){
+  xBins = _Hnominal->GetXaxis()->GetNbins();
+  xMin = _Hnominal->GetXaxis()->GetBinLowEdge(1);
+  xMax = _Hnominal->GetXaxis()->GetBinUpEdge(xBins);
+  memset(&xArray, 0, sizeof(xArray));
+  for (Int_t i=0; i<xBins+1; i++){
+    xArray[i] =  _Hnominal->GetXaxis()->GetBinLowEdge(i+1);
+  }
+}
+//---------------------------------------------------------------------------
+void RooDijetBinPdf::setRelTol(double _relTol){
+  relTol = _relTol;
+}
+//---------------------------------------------------------------------------
+void RooDijetBinPdf::setAbsTol(double _absTol){
+  absTol = _absTol;
+}
+//---------------------------------------------------------------------------
+Double_t RooDijetBinPdf::evaluate() const
+{
+  Double_t integral = 0.0;
+  
+
+  Int_t iBin = (Int_t) th1x;
+  if(iBin < 0 || iBin >= xBins) {
+    //cout << "in bin " << iBin << " which is outside of range" << endl;
+    return 0.0;
+  }
+
+  
+  Double_t xLow = xArray[iBin];
+  Double_t xHigh = xArray[iBin+1];
+    
+  // define the function to be integrated numerically
+  DijetFunction func;
+  double params[6];
+  params[0] = sqrts;    params[1] = p1;
+  params[2] = p2;       params[3] = p3;
+  params[4] = meff;     params[5] = seff;
+  func.SetParameters(params);
+
+  ROOT::Math::Integrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE,absTol,relTol);
+  ig.SetFunction(func,false);
+
+  
+  integral = ig.Integral(xLow,xHigh);
+  //Double_t total_integral = ig.Integral(xMin,xMax);
+
+  if (integral>0.0) {
+    return integral;
+  } else return 0;
+
+}
+
+// //---------------------------------------------------------------------------
+Int_t RooDijetBinPdf::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName) const{
+  if (matchArgs(allVars, analVars, th1x)) return 1;
+  return 0;
+}
+
+// //---------------------------------------------------------------------------
+Double_t RooDijetBinPdf::analyticalIntegral(Int_t code, const char* rangeName) const{
+
+   Double_t th1xMin = th1x.min(rangeName); Double_t th1xMax = th1x.max(rangeName);
+   Int_t iBinMin = (Int_t) th1xMin; Int_t iBinMax = (Int_t) th1xMax;
+
+
+   Double_t integral = 0.0;
+      
+   //cout <<  "iBinMin = " << iBinMin << ",iBinMax = " << iBinMax << endl;
+
+   
+   // define the function to be integrated numerically  
+   DijetFunction func;
+   double params[6];
+   params[0] = sqrts;    params[1] = p1;
+   params[2] = p2;       params[3] = p3;
+   params[4] = meff;     params[5] = seff;
+   func.SetParameters(params);
+
+   
+  ROOT::Math::Integrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE,absTol,relTol);
+  ig.SetFunction(func,false);
+    
+
+   if (code==1 && iBinMin<=0 && iBinMax>=xBins){
+     integral = ig.Integral(xMin,xMax);
+     
+   }
+   else if(code==1) { 
+     for (Int_t iBin=iBinMin; iBin<iBinMax; iBin++){
+       
+       if(iBin < 0 || iBin >= xBins) {
+	 integral += 0.0;
+       }
+       else{	 
+	 Double_t xLow = xArray[iBin];
+	 Double_t xHigh = xArray[iBin+1];    
+	 integral += ig.Integral(xLow,xHigh);
+       }
+     }
+   } else {
+     cout << "WARNING IN RooDijetBinPdf: integration code is not correct" << endl;
+     cout << "                           what are you integrating on?" << endl;
+     return 1.0;
+   }
+
+   if (integral>0.0) {
+     
+     return integral;
+   } else return 1.0;
+}
+// //---------------------------------------------------------------------------
+

--- a/src/classes.h
+++ b/src/classes.h
@@ -32,6 +32,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooMorphingPdf.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooParametricHist.h"
 #include "HiggsAnalysis/CombinedLimit/interface/GaussExp.h"
+#include "HiggsAnalysis/CombinedLimit/interface/RooDijetBinPdf.h"
 
 namespace {
     struct dictionary {

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -117,6 +117,7 @@
 	<class name="VerticalInterpPdf" />
 	<class name="GaussExp" />
 	<class name="RooParametricHist" />
+	<class name="RooDijetBinPdf" />	
 	<class name="RooMorphingPdf" />
         <function name="function th1fmorph" />
 


### PR DESCRIPTION
@nucleosynthesis 

Hi,

This binned pdf is for use in the MET+X combination for ICHEP 2016 (and beyond).

The variable is a "th1x"-type variable which is simply a bin number. You set the binning using the method setTH1Binning() which takes as input a 1D histogram. The pdf then integrates the 4-parameter analytic functional form and returns the value corresponding to the integral over each bin. This value is constant over each bin width. 

This pdf allows the analysts to perform binned fits with variable bin width.

Results using this pdf have been presented in the Dijet Analysis and EXO meetings, e.g.
https://indico.cern.ch/event/525676/contributions/2152768/attachments/1266233/1874514/Dijet_CaloScoutingUpdate_29Apr2016.pdf (first presentation of pdf)
https://indico.cern.ch/event/548921/contributions/2225540/attachments/1302387/1946919/EXO-16-032-PreApproval.pdf (preapproval)
https://indico.cern.ch/event/555209/contributions/2237351/attachments/1306528/1952917/Dijet_CaloScoutingUpdate_8July2016.pdf (combination of 2015+2016 datasets)
http://cms.cern.ch/iCMS/analysisadmin/cadilines?line=EXO-16-032&tp=an&id=1701&ancode=EXO-16-032 (CADI line)

Details on the MET+X combination can be found here:
https://gitlab.cern.ch/CMSExoMetxCombo/MetxCombo2016/ 
https://indico.cern.ch/event/555209/contributions/2237379/attachments/1306481/1952811/20160708_METXCombo_Dijet_TristanduPree.pdf

Thanks,

Javier
