### PR TITLE
Nckw add generic keyword in datacard

### DIFF
--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
     ("igpMem", "Setup support for memory profiling using IgProf")
     ("perfCounters", "Dump performance counters at end of job")
     ("LoadLibrary,L", po::value<vector<string> >(&librariesToLoad), "Load library through gSystem->Load(...). Can specify multiple libraries using this option multiple times")
-    ("model-point",  po::value<vector<string> >(&modelPoints), "Set model point values with 'PARAM=X', will replace $PARAM with X in datacards. Filename will also be extended with 'paramX'. Can specify multiple times")
+    ("keyword-value",  po::value<vector<string> >(&modelPoints), "Set keyword values with 'WORD=VALUE', will replace $WORD with VALUE in datacards. Filename will also be extended with 'WORDVALUE'. Can specify multiple times")
     ("X-rtd",  po::value<vector<string> >(&runtimeDefines), "Define some constants to be used at runtime (for debugging purposes). The syntax is --X-rtd identifier[=value], where value is an integer and defaults to 1. Can specify multiple times")
     ("X-fpeMask", po::value<int>(), "Set FPE mask: 1=NaN, 2=Div0, 4=Overfl, 8=Underf, 16=Inexact; 7=default")
     ;
@@ -232,15 +232,15 @@ int main(int argc, char **argv) {
   if (vm.count("expectedFromGrid") && !vm["expectedFromGrid"].defaulted()) toyName += TString::Format("quant%.3f.", vm["expectedFromGrid"].as<float>());
   if (vm.count("expected")         && !vm["expected"].defaulted())         toyName += TString::Format("quant%.3f.", vm["expected"].as<float>());
 
-  if (vm.count("model-point") ) {
+  if (vm.count("keyword-value") ) {
     for (vector<string>::const_iterator rmp = modelPoints.begin(), endrmp = modelPoints.end(); rmp != endrmp; ++rmp) {
       std::string::size_type idx = rmp->find('=');
       if (idx == std::string::npos) {
-     	cerr << "No value found for model point :\n\t" << *rmp << " use --model-point PARAMETER=X " << std::endl;
+     	cerr << "No value found for keyword :\n\t" << *rmp << " use --keyword-value WORD=VALUE " << std::endl;
       } else {
         std::string name   = rmp->substr(0, idx);
         std::string svalue = rmp->substr(idx+1);
-        if (verbose > 0) std::cout << "Setting model point " << name << " to " << svalue << std::endl;
+        if (verbose > 0) std::cout << "Setting keyword " << name << " to " << svalue << std::endl;
 	modelParamNameVector_.push_back(name);
 	modelParamValVector_.push_back(svalue);
 	massName += TString(name.c_str())+TString(svalue.c_str())+".";

--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -43,6 +43,9 @@ int main(int argc, char **argv) {
 
   vector<string> librariesToLoad;
   vector<string> runtimeDefines;
+  vector<string> modelPoints;
+  vector<string> modelParamNameVector_;
+  vector<string> modelParamValVector_;
 
   Combine combiner;
 
@@ -90,6 +93,7 @@ int main(int argc, char **argv) {
     ("igpMem", "Setup support for memory profiling using IgProf")
     ("perfCounters", "Dump performance counters at end of job")
     ("LoadLibrary,L", po::value<vector<string> >(&librariesToLoad), "Load library through gSystem->Load(...). Can specify multiple libraries using this option multiple times")
+    ("model-point",  po::value<vector<string> >(&modelPoints), "Set model point values with 'PARAM=X', will replace $PARAM with X in datacards. Filename will also be extended with 'paramX'. Can specify multiple times")
     ("X-rtd",  po::value<vector<string> >(&runtimeDefines), "Define some constants to be used at runtime (for debugging purposes). The syntax is --X-rtd identifier[=value], where value is an integer and defaults to 1. Can specify multiple times")
     ("X-fpeMask", po::value<int>(), "Set FPE mask: 1=NaN, 2=Div0, 4=Overfl, 8=Underf, 16=Inexact; 7=default")
     ;
@@ -227,6 +231,23 @@ int main(int argc, char **argv) {
   TString toyName  = "";  if (runToys > 0 || seed != 123456 || vm.count("saveToys")) toyName  = TString::Format("%d.", seed);
   if (vm.count("expectedFromGrid") && !vm["expectedFromGrid"].defaulted()) toyName += TString::Format("quant%.3f.", vm["expectedFromGrid"].as<float>());
   if (vm.count("expected")         && !vm["expected"].defaulted())         toyName += TString::Format("quant%.3f.", vm["expected"].as<float>());
+
+  if (vm.count("model-point") ) {
+    for (vector<string>::const_iterator rmp = modelPoints.begin(), endrmp = modelPoints.end(); rmp != endrmp; ++rmp) {
+      std::string::size_type idx = rmp->find('=');
+      if (idx == std::string::npos) {
+     	cerr << "No value found for model point :\n\t" << *rmp << " use --model-point PARAMETER=X " << std::endl;
+      } else {
+        std::string name   = rmp->substr(0, idx);
+        std::string svalue = rmp->substr(idx+1);
+        if (verbose > 0) std::cout << "Setting model point " << name << " to " << svalue << std::endl;
+	modelParamNameVector_.push_back(name);
+	modelParamValVector_.push_back(svalue);
+	massName += TString(name.c_str())+TString(svalue.c_str())+".";
+     }
+    }
+  }
+
   TString fileName = "higgsCombine" + name + "."+whichMethod+"."+massName+toyName+"root";
   TFile *test = new TFile(fileName, "RECREATE"); outputFile = test;
   TTree *t = new TTree("limit", "limit");
@@ -242,6 +263,10 @@ int main(int argc, char **argv) {
   t->Branch("t_cpu",   &t_cpu_,  "t_cpu/F");
   t->Branch("t_real",  &t_real_, "t_real/F");
   t->Branch("quantileExpected",  &g_quantileExpected_, "quantileExpected/F");
+  for (unsigned int mpi=0;mpi<modelParamNameVector_.size();++mpi){
+	std::string name = modelParamNameVector_[mpi];
+  	t->Branch(Form("%s",name.c_str()),  &modelParamValVector_[mpi]);
+  }
   
   writeToysHere = test->mkdir("toys","toys"); 
   if (toysFile != "") readToysFromHere = TFile::Open(toysFile.c_str());

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -95,6 +95,7 @@ private:
   bool floatAllNuisances_;
   bool freezeAllGlobalObs_;
   std::vector<std::string> librariesToLoad_;
+  std::vector<std::string> modelPoints_;
   
   static TTree *tree_;
 

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -14,6 +14,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("-m", "--mass",     dest="mass",     default=0,  type="float",  help="Higgs mass to use. Will also be written in the Workspace as RooRealVar 'MH'.")
     parser.add_option("-D", "--dataset",  dest="dataname", default="data_obs",  type="string",  help="Name of the observed dataset")
     parser.add_option("-L", "--LoadLibrary", dest="libs",  type="string" , action="append", help="Load these libraries")
+    parser.add_option("--model-point",     dest="modelparams",  default = [], nargs=1, type='string', action='append',  help="Set model point values with 'PARAM=X', will replace $PARAM with X in datacards. Filename will also be extended with 'paramX' ")
     parser.add_option("--poisson",  dest="poisson",  default=0,  type="int",    help="If set to a positive number, binned datasets wih more than this number of entries will be generated using poissonians")
     parser.add_option("--default-morphing",  dest="defMorph", type="string", default="shape2N", help="Default template morphing algorithm (to be used when the datacard has just 'shape')")
     parser.add_option("--no-b-only","--for-fits",    dest="noBOnly", default=False, action="store_true", help="Do not save the background-only pdf (saves time)")

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -14,7 +14,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("-m", "--mass",     dest="mass",     default=0,  type="float",  help="Higgs mass to use. Will also be written in the Workspace as RooRealVar 'MH'.")
     parser.add_option("-D", "--dataset",  dest="dataname", default="data_obs",  type="string",  help="Name of the observed dataset")
     parser.add_option("-L", "--LoadLibrary", dest="libs",  type="string" , action="append", help="Load these libraries")
-    parser.add_option("--model-point",     dest="modelparams",  default = [], nargs=1, type='string', action='append',  help="Set model point values with 'PARAM=X', will replace $PARAM with X in datacards. Filename will also be extended with 'paramX' ")
+    parser.add_option("--keyword-value",     dest="modelparams",  default = [], nargs=1, type='string', action='append',  help="Set keyword values with 'WORD=VALUE', will replace $WORD with VALUE in datacards. Filename will also be extended with 'WORDVALUE' ")
     parser.add_option("--poisson",  dest="poisson",  default=0,  type="int",    help="If set to a positive number, binned datasets wih more than this number of entries will be generated using poissonians")
     parser.add_option("--default-morphing",  dest="defMorph", type="string", default="shape2N", help="Default template morphing algorithm (to be used when the datacard has just 'shape')")
     parser.add_option("--no-b-only","--for-fits",    dest="noBOnly", default=False, action="store_true", help="Do not save the background-only pdf (saves time)")

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -364,7 +364,7 @@ class ShapeBuilder(ModelBuilder):
         strmass = "%d" % self.options.mass if self.options.mass % 1 == 0 else str(self.options.mass)
         finalNames = [ x.replace("$PROCESS",process).replace("$CHANNEL",channel).replace("$SYSTEMATIC",syst).replace("$MASS",strmass) for x in names ]
 	for mp in self.options.modelparams:
-	   if len(mp.split('='))!=2 : raise RuntimeError, "No value found for model point in %s (use --model-point PARAMTER=X)"%mp 
+	   if len(mp.split('='))!=2 : raise RuntimeError, "No value found for keyword in %s (use --keyword-value WORD=VALUE)"%mp 
 	   mpname, mpv = mp.split('=')
 	   protected_kwords =  ["PROCESS","CHANNEL","SYSTEMATIC","MASS"]
 	   if mpname in protected_kwords: raise RuntimeError, "Cannot use the following keywords (already assigned in combine): $"+" $".join(protected_kwords) 

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -363,6 +363,10 @@ class ShapeBuilder(ModelBuilder):
             names = [names[0], names[1]]
         strmass = "%d" % self.options.mass if self.options.mass % 1 == 0 else str(self.options.mass)
         finalNames = [ x.replace("$PROCESS",process).replace("$CHANNEL",channel).replace("$SYSTEMATIC",syst).replace("$MASS",strmass) for x in names ]
+	for mp in self.options.modelparams:
+	   if len(mp.split('='))!=2 : raise RuntimeError, "No value found for model point in %s (use --model-point PARAMTER=X)"%mp 
+	   mpname, mpv = mp.split('=')
+           finalNames = [ fn.replace("$%s"%mpname,mpv) for fn in finalNames ]
         if not _fileCache.has_key(finalNames[0]): 
             trueFName = finalNames[0]
             if not os.path.exists(trueFName) and not os.path.isabs(trueFName) and os.path.exists(self.options.baseDir+"/"+trueFName):

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -366,6 +366,8 @@ class ShapeBuilder(ModelBuilder):
 	for mp in self.options.modelparams:
 	   if len(mp.split('='))!=2 : raise RuntimeError, "No value found for model point in %s (use --model-point PARAMTER=X)"%mp 
 	   mpname, mpv = mp.split('=')
+	   protected_kwords =  ["PROCESS","CHANNEL","SYSTEMATIC","MASS"]
+	   if mpname in protected_kwords: raise RuntimeError, "Cannot use the following keywords (already assigned in combine): $"+" $".join(protected_kwords) 
            finalNames = [ fn.replace("$%s"%mpname,mpv) for fn in finalNames ]
         if not _fileCache.has_key(finalNames[0]): 
             trueFName = finalNames[0]

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -192,8 +192,8 @@ void Combine::applyOptions(const boost::program_options::variables_map &vm) {
     librariesToLoad_ = vm["LoadLibrary"].as<std::vector<std::string> >();
   }
 
-  if (vm.count("model-point") ) {
-    modelPoints_ = vm["model-point"].as<std::vector<std::string> >();
+  if (vm.count("keyword-value") ) {
+    modelPoints_ = vm["keyword-value"].as<std::vector<std::string> >();
   }
 }
 
@@ -273,7 +273,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     if (verbose > 1)      options += TString::Format(" --verbose %d", verbose-1);
     if (algo->name() == "FitDiagnostics" || algo->name() == "MultiDimFit") options += " --for-fits";
     for(auto lib2l : librariesToLoad_ ) { options += TString::Format(" --LoadLibrary %s", lib2l.c_str() ); }
-    for(auto mp : modelPoints_) {options +=  TString::Format(" --model-point %s", mp.c_str() ) ;}
+    for(auto mp : modelPoints_) {options +=  TString::Format(" --keyword-value %s", mp.c_str() ) ;}
     //-- Text mode: old default
     //int status = gSystem->Exec("text2workspace.py "+options+" '"+txtFile+"' -o "+tmpFile+".hlf"); 
     //isTextDatacard = true; fileToLoad = tmpFile+".hlf";

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -191,6 +191,10 @@ void Combine::applyOptions(const boost::program_options::variables_map &vm) {
   if( vm.count("LoadLibrary") ) {
     librariesToLoad_ = vm["LoadLibrary"].as<std::vector<std::string> >();
   }
+
+  if (vm.count("model-point") ) {
+    modelPoints_ = vm["model-point"].as<std::vector<std::string> >();
+  }
 }
 
 bool Combine::mklimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr) {
@@ -269,6 +273,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     if (verbose > 1)      options += TString::Format(" --verbose %d", verbose-1);
     if (algo->name() == "FitDiagnostics" || algo->name() == "MultiDimFit") options += " --for-fits";
     for(auto lib2l : librariesToLoad_ ) { options += TString::Format(" --LoadLibrary %s", lib2l.c_str() ); }
+    for(auto mp : modelPoints_) {options +=  TString::Format(" --model-point %s", mp.c_str() ) ;}
     //-- Text mode: old default
     //int status = gSystem->Exec("text2workspace.py "+options+" '"+txtFile+"' -o "+tmpFile+".hlf"); 
     //isTextDatacard = true; fileToLoad = tmpFile+".hlf";


### PR DESCRIPTION
Any keyword can now be used in a datacard to be replaced via command line with option `--keyword-value`

eg, a keyword $WORD in the card can be set with

`--keyword-value WORD=VALUE`

The value will also be saved as a string in the output TTree and the name/value pair will be included in the output ROOT file name
