### PR TITLE
Nckw python config

### DIFF
--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -80,7 +80,7 @@ MB = None
 	print "DC.exp = 	"		, self.exp                      ,"#",type(self.exp)			
 	print "DC.systs = 	"		, self.systs                    ,"#",type(self.systs)		
 	print "DC.shapeMap = 	"		, self.shapeMap                 ,"#",type(self.shapeMap)		
-	print "DC.hasShapes = 	"		, self.hasShapes                 ,"#",type(self.hasShapes)		
+	print "DC.hasShapes = 	"		, self.hasShapes                ,"#",type(self.hasShapes)		
 	print "DC.flatParamNuisances = "	, self.flatParamNuisances       ,"#",type(self.flatParamNuisances)	
 	print "DC.rateParams = "		, self.rateParams               ,"#",type(self.rateParams)		
 	print "DC.extArgs = 	"		, self.extArgs                  ,"#",type(self.extArgs)		
@@ -96,7 +96,7 @@ MB = None
 ###### User defined options #############################################
 
 options.out 	 = "combine_workspace.root"  	# Output workspace name
-options.fileName = "./data/tutorials/shapes/" 	# Path to input ROOT files 
+options.fileName = "./" 			# Path to input ROOT files 
 options.verbose  = "1" 				# Verbosity
 
 ##########################################################################

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -27,11 +27,14 @@ class Datacard():
         ## list of [{bin : {process : [input file, path to shape, path to shape for uncertainty]}}]
         self.shapeMap = {}
         ## boolean that indicates whether the datacard contains shapes or not
-        self.hasShape = False
+        self.hasShapes = False
         ## dirct of {name of uncert, boolean to indicate whether it is a flat parametric uncertainty or not}
         self.flatParamNuisances = {}
+	## dict of rateParam 
         self.rateParams = {}
+	## dict of extArgs 
         self.extArgs = {}
+	## maintain the order for rate modifiers
         self.rateParamsOrder = set() 
         ## dirct of {name of uncert, boolean to indicate whether this nuisance is floating or not}
         self.frozenNuisances = set()
@@ -41,6 +44,72 @@ class Datacard():
 
         # Keep edits 
 	self.nuisanceEditLines = []
+
+	self.groups = {}
+	self.discretes = []
+
+    def print_structure(self):
+	"""
+	Print the contents of the -> should allow for direct text2workspace on python config
+	"""
+	print """
+from HiggsAnalysis.CombinedLimit.DatacardParser import *
+from HiggsAnalysis.CombinedLimit.ModelTools import *
+from HiggsAnalysis.CombinedLimit.ShapeTools import *
+from HiggsAnalysis.CombinedLimit.PhysicsModel import *
+
+from sys import argv, stdout, stderr, exit, modules
+from optparse import OptionParser
+parser = OptionParser()
+addDatacardParserOptions(parser)
+options,args = parser.parse_args()
+options.bin = True # make a binary workspace
+
+DC = Datacard()
+MB = None
+
+############## Setup the datacard (must be filled in) ###########################
+	"""
+
+	print "DC.bins = 	"		, self.bins			,"#",type(self.bins)		
+	print "DC.obs = 	"		, self.obs                      ,"#",type(self.obs)			
+	print "DC.processes = 	"		, self.processes                ,"#",type(self.processes)		
+	print "DC.signals = 	"		, self.signals                  ,"#",type(self.signals)		
+	print "DC.isSignal = 	"		, self.isSignal                 ,"#",type(self.isSignal)		
+	print "DC.keyline = 	"		, self.keyline                  ,"#",type(self.keyline)		
+	print "DC.exp = 	"		, self.exp                      ,"#",type(self.exp)			
+	print "DC.systs = 	"		, self.systs                    ,"#",type(self.systs)		
+	print "DC.shapeMap = 	"		, self.shapeMap                 ,"#",type(self.shapeMap)		
+	print "DC.hasShapes = 	"		, self.hasShapes                 ,"#",type(self.hasShapes)		
+	print "DC.flatParamNuisances = "	, self.flatParamNuisances       ,"#",type(self.flatParamNuisances)	
+	print "DC.rateParams = "		, self.rateParams               ,"#",type(self.rateParams)		
+	print "DC.extArgs = 	"		, self.extArgs                  ,"#",type(self.extArgs)		
+	print "DC.rateParamsOrder 	= "	, self.rateParamsOrder          ,"#",type(self.rateParamsOrder)	
+	print "DC.frozenNuisances 	= "	, self.frozenNuisances          ,"#",type(self.frozenNuisances)	
+	print "DC.systematicsShapeMap = "	, self.systematicsShapeMap      ,"#",type(self.systematicsShapeMap)	
+	print "DC.nuisanceEditLines 	= "	, self.nuisanceEditLines        ,"#",type(self.nuisanceEditLines)	
+	print "DC.groups 	= "		, self.groups        		,"#",type(self.groups)	
+	print "DC.discretes 	= "		, self.discretes        	,"#",type(self.discretes)	
+
+	print """
+
+###### User defined options #############################################
+
+options.out 	 = "combine_workspace.root"  	# Output workspace name
+options.fileName = "./data/tutorials/shapes/" 	# Path to input ROOT files 
+options.verbose  = "1" 				# Verbosity
+
+##########################################################################
+
+if DC.hasShapes:
+    MB = ShapeBuilder(DC, options)
+else:
+    MB = CountingModelBuilder(DC, options)
+
+# Set physics models 
+MB.setPhysics(defaultModel)
+MB.doModel()
+	"""
 
     def list_of_bins(self) :
         """

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -58,7 +58,7 @@ from HiggsAnalysis.CombinedLimit.ModelTools import *
 from HiggsAnalysis.CombinedLimit.ShapeTools import *
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 
-from sys import argv, stdout, stderr, exit, modules
+from sys import exit
 from optparse import OptionParser
 parser = OptionParser()
 addDatacardParserOptions(parser)

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -77,6 +77,8 @@ def parseCard(file, options):
     if type(file) == type("str"):
         raise RuntimeError, "You should pass as argument to parseCards a file object, stream or a list of lines, not a string"
     ret = Datacard()
+
+    # resetting these here to defaults, parseCard will fill them up
     ret.discretes=[]
     ret.groups={}
  

--- a/scripts/text2workspace.py
+++ b/scripts/text2workspace.py
@@ -19,6 +19,7 @@ parser = OptionParser(usage="usage: %prog [options] datacard.txt -o output \nrun
 addDatacardParserOptions(parser)
 parser.add_option("-P", "--physics-model", dest="physModel", default="HiggsAnalysis.CombinedLimit.PhysicsModel:defaultModel",  type="string", help="Physics model to use. It should be in the form (module name):(object name)")
 parser.add_option("--PO", "--physics-option", dest="physOpt", default=[],  type="string", action="append", help="Pass a given option to the physics model (can specify multiple times)")
+parser.add_option("", "--dump-datacard", dest="dumpCard", default=False, action='store_true',  help="Print to screen the DataCard as a python config and exit")
 (options, args) = parser.parse_args()
 
 if len(args) == 0:
@@ -35,6 +36,10 @@ else:
 
 ## Parse text file 
 DC = parseCard(file, options)
+
+if options.dumpCard:
+    DC.print_structure()
+    exit()
 
 ## Load tools to build workspace
 MB = None


### PR DESCRIPTION
Allow for printing of Datacard object as python script with the text2workspace option `--dump-datacard`. 

This allows users to produce a template script for building a combine friendly workspace without a text file (for fast studies of simple analyses)

Also fixed member of Datacard (not being used)