### PR TITLE
Adding STXS Physics Model

### DIFF
--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -131,11 +131,11 @@ def getHiggsProdDecMode(bin,process,options):
     processSource = process
     decaySource   = options.fileName+":"+bin # by default, decay comes from the datacard name or bin label
     if "_" in process: 
-        (processSource, decaySource) = process.split("_")
+        (processSource, decaySource) = "_".join(process.split("_")[0]),process.split("_")[-1] # ignore anything in the middle for SM-like higgs
         if decaySource not in ALL_HIGGS_DECAYS:
             print "ERROR", "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)
             #raise RuntimeError, "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)
-    if processSource not in ALL_HIGGS_PROD:
+    if processSource not in ALL_HIGGS_PROD :
         raise RuntimeError, "Validation Error: signal process %s not among the allowed ones." % processSource
     #
     foundDecay = None

--- a/python/STXSModels.py
+++ b/python/STXSModels.py
@@ -1,0 +1,117 @@
+from HiggsAnalysis.CombinedLimit.PhysicsModel import *
+from HiggsAnalysis.CombinedLimit.SMHiggsBuilder import SMHiggsBuilder
+import fnmatch 
+
+ALL_STXS_PROCS = {
+	"Stage0": {
+	 "ggH*": 	  "r_ggH"
+	,"bbH*": 	  "r_ggH"
+	,"qqH*": 	  "r_qqH"
+	,"ttH*":    	  "r_ttH"
+	,"tH[Wq]*":    	  "r_ttH"
+	,"ZH_lep*": 	  "r_QQ2HLL"
+	,"WH_lep*": 	  "r_QQ2HLNU"
+	,"[VWZ]H_had*":   "r_VH2HQQ"
+	}
+}
+
+def getSTXSProdDecMode(bin,process,options):
+    """Return a triple of (production)"""
+    processSource = process
+    decaySource   = options.fileName+":"+bin # by default, decay comes from the datacard name or bin label
+    if "_" in process: 
+        (processSource, decaySource) = "_".join(process.split("_")[0:-1]),process.split("_")[-1]
+    foundDecay = None
+    for D in ALL_HIGGS_DECAYS:
+        if D in decaySource:
+            if foundDecay: raise RuntimeError, "Validation Error: decay string %s contains multiple known decay names" % decaySource
+            foundDecay = D
+    if not foundDecay: raise RuntimeError, "Validation Error: decay string %s does not contain any known decay name" % decaySource
+    #
+    foundEnergy = None
+    for D in [ '7TeV', '8TeV', '13TeV', '14TeV' ]:
+        if D in decaySource:
+            if foundEnergy: raise RuntimeError, "Validation Error: decay string %s contains multiple known energies" % decaySource
+            foundEnergy = D
+    if not foundEnergy:
+        for D in [ '7TeV', '8TeV', '13TeV', '14TeV' ]:
+            if D in options.fileName+":"+bin:
+                if foundEnergy: raise RuntimeError, "Validation Error: decay string %s contains multiple known energies" % decaySource
+                foundEnergy = D
+    if not foundEnergy:
+        foundEnergy = '7TeV' ## To ensure backward compatibility
+        print "Warning: decay string %s does not contain any known energy, assuming %s" % (decaySource, foundEnergy)
+    #
+    return (processSource, foundDecay, foundEnergy)
+
+
+class STXSBaseModel(PhysicsModel):
+    def __init__(self):
+        PhysicsModel.__init__(self) # not using 'super(x,self).__init__' since I don't understand it
+        self.floatMass = False
+    def preProcessNuisances(self,nuisances):
+    	# add here any pre-processed nuisances such as constraint terms for the mass profiling?
+    	return 
+    def setPhysicsOptionsBase(self,physOptions):
+        for po in physOptions:
+            if po.startswith("higgsMassRange="):
+                self.floatMass = True
+                self.mHRange = po.replace("higgsMassRange=","").split(",")
+                print 'The Higgs mass range:', self.mHRange
+                if len(self.mHRange) != 2:
+                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                elif float(self.mHRange[0]) >= float(self.mHRange[1]):
+                    raise RuntimeError, "Extrama for Higgs mass range defined with inverterd order. Second must be larger the first"
+    def doMH(self):
+        if self.floatMass:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]),float(self.mHRange[1]))
+                self.modelBuilder.out.var("MH").setConstant(False)
+            else:
+                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1])) 
+        else:
+            if self.modelBuilder.out.var("MH"):
+                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                self.modelBuilder.out.var("MH").setConstant(True)
+            else:
+                self.modelBuilder.doVar("MH[%g]" % self.options.mass)
+
+    def getYieldScale(self,bin,process):
+        "Split in production and decay, and call getHiggsSignalYieldScale; return 1 for backgrounds "
+        if not self.DC.isSignal[process]: return 1
+        (processSource, foundDecay, foundEnergy) = getSTXSProdDecMode(bin,process,self.options)
+        return self.getHiggsSignalYieldScale(processSource, foundDecay, foundEnergy)
+
+
+class StageZero(STXSBaseModel):
+    "Allow different signal strength fits for the stage-0 model"
+    def __init__(self):
+        STXSBaseModel.__init__(self) # not using 'super(x,self).__init__' since I don't understand it
+        self.POIs = ""
+    def doVar(self,x,constant=True):
+        self.modelBuilder.doVar(x)
+        vname = re.sub(r"\[.*","",x)
+        self.modelBuilder.out.var(vname).setConstant(constant)
+        print "SignalStrengths:: declaring %s as %s, and set to constant" % (vname,x)
+    def doParametersOfInterest(self):
+        """Create POI out of signal strengths (and MH)"""
+        self.doMH()
+        for X in [ "qqH", "ggH", "ttH", "QQ2HLNU", "QQ2HLL", "VH2HQQ"]:
+            self.doVar("r_%s[1,0,10]" % X)
+        print "Default parameters of interest: ", self.POIs
+        self.modelBuilder.doSet("POI",self.POIs)
+        self.SMH = SMHiggsBuilder(self.modelBuilder)
+        self.setup()
+    def setup(self):
+	return 
+
+    def getHiggsSignalYieldScale(self,production,decay,energy):
+        name = "%s_%s_%s" % (production,decay,energy)
+	for regproc in ALL_STXS_PROCS["Stage0"].keys():
+	    if	fnmatch.fnmatch(production, regproc): 
+	    	retpoi = "%s"%(ALL_STXS_PROCS["Stage0"][regproc])
+	    	print "Will scale %s with POI %s"%(name,retpoi)
+	    	return retpoi 
+        raise RuntimeError, "No production process matching %s for Stage0 found !"%production
+
+stage0 = StageZero()

