### PR TITLE
RooParametericShapeBinPdf 81X

### DIFF
--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -28,6 +28,8 @@ public:
    RooParametricShapeBinPdf() {} ;
    RooParametricShapeBinPdf(const char *name, const char *title,  const char *formula, 
 		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
+   RooParametricShapeBinPdf(const char *name, const char *title,  RooAbsReal& _pdf, 
+		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
    RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,
       const char* name = 0);
    void setTH1Binning(const TH1& _Hnominal);

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -26,8 +26,10 @@ class RooParametricShapeBinPdf : public RooAbsPdf
 {
 public:
    RooParametricShapeBinPdf() {} ;
+   /*
    RooParametricShapeBinPdf(const char *name, const char *title,  const char *formula, 
 		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
+   */
    RooParametricShapeBinPdf(const char *name, const char *title,  RooAbsReal& _pdf, 
 		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
    RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -27,7 +27,7 @@ class RooParametricShapeBinPdf : public RooAbsPdf
 public:
    RooParametricShapeBinPdf() {} ;
    RooParametricShapeBinPdf(const char *name, const char *title,  const char *formula, 
-		  RooAbsReal& _th1x, RooArgList& _pars, const TH1 &_shape );
+		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
    RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,
       const char* name = 0);
    void setTH1Binning(const TH1& _Hnominal);
@@ -41,7 +41,7 @@ public:
 
 protected:   
 
-   RooRealProxy th1x;        // dependent variable
+   RooRealProxy x;        // dependent variable
    RooListProxy pars;
    TF1 * myfunc;
    Int_t xBins;        // X bins
@@ -54,7 +54,7 @@ protected:
 
    Double_t evaluate() const;
 private:
-   ClassDef(RooParametricShapeBinPdf,1) // RazorDijetBinPdf function
+   ClassDef(RooParametricShapeBinPdf,1) // RooParametricShapeBinPdf function
     
 };
 //---------------------------------------------------------------------------

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -35,6 +35,7 @@ public:
    void setTH1Binning(const TH1& _Hnominal);
    void setAbsTol(double _absTol);
    void setRelTol(double _relTol);
+   RooAbsPdf* getPdf() const;
    virtual TObject* clone(const char* newname) const { return new RooParametricShapeBinPdf(*this,newname); }
    inline virtual ~RooParametricShapeBinPdf() { }
 
@@ -45,6 +46,7 @@ protected:
 
    RooRealProxy x;        // dependent variable
    RooListProxy pars;
+   RooRealProxy mypdf;
    TF1 * myfunc;
    Int_t xBins;        // X bins
    Double_t xArray[2000]; // xArray[xBins+1]
@@ -56,6 +58,19 @@ protected:
 
    Double_t evaluate() const;
 private:
+   virtual RooPlot* plotOn(RooPlot* frame, 
+              const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
+              const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
+              const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
+              const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),
+              const RooCmdArg& arg9=RooCmdArg::none(), const RooCmdArg& arg10=RooCmdArg::none()
+                 ) const {
+     return mypdf.arg().plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
+     }
+     virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const {
+       return mypdf.arg().plotOn(frame,cmdList) ;
+     }
+     
    ClassDef(RooParametricShapeBinPdf,1) // RooParametricShapeBinPdf function
     
 };

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -48,9 +48,9 @@ protected:
    Double_t xArray[2000]; // xArray[xBins+1]
    Double_t xMax;        // X max
    Double_t xMin;        // X min
-   Int_t nPars;
    Double_t relTol;      //relative tolerance for numerical integration
    Double_t absTol;      //absolute tolerance for numerical integration
