### PR TITLE
Fixing (seemingly) random MaxLikelihoodFit segfaults with --justFit

### DIFF
--- a/src/MaxLikelihoodFit.cc
+++ b/src/MaxLikelihoodFit.cc
@@ -55,7 +55,9 @@ MaxLikelihoodFit::MaxLikelihoodFit() :
     FitterAlgoBase("MaxLikelihoodFit specific options"),
     globalObservables_(0),
     nuisanceParameters_(0),
-    processNormalizations_(0)
+    processNormalizations_(0),
+    t_fit_b_(nullptr),
+    t_fit_sb_(nullptr)
 {
     options_.add_options()
         ("minos",              boost::program_options::value<std::string>(&minos_)->default_value(minos_), "Compute MINOS errors for: 'none', 'poi', 'all'")


### PR DESCRIPTION
The t_fit_b_ and t_fit_sb_ pointers are now explicitly initialised as null in the constructor to avoid random segfaults occuring depending on the memory layout at runtime