--- a/python/STXSModels.py
+++ b/python/STXSModels.py
@@ -52,8 +52,9 @@ class STXSBaseModel(PhysicsModel):
     def preProcessNuisances(self,nuisances):
     	# add here any pre-processed nuisances such as constraint terms for the mass profiling?
     	return 
-    def setPhysicsOptionsBase(self,physOptions):
+    def setPhysicsOptions(self,physOptions):
         for po in physOptions:
+	    print po
             if po.startswith("higgsMassRange="):
                 self.floatMass = True
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
@@ -68,7 +69,8 @@ class STXSBaseModel(PhysicsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]),float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1])) 
+                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0],self.mHRange[1]))
+	    self.POIs+=",MH"
         else:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setVal(self.options.mass)
@@ -91,17 +93,20 @@ class StageZero(STXSBaseModel):
     def doVar(self,x,constant=True):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*","",x)
-        self.modelBuilder.out.var(vname).setConstant(constant)
-        print "SignalStrengths:: declaring %s as %s, and set to constant" % (vname,x)
+        #self.modelBuilder.out.var(vname).setConstant(constant)
+        print "SignalStrengths:: declaring %s as %s" % (vname,x)
     def doParametersOfInterest(self):
         """Create POI out of signal strengths (and MH)"""
-        self.doMH()
+	pois = []
         for X in [ "qqH", "ggH", "ttH", "QQ2HLNU", "QQ2HLL", "VH2HQQ"]:
             self.doVar("r_%s[1,0,10]" % X)
+	    pois.append("r_%s"%X)
+	self.POIs=",".join(pois)
+        self.doMH()
         print "Default parameters of interest: ", self.POIs
         self.modelBuilder.doSet("POI",self.POIs)
-        self.SMH = SMHiggsBuilder(self.modelBuilder)
-        self.setup()
+        #self.SMH = SMHiggsBuilder(self.modelBuilder)
+        #self.setup()
     def setup(self):
 	return 
 


### PR DESCRIPTION
Adding a model for Stage0 in the STXS (inherits from PhysicsModel)
`getSTXSProdDecMode` defined to allow for separate parsing of process string from the usual SMHiggs model. 

Change to PhysicsModel.py allow for STXS based datacards to be used with the LHCHCG-type (kappa) models since only the first part of the production and the decay is needed. 
