### PR TITLE
Minor fixes for CMSHistFunc

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -178,7 +178,11 @@ class ShapeBuilder(ModelBuilder):
                     self.out._import(sum_b, ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
             if channelBinParFlag:
                 for idx in xrange(pdfs.getSize()):
-                    self.out._import(ROOT.CMSHistFuncWrapper(pdfs[idx].GetName() + '_wrapper', '', pdfs.at(idx).getXVar(), pdfs.at(idx), prop, idx), ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
+                    wrapper = ROOT.CMSHistFuncWrapper(pdfs[idx].GetName() + '_wrapper', '', pdfs.at(idx).getXVar(), pdfs.at(idx), prop, idx)
+                    wrapper.setStringAttribute("combine.process", pdfs.at(idx).getStringAttribute("combine.process"))
+                    wrapper.setStringAttribute("combine.channel", pdfs.at(idx).getStringAttribute("combine.channel"))
+                    self.out._import(wrapper, ROOT.RooFit.RecycleConflictNodes(), ROOT.RooFit.Silence())
+
         if self.options.verbose:
             stderr.write("\b\b\b\bdone.\n"); stderr.flush()
     def doCombination(self):

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -114,6 +114,7 @@ CMSHistFunc::CMSHistFunc(CMSHistFunc const& other, const char* name)
       htype_(other.htype_),
       mtype_(other.mtype_),
       vtype_(other.vtype_),
+      divide_by_width_(other.divide_by_width_),
       vsmooth_par_(other.vsmooth_par_) {
   // initialize();
 }
@@ -803,10 +804,13 @@ void CMSHistFunc::prepareInterpCache(Cache& c1,
       x1 = cache_.GetEdge(ix1);
       y = c1.cdf[ix1];
       Double_t x20 = cache_.GetEdge(ix2);
-      Double_t x21 = cache_.GetEdge(ix2 + 1);
       Double_t y20 = c2.cdf[ix2];
-      Double_t y21 = c2.cdf[ix2 + 1];
-
+      Double_t x21 = x20;
+      Double_t y21 = y20;
+      if (ix2 < ix2l) {
+        x21 = cache_.GetEdge(ix2 + 1);
+        y21 = c2.cdf[ix2 + 1];
+      }
       // .....Calculate where the cummulative probability y in distribution 1
       //      intersects between the 2 points from distribution 2 which
       //      bracket it.
@@ -824,9 +828,13 @@ void CMSHistFunc::prepareInterpCache(Cache& c1,
       x2 = cache_.GetEdge(ix2);
       y = c2.cdf[ix2];
       Double_t x10 = cache_.GetEdge(ix1);
-      Double_t x11 = cache_.GetEdge(ix1 + 1);
       Double_t y10 = c1.cdf[ix1];
-      Double_t y11 = c1.cdf[ix1 + 1];
+      Double_t x11 = x10;
+      Double_t y11 = y10;
+      if (ix1 < ix1l) {
+        x11 = cache_.GetEdge(ix1 + 1);
+        y11 = c1.cdf[ix1 + 1];
+      }
 
       // .....Calculate where the cummulative probability y in distribution 2
       //      intersects between the 2 points from distribution 1 which
@@ -871,7 +879,7 @@ void CMSHistFunc::prepareInterpCache(Cache& c1,
     }
   }
 #if HFVERBOSE > 2
-    for (Int_t i = 0; i < nx3; i++) {
+    for (unsigned i = 0; i < c1.y.size(); i++) {
       std::cout << " nx " << i << " " << c1.x1[i] << " " << c1.x2[i] << " " << c1.y[i]
                 << std::endl;
     }

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -594,7 +594,7 @@ void CMSHistFunc::setCdf(Cache& c, FastTemplate const& h) const {
   c.cdf = FastTemplate(h.size() + 1);
   c.integral = integrateTemplate(h);
   for (unsigned i = 1; i < c.cdf.size(); ++i) {
-    c.cdf[i] = h[i - 1] / c.integral + c.cdf[i - 1];
+    c.cdf[i] = (h[i - 1] * cache_.GetWidth(i-1)) / c.integral + c.cdf[i - 1];
   }
   c.cdf_set = true;
 }
@@ -1039,6 +1039,9 @@ FastTemplate CMSHistFunc::cdfMorph(unsigned idx, double par1, double par2,
                   << std::endl;
         std::cout << "Warning - th1fmorph: Zero slope solving x(y)"
                   << std::endl;
+        // for (unsigned z = 0; z < c1.y.size(); ++z) {
+        //   printf("x %.6f x1 %.6f x2 %.6f y %.6f\n", xdisn[z], c1.x1[z], c1.x2[z], c1.y[z]);
+        // }
       }
     }
     sigdisf[ix] = y;
@@ -1058,7 +1061,7 @@ FastTemplate CMSHistFunc::cdfMorph(unsigned idx, double par1, double par2,
 
   for (ix = nbn - 1; ix > -1; ix--) {
     y = sigdisf[ix + 1] - sigdisf[ix];
-    morphedhist[ix] = y;
+    morphedhist[ix] = y / cache_.GetWidth(ix);
   }
 
   // ......All done, return the result.


### PR DESCRIPTION
 - add `combine.channel` and `combine.process` attributes to wrapper functions too
 - CMSHistFunc `divide_by_bin_width` flag was not propagated in copy constructor
 - Bug in the logic of the integral morphing fixed