### PR TITLE
allow for regexp in some command line options

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -108,7 +108,7 @@ Combine::Combine() :
       ("unbinned,U", "Generate unbinned datasets instead of binned ones (works only for extended pdfs)")
       ("generateBinnedWorkaround", "Make binned datasets generating unbinned ones and then binnning them. Workaround for a bug in RooFit.")
       ("setPhysicsModelParameters", po::value<string>(&setPhysicsModelParameterExpression_)->default_value(""), "Set the values of relevant physics model parameters. Give a comma separated list of parameter value assignments. Example: CV=1.0,CF=1.0")      
-      ("setPhysicsModelParameterRanges", po::value<string>(&setPhysicsModelParameterRangeExpression_)->default_value(""), "Set the range of relevant physics model parameters. Give a colon separated list of parameter ranges. Example: CV=0.0,2.0:CF=0.0,5.0")      
+      ("setPhysicsModelParameterRanges", po::value<string>(&setPhysicsModelParameterRangeExpression_)->default_value(""), "Set the range of relevant physics model parameters. Give a colon separated list of parameter ranges. Also accepts regexp with syntax 'rgx{<my regexp>}'. Example: CV=0.0,2.0:CF=0.0,5.0:'rgx{^CMS_eff_.*$}'=-3,3")      
       ("redefineSignalPOIs", po::value<string>(&redefineSignalPOIs_)->default_value(""), "Redefines the POIs to be this comma-separated list of variables from the workspace.")      
       ("freezeNuisances", po::value<string>(&freezeNuisances_)->default_value(""), "Set as constant all these nuisance parameters.")      
       ("freezeNuisanceGroups", po::value<string>(&freezeNuisanceGroups_)->default_value(""), "Set as constant all these groups of nuisance parameters.")      

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -31,7 +31,7 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <regex>
 
 #include "HiggsAnalysis/CombinedLimit/interface/CloseCoutSentry.h"
@@ -727,35 +727,27 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
       double PhysicsParameterRangeLow = atof(SetParameterRangeExpression[1].c_str());
       double PhysicsParameterRangeHigh = atof(SetParameterRangeExpression[2].c_str());
 
-      // check for wildcard character *
-      if (SetParameterRangeExpression[0].find("*") != std::string::npos) {
-
-          std::string reg_esp = "^"; 
-          reg_esp += boost::replace_all_copy(SetParameterRangeExpression[0], "*", ".*");
-          reg_esp += "$";
-          std::regex rgx(reg_esp.c_str(),std::regex::ECMAScript);
-
-          std::cout<<"interpreting "<<SetParameterRangeExpression[0]<<" as regex "<<reg_esp<<std::endl;
+      // check for regex syntax: rgx{regex}
+      if (boost::starts_with(SetParameterRangeExpression[0], "rgx{") && boost::ends_with(SetParameterRangeExpression[0], "}")) {
+          
+          std::string reg_esp = SetParameterRangeExpression[0].substr(4, SetParameterRangeExpression[0].size()-5);
+          std::cout<<"interpreting "<<reg_esp<<" as regex "<<std::endl;
+          std::regex rgx( reg_esp, std::regex::ECMAScript);
 
           std::auto_ptr<TIterator> iter(params.createIterator());
           for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
               RooRealVar *tmpParameter = dynamic_cast<RooRealVar *>(a);
-              //string varname = tmpParameter->GetName();
               const std::string &target = tmpParameter->GetName();
               std::smatch match;
               if (std::regex_match(target, match, rgx)) {
-                  std::string isconst="";
-                  if (tmpParameter->isConstant()) {
-                      isconst="Constant ";
-                  }
-                  cout << "Set Range of "<<isconst<<"Parameter " << target
+                  if (tmpParameter->isConstant()) continue;
+                  cout << "Set Range of Parameter " << target
                        << " To : (" << PhysicsParameterRangeLow << "," << PhysicsParameterRangeHigh << ")\n";
                   tmpParameter->setRange(PhysicsParameterRangeLow,PhysicsParameterRangeHigh);
               }
-
           }
-      }       
-      
+
+      }         
       else {
           RooRealVar *tmpParameter = (RooRealVar*)params.find(SetParameterRangeExpression[0].c_str());            
           if (tmpParameter) {


### PR DESCRIPTION
This addresses recent question on allowing for wildcards in setPhysicsModelParameterRanges. Before implementing something similar for setPhysicsModelParameters or freezeNuisances, I would like to know whether:

1) The regex intepretation is ok. I am assuming the user will put in a string with only the wildcard character "*", and then convert this string to a regexp. We could also check for other regexp characters to try and figure out if it is meant to be a an actual regexp, and in that case use the proved string directly. 

2) Also, in this case of setting ranges, we could skip constant parameters instead of setting them (although it doesn't matter it may confuse the user), unless there is a possibility that we set the range of a constant parameter and later change it non-constant.