### PR TITLE
Fix Sentry for RooRealVars with dynamic ranges

### DIFF
--- a/src/SimpleCacheSentry.cc
+++ b/src/SimpleCacheSentry.cc
@@ -34,7 +34,7 @@ void SimpleCacheSentry::addVars(const RooAbsCollection &vars)
     TIterator *iter = vars.createIterator();
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         if (_deps.containsInstance(*a)) continue;
-        // RooRealVars can return false to isDerived() if the ranges or binning depend on
+        // RooRealVars can return true to isDerived() if the ranges or binning depend on
         // other parameters, so always add RooRealVars to the list
         if (dynamic_cast<RooRealVar*>(a)) {
           _deps.add(*a);

--- a/src/SimpleCacheSentry.cc
+++ b/src/SimpleCacheSentry.cc
@@ -34,8 +34,15 @@ void SimpleCacheSentry::addVars(const RooAbsCollection &vars)
     TIterator *iter = vars.createIterator();
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         if (_deps.containsInstance(*a)) continue;
-        if (a->isDerived()) addFunc(*a);
-        else _deps.add(*a);
+        // RooRealVars can return false to isDerived() if the ranges or binning depend on
+        // other parameters, so always add RooRealVars to the list
+        if (dynamic_cast<RooRealVar*>(a)) {
+          _deps.add(*a);
+        } else if (a->isDerived()) {
+          addFunc(*a);
+        } else {
+          _deps.add(*a);
+        }
     }
     delete iter;
 }


### PR DESCRIPTION
Currently the SimpleCacheSentry does not add RooRealVars in a collection
(via addVars) if they have dynamic ranges that depend on other
parameters. The test isDerived() returns true in this case, addFunc is
called on the RooRealVar and the var itself is never added. With this
change RooRealVars are always added to the sentry directly.