### PR TITLE
Fix r=0 logic when loading snapshot

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -711,7 +711,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
         }
       }
       // Set the value of r in cases 1), 2) and 4)
-      if (expectSignalSet_ || (!expectSignalSet_ && !rInParamExp)) {
+      if (expectSignalSet_ || (!expectSignalSet_ && !rInParamExp && snapshotName_=="" )) {
         ((RooRealVar*)POI->find("r"))->setVal(expectSignal_);
       }
       if (expectSignalSet_ && rInParamExp) {


### PR DESCRIPTION
Fixing Logic so that signal POI `r` not set to 0 for toy generation if snapshot is being loaded and neither `--expectSignal` nor `--setPhysicsModelParameters` is set