### PR TITLE
Dup fdOut_ before opening a file pointer for trueStdOut_

### DIFF
--- a/interface/CloseCoutSentry.h
+++ b/interface/CloseCoutSentry.h
@@ -16,7 +16,7 @@ class CloseCoutSentry {
         static FILE *trueStdOutGlobal();
     private:
         bool silent_;
-        static int fdOut_, fdErr_, fdTmp_;
+        static int fdOut_, fdErr_, fdTmp_, fdOutDup_;
         static bool open_;
         // always clear, even if I was not the one closing it
         void static reallyClear() ;

--- a/src/CloseCoutSentry.cc
+++ b/src/CloseCoutSentry.cc
@@ -10,6 +10,8 @@
 bool CloseCoutSentry::open_ = true;
 int  CloseCoutSentry::fdOut_ = 0;
 int  CloseCoutSentry::fdErr_ = 0;
+int  CloseCoutSentry::fdTmp_ = 0;
+int  CloseCoutSentry::fdOutDup_ = 0;
 FILE * CloseCoutSentry::trueStdOut_ = 0;
 CloseCoutSentry *CloseCoutSentry::owner_ = 0;
 
@@ -24,7 +26,7 @@ CloseCoutSentry::CloseCoutSentry(bool silent) :
                 fdOut_ = dup(1);
                 fdErr_ = dup(2);
             }
-            int fdTmp_ = open( "/dev/null", O_RDWR );
+            fdTmp_ = open( "/dev/null", O_RDWR );
             dup2(fdTmp_, 1);
             dup2(fdTmp_, 2);
             assert(owner_ == 0);
@@ -80,6 +82,7 @@ FILE *CloseCoutSentry::trueStdOut()
     if (owner_ != this && owner_ != 0) return owner_->trueStdOut();
     assert(owner_ == this);
     stdOutIsMine_ = true;
-    trueStdOut_ = fdopen( fdOut_, "w" );
+    fdOutDup_ = dup( fdOut_ ); // When clear() calls fclose(trueStdOut_), this makes sure fdOutDup_ gets closed instead of fdOut_
+    trueStdOut_ = fdopen( fdOutDup_, "w" );
     return trueStdOut_;
 }


### PR DESCRIPTION
Addition to PR #375 . This makes sure that when fclose(trueStdOut_) is called in clear(), not fdOut_ is closed but fdOutDup_ is closed (otherwise the stdout is not properly restored upon calling clear() ).