+   Int_t nPars;
 
    Double_t evaluate() const;
 private:

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------------
+#ifndef ROOPARAMETRICSHAPEBINPDF
+#define ROOPARAMETRICSHAPEBINPDF
+//---------------------------------------------------------------------------
+#include "RooAbsPdf.h"
+#include "RooConstVar.h"
+#include "RooRealProxy.h"
+//---------------------------------------------------------------------------
+class RooRealVar;
+class RooAbsReal;
+
+#include "Riostream.h"
+#include "TMath.h"
+#include <TH1.h>
+#include <TF1.h>
+#include "Math/SpecFuncMathCore.h"
+#include "Math/SpecFuncMathMore.h"
+#include "Math/Functor.h"
+#include "Math/WrappedFunction.h"
+#include "Math/WrappedTF1.h"
+#include "Math/IFunction.h"
+#include "Math/Integrator.h"
+
+//---------------------------------------------------------------------------
+class RooParametricShapeBinPdf : public RooAbsPdf
+{
+public:
+   RooParametricShapeBinPdf() {} ;
+   RooParametricShapeBinPdf(const char *name, const char *title,  const char *formula, 
+		  RooAbsReal& _th1x, RooArgList& _pars, const TH1 &_shape );
+   RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,
+      const char* name = 0);
+   void setTH1Binning(const TH1& _Hnominal);
+   void setAbsTol(double _absTol);
+   void setRelTol(double _relTol);
+   virtual TObject* clone(const char* newname) const { return new RooParametricShapeBinPdf(*this,newname); }
+   inline virtual ~RooParametricShapeBinPdf() { }
+
+   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
+   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+
+protected:   
+
+   RooRealProxy th1x;        // dependent variable
+   RooListProxy pars;
+   TF1 * myfunc;
+   Int_t xBins;        // X bins
+   Double_t xArray[2000]; // xArray[xBins+1]
+   Double_t xMax;        // X max
+   Double_t xMin;        // X min
+   Int_t nPars;
+   Double_t relTol;      //relative tolerance for numerical integration
+   Double_t absTol;      //absolute tolerance for numerical integration
+
+   Double_t evaluate() const;
+private:
+   ClassDef(RooParametricShapeBinPdf,1) // RazorDijetBinPdf function
+    
+};
+//---------------------------------------------------------------------------
+#endif
+

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -23,6 +23,7 @@ using namespace RooFit;
 
 ClassImp(RooParametricShapeBinPdf)
 //---------------------------------------------------------------------------
+/*
 RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char *title, const char *formula, 
 			       RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape ) : RooAbsPdf(name, title), 
   x("x", "x Observable", this, _x),
@@ -49,6 +50,7 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char 
   //mypdf.setArg((RooAbsPdf&)* new RooTFnBinding("mypdf","mypdf",myfunc,obs,pars));
   nPars = pars.getSize();
 }
+*/
 //---------------------------------------------------------------------------
 RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char *title, RooAbsReal& _pdf, 
 			       RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape ) : RooAbsPdf(name, title), 

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -9,6 +9,7 @@
 
 #include "HiggsAnalysis/CombinedLimit/interface/RooParametricShapeBinPdf.h"
 #include "RooRealVar.h"
+#include "RooArgList.h"
 #include "RooConstVar.h"
 #include "Math/Functor.h"
 #include "Math/WrappedFunction.h"
@@ -40,6 +41,30 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char 
   }
   setTH1Binning(_shape);  
   myfunc = new TF1("myfunc",formula,xMin,xMax);
