### PR TITLE
Add data as tgraphasymm errors to mlfit output

### DIFF
--- a/interface/MaxLikelihoodFit.h
+++ b/interface/MaxLikelihoodFit.h
@@ -43,6 +43,7 @@ protected:
   static bool        saveNormalizations_;
   static bool        oldNormNames_;
   static bool        saveShapes_;
+  static bool        saveOverallShapes_;
   static bool        saveWithUncertainties_;
   static bool	     saveWorkspace_;
   static bool        reuseParams_;

--- a/interface/MaxLikelihoodFit.h
+++ b/interface/MaxLikelihoodFit.h
@@ -80,7 +80,7 @@ protected:
         virtual const RooAbsCollection & get(int itoy) = 0;
         virtual const RooAbsCollection & centralValues() = 0;
   };
-  void getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, RooArgSet &out, NuisanceSampler &sampler, TDirectory *fOut, const std::string &postfix);
+  void getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, RooArgSet &out, NuisanceSampler &sampler, TDirectory *fOut, const std::string &postfix,RooAbsData &data);
 
   class CovarianceReSampler : public NuisanceSampler {
     public:

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <TGraphAsymmErrors.h>
+#include <RooHistError.h>
+#include <TH1.h>
 struct RooDataHist;
 struct RooAbsData;
 struct RooAbsPdf;
@@ -24,12 +27,14 @@ namespace utils {
     void printPdf(const RooAbsReal *pdf) ;
     void printPdf(RooStats::ModelConfig &model) ;
     void printPdf(RooWorkspace *w, const char *pdfName) ;
+    TGraphAsymmErrors * makeDataGraph(TH1 * dataHist);
+    //Make a tgraph asym errors from th1 of data
 
-    // Clone a pdf and all it's branch nodes. on request, clone also leaf nodes (i.e. RooRealVars)
+    // Clone a pdf and all its branch nodes. on request, clone also leaf nodes (i.e. RooRealVars)
     RooAbsPdf *fullClonePdf(const RooAbsPdf *pdf, RooArgSet &holder, bool cloneLeafNodes=false) ;
-    // Clone a function and all it's branch nodes. on request, clone also leaf nodes (i.e. RooRealVars)
+    // Clone a function and all its branch nodes. on request, clone also leaf nodes (i.e. RooRealVars)
     RooAbsReal *fullCloneFunc(const RooAbsReal *pdf, RooArgSet &holder, bool cloneLeafNodes=false) ;
-    // Clone a function and all it's branch nodes that depends on the observables. on request, clone also leaf nodes (i.e. RooRealVars)
+    // Clone a function and all its branch nodes that depends on the observables. on request, clone also leaf nodes (i.e. RooRealVars)
     RooAbsReal *fullCloneFunc(const RooAbsReal *pdf, const RooArgSet &obs, RooArgSet &holder, bool cloneLeafNodes=false) ;
 
     /// Create a pdf which depends only on observables, and collect the other constraint terms

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -547,14 +547,10 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
         }
     }
 
-    std::vector<int> binsOverall(totByCh.size(),0);
     int totalBins = 0;
-    unsigned int iHist = 0;
 
     for (IH h = totByCh.begin(), eh = totByCh.end(); h != eh; ++h) {
-	binsOverall[iHist] = h->second->GetNbinsX();
-	totalBins += binsOverall[iHist];
-	iHist++;
+	totalBins +=  h->second->GetNbinsX();
     }
 
     //Total covariance
@@ -570,11 +566,10 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
     TH1D* sigOverall = new TH1D("total_signal","Total signal",totalBins,0,totalBins);
     sigOverall->SetDirectory(0);
     int iBinOverall = 1;
