### PR TITLE
Fix broken saturated GOF test

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -124,6 +124,7 @@ class CachingAddNLL : public RooAbsReal {
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
         void clearZeroPoint() ;
+        void clearConstantZeroPoint() ;
         void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
         /// note: setIncludeZeroWeights(true) won't have effect unless you also re-call setData
         virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
@@ -166,6 +167,7 @@ class CachingSimNLL  : public RooAbsReal {
         static void setNoDeepLogEvalError(bool noDeep) { noDeepLEE_ = noDeep; }
         void setZeroPoint() ; 
         void clearZeroPoint() ;
+        void clearConstantZeroPoint() ;
         void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
         static void forceUnoptimizedConstraints() { optimizeContraints_ = false; }
         void setChannelMasks(RooArgList const& args);

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -718,6 +718,13 @@ cacheutils::CachingAddNLL::clearZeroPoint()
     setValueDirty();
 }
 
+void
+cacheutils::CachingAddNLL::clearConstantZeroPoint()
+{
+    constantZeroPoint_ = 0.0;
+    setValueDirty();
+}
+
 void 
 cacheutils::CachingAddNLL::setData(const RooAbsData &data) 
 {
@@ -1086,6 +1093,13 @@ void cacheutils::CachingSimNLL::clearZeroPoint() {
     std::fill(constrainZeroPoints_.begin(), constrainZeroPoints_.end(), 0.0);
     std::fill(constrainZeroPointsFast_.begin(), constrainZeroPointsFast_.end(), 0.0);
     std::fill(constrainZeroPointsFastPoisson_.begin(), constrainZeroPointsFastPoisson_.end(), 0.0);
+    setValueDirty();
+}
+
+void cacheutils::CachingSimNLL::clearConstantZeroPoint() {
+    for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it) {
+        if (*it != 0) (*it)->clearConstantZeroPoint();
+    }
     setValueDirty();
 }
 


### PR DESCRIPTION
 - Problem in ROOT6 branch originates in the constantZeroPoint for
   the CachingAddNLL. This is a special case where we compare the
   likelihoods of two different models with the same data and so the
   initial likelihood values are different.
 - Solution adds a clearConstantZeroPoint() method to CachingAddNLL and
   CachingSimNLL that sets this back to zero.
 - Also took the opportunity to switch the fitting to the cascade
   minimizer inside the GOF calculation.