### PR TITLE
Adding option to replace observation with expected quantile value

### DIFF
--- a/test/plotTestStatCLs.py
+++ b/test/plotTestStatCLs.py
@@ -18,6 +18,7 @@ parser.add_option("-r","--rebin",default=0,type='int',help="Rebin the histos by 
 parser.add_option("-m","--mass",default=[],action='append',help="mass value(s) (same as -m for combine)")
 parser.add_option("-P","--Print",default=False,action='store_true',help="Just print the toys directory to see whats there")
 parser.add_option("-e","--expected",default=False,action='store_true',help="Replace observation with expected (under alt hyp)")
+parser.add_option("-q","--quantileExpected",default=0.5,type='float',help="Replace observation with expected quantile (under alt hyp, i.e CLb=quantileExpected)")
 parser.add_option("","--doublesided",action='store_true',default=False,help="If 2 sided (i.e LEP style or non-nested hypos e.g for spin)")
 (options,args)=parser.parse_args()
 
@@ -68,7 +69,7 @@ for m in options.mass:
   #ft = ROOT.TFile.Open("tmp_out%s%d.root"%(m,i))
   ft = ROOT.TFile.Open("tmp_out.root")
   print "Plotting ... "
-  can = qmuPlot(float(m),options.poi,float(pv),int(options.doublesided),int(options.invert),options.rebin,options.expected)
+  can = qmuPlot(float(m),options.poi,float(pv),int(options.doublesided),int(options.invert),options.rebin,options.expected,options.quantileExpected)
   canvases.append(can.Clone())
   ft.Close()
 ofile = ROOT.TFile(options.output,"RECREATE")

--- a/test/plotting/qmuPlot.cxx
+++ b/test/plotting/qmuPlot.cxx
@@ -91,7 +91,7 @@ double tailReal(TTree *t, std::string br, double cv, int mode){
     return ((double)tpass)/ttotal;
 }
 
-TCanvas *qmuPlot(float mass, std::string poinam, double poival, int mode=0, int invert=0,int rebin=0, int runExpected_=0) {
+TCanvas *qmuPlot(float mass, std::string poinam, double poival, int mode=0, int invert=0,int rebin=0, int runExpected_=0, double quantileExpected_=0.5) {
     if (gFile == 0) { std::cerr << "You must have a file open " << std::endl; return 0; }
     TTree *t = (TTree *) gFile->Get("q");
     if (t == 0) { std::cerr << "File " << gFile->GetName() << " does not contain a tree called 'q'" << std::endl; return 0; }
@@ -132,9 +132,16 @@ TCanvas *qmuPlot(float mass, std::string poinam, double poival, int mode=0, int 
     if (mode==0)t->Draw("max(2*q,0)>>qObs","weight*(type==0)");
     else t->Draw("2*q>>qObs","weight*(type==0)");
     double qObs = ((TH1F*) gROOT->FindObject("qObs"))->GetMean();
-    if (runExpected_) qObs = getMedianVal(qB);
+    if (runExpected_) {
+      
+      double medx[1] ={quantileExpected_};
+      double medy[1] ={0.};
+      qB->GetQuantiles(1,medy,medx);
+      qObs = medy[0];
+    }
+
     TArrow *qO = new TArrow(qObs, 0.2, qObs, yMin*1.05, 0.01, "---|>");
- 
+    
     if (rebin>0){
 	qB->Rebin(rebin);
 	qS->Rebin(rebin);


### PR DESCRIPTION
`--quantileExpected X` will now replace the observation, q0, with the particular quantile derived the bkg-only distribution, such that P(q>q0|bkg-only) = X