+  nPars = pars.getSize();
+}
+//---------------------------------------------------------------------------
+RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char *title, RooAbsReal& _pdf, 
+			       RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape ) : RooAbsPdf(name, title), 
+  x("x", "x Observable", this, _x),
+  pars("pars","pars",this),
+  xBins(0),
+  xMax(0),
+  xMin(0),
+  relTol(1E-12),
+  absTol(1E-12),
+  nPars(0)
+{
+  memset(&xArray, 0, sizeof(xArray));
+  TIterator *varIter=_pars.createIterator(); 
+  RooAbsReal *fVar;
+  while ( (fVar = (RooAbsReal*)varIter->Next()) ){
+	pars.add(*fVar);
+  }
+  setTH1Binning(_shape);
+  RooArgList obs;
+  obs.add(x.arg());
+  myfunc = _pdf.asTF(obs,pars);
   nPars = pars.getSize();
 }
 //---------------------------------------------------------------------------

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -1,0 +1,189 @@
+//---------------------------------------------------------------------------
+#include "RooFit.h"
+
+#include "Riostream.h"
+#include <TMath.h>
+#include <cassert>
+#include <cmath>
+#include <math.h>
+
+#include "HiggsAnalysis/CombinedLimit/interface/RooParametricShapeBinPdf.h"
+#include "RooRealVar.h"
+#include "RooConstVar.h"
+#include "Math/Functor.h"
+#include "Math/WrappedFunction.h"
+#include "Math/IFunction.h"
+#include "Math/Integrator.h"
+#include "Math/GSLIntegrator.h"
+
+using namespace std;
+using namespace RooFit;
+
+ClassImp(RooParametricShapeBinPdf)
+//---------------------------------------------------------------------------
+RooParametricShapeBinPdf::RooDijetBinPdf(const char *name, const char *title, const char *formula, 
+			       RooAbsReal& _th1x, RooArgList& _pars, const TH1 &_shape ) : RooAbsPdf(name, title), 
+  th1x("th1x", "th1x Observable", this, _th1x),
+  pars("pars","pars",this),
+  xBins(0),
+  xMax(0),
+  xMin(0),
+  relTol(1E-12),
+  absTol(1E-12),
+  nPars(0)
+{
+  memset(&xArray, 0, sizeof(xArray));
+  TIterator *varIter=_pars.createIterator(); 
+  RooAbsReal *fVar;
+  while ( (fVar = (RooAbsReal*)varIter->Next()) ){
+	pars.add(*fVar);
+  }
+  setTH1Binning(_shape);  
+  myfunc = new TF1("myfunc",formula,xMin,xMax);
+  nPars = pars.getSize();
+}
+//---------------------------------------------------------------------------
+RooParametricShapeBinPdf::RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other, const char* name) : RooAbsPdf(other, name), 
+   th1x("th1x", this, other.th1x),
+   pars("_pars",this,RooListProxy()),
+   xBins(other.xBins),
+   xMax(other.xMax),
+   xMin(other.xMin),
+   relTol(other.relTol),
+   absTol(other.absTol),
+   nPars(other.nPars)
+{
+  //memset(&xArray, 0, sizeof(xArray));
+  for (Int_t i=0; i<xBins+1; i++){
+    xArray[i] = other.xArray[i];
+  }
+  
+  TIterator *varIter=other.pars.createIterator(); 
+  RooAbsReal *fVar;
+  while ( (fVar = (RooAbsReal*) varIter->Next()) ){
+	pars.add(*fVar);
+  }
+  myfunc = new TF1(*(other.myfunc));
+  
+}
+//---------------------------------------------------------------------------
+void RooParametricShapeBinPdf::setTH1Binning(const TH1 &_Hnominal){
+  xBins = _Hnominal.GetXaxis()->GetNbins();
+  xMin = _Hnominal.GetXaxis()->GetBinLowEdge(1);
+  xMax = _Hnominal.GetXaxis()->GetBinUpEdge(xBins);
+  memset(&xArray, 0, sizeof(xArray));
+  for (Int_t i=0; i<xBins+1; i++){
+    xArray[i] =  _Hnominal.GetXaxis()->GetBinLowEdge(i+1);
+  }
+}
+//---------------------------------------------------------------------------
+void RooParametricShapeBinPdf::setRelTol(double _relTol){
+  relTol = _relTol;
+}
+//---------------------------------------------------------------------------
+void RooParametricShapeBinPdf::setAbsTol(double _absTol){
+  absTol = _absTol;
+}
+//---------------------------------------------------------------------------
+Double_t RooParametricShapeBinPdf::evaluate() const
+{
+  Double_t integral = 0.0;
+  
+
+  Int_t iBin = (Int_t) th1x;
+  if(iBin < 0 || iBin >= xBins) {
+    //cout << "in bin " << iBin << " which is outside of range" << endl;
+    return 0.0;
+  }
+  
+  Double_t xLow = xArray[iBin];
+  Double_t xHigh = xArray[iBin+1];
+    
+  // define the function to be integrated numerically  
+  ROOT::Math::WrappedTF1 func(*myfunc);
+  double *params = myfunc->GetParameters();  
+  TIterator *varIter=pars.createIterator(); 
+  RooAbsReal *fVar;
+  int iPar = 0;
+  while ( (fVar = (RooAbsReal*) varIter->Next()) ){
+    params[iPar] = fVar->getVal();
+    iPar+=1;
+  }
+  myfunc->SetParameters(params);
+  func.SetParameters(params);
+
+
+  ROOT::Math::Integrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE,absTol,relTol);
+  ig.SetFunction(func,false);
+  
+  integral = ig.Integral(xLow,xHigh);
+  //Double_t total_integral = ig.Integral(xMin,xMax);
+
+  if (integral>0.0) {
+    return integral;
+  } else return 0;
+
+}
+
+// //---------------------------------------------------------------------------
+Int_t RooParametricShapeBinPdf::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName) const{
+  if (matchArgs(allVars, analVars, th1x)) return 1;
+  return 0;
+}
+
+// //---------------------------------------------------------------------------
+Double_t RooParametricShapeBinPdf::analyticalIntegral(Int_t code, const char* rangeName) const{
+
+   Double_t th1xMin = th1x.min(rangeName); Double_t th1xMax = th1x.max(rangeName);
+   Int_t iBinMin = (Int_t) th1xMin; Int_t iBinMax = (Int_t) th1xMax;
+
+   Double_t integral = 0.0;
+      
+   //cout <<  "iBinMin = " << iBinMin << ",iBinMax = " << iBinMax << endl;
+
+   
+   // define the function to be integrated numerically  
+   ROOT::Math::WrappedTF1 func(*myfunc);
+   double *params = myfunc->GetParameters();
+   TIterator *varIter=pars.createIterator(); 
+   RooAbsReal *fVar;
+   int iPar = 0;
+   while ( (fVar = (RooAbsReal*) varIter->Next()) ){
+     params[iPar] = fVar->getVal();
+     iPar+=1;
+   }
+   myfunc->SetParameters(params);
+   func.SetParameters(params);
+   
+   ROOT::Math::Integrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE,absTol,relTol);
+   ig.SetFunction(func,false);
+    
+
+   if (code==1 && iBinMin<=0 && iBinMax>=xBins){
+     integral = ig.Integral(xMin,xMax);
+     
+   }
+   else if(code==1) { 
+     for (Int_t iBin=iBinMin; iBin<iBinMax; iBin++){
+       
+       if(iBin < 0 || iBin >= xBins) {
+	 integral += 0.0;
+       }
+       else{	 
+	 Double_t xLow = xArray[iBin];
+	 Double_t xHigh = xArray[iBin+1];    
+	 integral += ig.Integral(xLow,xHigh);
+       }
+     }
+   } else {
+     cout << "WARNING IN RooParametricShapeBinPdf: integration code is not correct" << endl;
+     cout << "                           what are you integrating on?" << endl;
+     return 1.0;
+   }
+
+   if (integral>0.0) {
+     return integral;
+   } else return 1.0;
+}
+// //---------------------------------------------------------------------------
+

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -142,7 +142,7 @@ Double_t RooParametricShapeBinPdf::evaluate() const
   ROOT::Math::Integrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE,absTol,relTol);
   ig.SetFunction(func,false);
   
