### PR TITLE
Restoring (apparently) lost behaviour in NuisanceModifier.py where do…

### DIFF
--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -115,6 +115,8 @@ def doRenameNuisance(datacard, args):
                     for p in datacard.exp[b].keys():
                         if process == "*" or cprocess.match(p):
                             foundProc = True
+                            if errline0[b][p] in [0.0]:
+                                continue
     			    if "shape" in pdf0 : datacard.systematicsShapeMap[newname,b,p]=oldname
                             if p in errline0[b] and errline2[b][p] not in [ 0.0, 1.0 ]:
                                 if "addq" in opts:


### PR DESCRIPTION
…RenameNuisance would skip bin,process entries with a value of zero.

I noticed that building the combined run 1 workspace had stopped working:

```
RuntimeError: Error reading line 2319 of file comb.txt.gz: Can't rename nuisance with args = ['^(tHW)$', '*', '^(pdf_gg)$', 'pdf_Higgs_qg'] for bin hgg_7TeV_ttH, process tHW: found existing non-null value [0.923, 1.084], and no option 'addq' or 'overwrite' given
```

 and tracked it down to this line on the lhchcg-run1-couplings branch having been dropped at some point:

https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/5cdc00253de33a63d9a7ee223d88119a0f169378/python/NuisanceModifier.py#L117

However not explicitly in any commit I could find - I think it might have happened when another branch with conflicts was merged in. Does anyone see a problem with restoring this?