-    iHist = 0;
     //Map to hold info on bins across channels
     std::map<TString,int> binMap;
     for (IH h = totByCh.begin(), eh = totByCh.end(); h != eh; ++h){
-	for (int iBin = 0; iBin < binsOverall[iHist]; iBin++){
+	for (int iBin = 0; iBin < h->second->GetNbinsX(); iBin++,iBinOverall++){
 	    TString label = Form("%s_%d",h->first.c_str(),iBin);
 	    binMap[label] = iBinOverall;
 	    totOverall->GetXaxis()->SetBinLabel(iBinOverall,label);
@@ -588,9 +583,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
 
 	    totOverall2Covar->GetXaxis()->SetBinLabel(iBinOverall,label);
 	    totOverall2Covar->GetYaxis()->SetBinLabel(iBinOverall,label);
-	    iBinOverall++;
 	}
-	iHist++;
     }
 
     if (saveWithUncertainties_) {

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -576,7 +576,11 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
 	    totOverall->SetBinContent(iBinOverall,h->second->GetBinContent(iBin+1));
 
 	    sigOverall->GetXaxis()->SetBinLabel(iBinOverall,label);
-	    sigOverall->SetBinContent(iBinOverall,sigByCh[h->first]->GetBinContent(iBin+1));
+	    //For signal have to deal with empty channels
+	    std::map<std::string,TH1*>::iterator iH = sigByCh.find(h->first);
+	    if (iH != sigByCh.end()){
+		sigOverall->SetBinContent(iBinOverall,iH->second->GetBinContent(iBin+1));
+	    }
 
 	    bkgOverall->GetXaxis()->SetBinLabel(iBinOverall,label);
 	    bkgOverall->SetBinContent(iBinOverall,bkgByCh[h->first]->GetBinContent(iBin+1));

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -559,7 +559,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
     totOverall2Covar->GetYaxis()->SetTitle("Bin number");
     totOverall2Covar->SetDirectory(0);
     //Total background
-    TH1D* totOverall = new TH1D("total overall","signal+background",totalBins,0,totalBins);
+    TH1D* totOverall = new TH1D("total_overall","signal+background",totalBins,0,totalBins);
     totOverall->SetDirectory(0);
     TH1D* bkgOverall = new TH1D("total_background","Total background",totalBins,0,totalBins);
     bkgOverall->SetDirectory(0);

--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -568,6 +568,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
     sigOverall->SetDirectory(0);
     int iBinOverall = 1;
     iHist = 0;
+    //Map to hold info on bins across channels
     std::map<TString,int> binMap;
     for (IH h = totByCh.begin(), eh = totByCh.end(); h != eh; ++h){
 	for (int iBin = 0; iBin < binsOverall[iHist]; iBin++){
@@ -622,7 +623,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
                     (sig[i] ? sigByCh1 : bkgByCh1)[pair->second.channel]->Add(&*hist);
                 }
             }
-            // now add up the deviations in this toy
+            // now add up the deviations within channels in this toy
             for (IH h = totByCh1.begin(), eh = totByCh1.end(); h != eh; ++h) {
                 TH1 *target = totByCh2[h->first], *reference = totByCh[h->first];
                 TH2 *targetCovar = totByCh2Covar[h->first];
@@ -644,7 +645,7 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
 		    }
 		}
 	    }
-            // deviations across channels
+            // deviations across channels in this toy
 	    for (IH h = totByCh1.begin(), eh = totByCh1.end(); h != eh; ++h) {
 		TH1 *reference = totByCh[h->first];
 		for (IH h2 = totByCh1.begin();h2 != h; ++h2) {
@@ -748,11 +749,24 @@ void MaxLikelihoodFit::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, R
         for (IH h = sigByCh.begin(), eh = sigByCh.end(); h != eh; ++h) { shapesByChannel[h->first]->WriteTObject(h->second); }
         for (IH h = bkgByCh.begin(), eh = bkgByCh.end(); h != eh; ++h) { shapesByChannel[h->first]->WriteTObject(h->second); }
         for (IH2 h = totByCh2Covar.begin(), eh = totByCh2Covar.end(); h != eh; ++h) { shapesByChannel[h->first]->WriteTObject(h->second); }
+	//Save total shapes or clean up if not keeping
 	shapeDir->cd();
-	totOverall2Covar->Write();
-	totOverall->Write();
-	sigOverall->Write();
-	bkgOverall->Write();
+	if (saveShapes_){
+	    totOverall->Write();
+	    sigOverall->Write();
+	    bkgOverall->Write();
+	}
+	else{
+	    delete totOverall;
+	    delete sigOverall;
+	    delete bkgOverall;
+	}
+	if (saveWithUncertainties_){
+	    totOverall2Covar->Write();
+	}
+	else{
+	    delete totOverall2Covar;
+	}
     }
 }
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -527,6 +527,27 @@ utils::setChannelGenModes(RooSimultaneous &simPdf, const std::string &binned, co
         }
     }
 }
+TGraphAsymmErrors * utils::makeDataGraph(TH1 * dataHist)
+{
+    // Properly normalise 
+    TGraphAsymmErrors * dataGraph = new TGraphAsymmErrors(dataHist->GetNbinsX());
+    for (int b=1;b <= dataHist->GetNbinsX();b++){
+	double yv = dataHist->GetBinContent(b);
+	double bw = dataHist->GetBinWidth(b);
+
+	double up; 
+	double dn;
+
+	RooHistError::instance().getPoissonInterval(yv,dn,up,1);
+
+	double errlow  = (yv-dn);
+	double errhigh = (up-yv);
+
+	dataGraph->SetPoint(b,dataHist->GetBinCenter(b),yv);
+	dataGraph->SetPointError(b,bw/2,bw/2,errlow,errhigh);
+    }
+    return dataGraph;
+}
 
 std::vector<RooPlot *>
 utils::makePlots(const RooAbsPdf &pdf, const RooAbsData &data, const char *signalSel, const char *backgroundSel, float rebinFactor) {


### PR DESCRIPTION
adds a data graph per channel (as well as a data graph for the overall workspace if used with opt --saveOverall)

This should be merged after the PR #338 