### PR TITLE
Why load libHiggsAnalysisCombinedLimit?

### DIFF
--- a/test/diffNuisances.py
+++ b/test/diffNuisances.py
@@ -17,7 +17,7 @@ for X in ("-h", "-?", "--help"):
 argv.append( '-b-' )
 import ROOT
 ROOT.gROOT.SetBatch(True)
-ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit")
+#ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit")
 argv.remove( '-b-' )
 if hasHelp: argv.append("-h")
 


### PR DESCRIPTION
Noted by @nucleosynthesis that this may not be needed in this script as no combine-specific objects are used (only plain `ROOT`).