-  integral = ig.Integral(xLow,xHigh);
+  integral = ig.Integral(xLow,xHigh) / (xHigh-xLow); //return integral as a density 
   //Double_t total_integral = ig.Integral(xMin,xMax);
 
   if (integral>0.0) {

--- a/src/classes.h
+++ b/src/classes.h
@@ -31,6 +31,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooMomentMorphND.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooMorphingPdf.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooParametricHist.h"
+#include "HiggsAnalysis/CombinedLimit/interface/RooParametricShapeBinPdf.h"
 #include "HiggsAnalysis/CombinedLimit/interface/GaussExp.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooDoubleCBFast.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -117,6 +117,7 @@
 	<class name="VerticalInterpPdf" />
 	<class name="GaussExp" />
 	<class name="RooParametricHist" />
+	<class name="RooParametricShapeBinPdf" />
 	<class name="RooMorphingPdf" />
         <function name="function th1fmorph" />
   <class name="CMSHistFunc" />


### PR DESCRIPTION
This is an attempt to make #325 more general and responding to the comments I received. This is now this is a fully generic binned pdf, which implements a TF1-style parametric function. The dependent variable "x" is now the actual variable that is being integrated. The class numerically integrates the TF1 function over each (possibly variable-width) bin, and returns that value as a constant over the bin. This would allow analysts to use parametric models in conjunction with binned MC templates without worrying about the RooFit-evaluation-at-the-center-of-the-bin problem. 

A specialized version of this has been used for the EXO-16-032 (ICHEP dijet), EXO-16-056 (Moriond dijet), and EXO-17-002 (gamma+jet) analyses. I've validated that this new class reproduces the most recent 2016 dijet fit results. Below is a python snippet showing how to define the pdf for the case of the dijet fit. Let me know if you think this would be useful.

Thanks,

Javier

```python
import ROOT as rt
from array import array
w = rt.RooWorkspace('w')
w.factory('mjj[489,489,2037]')
w.factory('p1_CaloDijet2016[4.1]')
w.factory('p2_CaloDijet2016[7.9]')
w.factory('p3_CaloDijet2016[0.6]')
w.factory('p4_CaloDijet2016[0.025]')
w.factory('sqrts[13000]')
parlist = rt.RooArgList('pars_CaloDijet2016')
parlist.add(w.var('sqrts'))
parlist.add(w.var('p1_CaloDijet2016'))
parlist.add(w.var('p2_CaloDijet2016'))
parlist.add(w.var('p3_CaloDijet2016'))
parlist.add(w.var('p4_CaloDijet2016'))
x = array('d',[489, 526, 565, 606, 649, 693, 740, 788, 838, 890, 944, 1000, 1058, 1118, 1181, 1246, 1313, 1383, 1455, 1530, 1607, 1687, 1770, 1856, 1945, 2037])
emptyHist1D = rt.TH1D("emptyHist1D","emptyHist1D",len(x)-1,x)
pdf = rt.RooParametricShapeBinPdf("CaloDijet2016_bkg","CaloDijet2016_bkg","pow(1-x/[0],[1])/pow(x/[0],[2]+[3]*log(x/[0])+[4]*log(x/[0])*log(x/[0]))",w.var('mjj'),parlist,emptyHist1D)
pdf.Print("v")
```