### PR TITLE
text2workspace.py failing when using certain characters in the options

### DIFF
--- a/scripts/text2workspace.py
+++ b/scripts/text2workspace.py
@@ -7,6 +7,7 @@ from optparse import OptionParser
 argv.append( '-b-' )
 import ROOT
 ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
 argv.remove( '-b-' )
 
 from HiggsAnalysis.CombinedLimit.DatacardParser import *


### PR DESCRIPTION
Currently test2workspace.py fails with a segfault when using certain characters in the command line options. This for example happens when using "$", which is a potential usecase for the regular expression to match the mapping in the MultiSignalModel.

The reason for this segfault is pyRoot trying to parse the command line options. To fix this pyRoot is now configured to ignore commandline options.
This might potentially also apply to other scripts than text2workspace.py