### PR TITLE
save proper MultiDimFit best fit point

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -195,7 +195,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
 		specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
 	}
-	Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
+	//Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
 	//}
     }
    
@@ -237,7 +237,8 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
         case Stitch2D: doStitch2D(w,*nll); break;
         case Impact: if (res.get()) doImpact(*res, *nll); break;
     }
-    
+    Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.);  
+
     Combine::toggleGlobalFillTree(false);
     return true;
 }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -183,12 +183,14 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     if(w->var("r")) {w->var("r")->Print();}
     if ( loadedSnapshot_ || res.get() || keepFailures_) {
         for (int i = 0, n = poi_.size(); i < n; ++i) {
-            RooAbsArg *rfloat = (*res).floatParsFinal().find(poi_[i].c_str());
-            if (!rfloat) {
-                rfloat = (*res).constPars().find(poi_[i].c_str());
+            if (res.get()){
+                RooAbsArg *rfloat = (*res).floatParsFinal().find(poi_[i].c_str());
+                if (!rfloat) {
+                    rfloat = (*res).constPars().find(poi_[i].c_str());
+                }
+                RooRealVar *rf = dynamic_cast<RooRealVar*>(rfloat);
+                poiVals_[i] = rf->getVal();//for Singles we store the RooFitResults values
             }
-            RooRealVar *rf = dynamic_cast<RooRealVar*>(rfloat);
-            if (algo_ == Singles) poiVals_[i] = rf->getVal();//for Singles we store the RooFitResults values
             else poiVals_[i] = poiVars_[i]->getVal();
         }
         //if (algo_ != None) {

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -49,22 +49,22 @@ float MultiDimFit::maxDeltaNLLForProf_ = 200;
 float MultiDimFit::autoRange_ = -1.0;
 std::string MultiDimFit::fixedPointPOIs_ = "";
 
-  std::string MultiDimFit::saveSpecifiedFuncs_;
-  std::string MultiDimFit::saveSpecifiedIndex_;
-  std::string MultiDimFit::saveSpecifiedNuis_;
- std::vector<std::string>  MultiDimFit::specifiedFuncNames_;
- std::vector<RooAbsReal*> MultiDimFit::specifiedFunc_;
- std::vector<float>        MultiDimFit::specifiedFuncVals_;
- RooArgList                MultiDimFit::specifiedFuncList_;
- std::vector<std::string>  MultiDimFit::specifiedCatNames_;
- std::vector<RooCategory*> MultiDimFit::specifiedCat_;
- std::vector<int>        MultiDimFit::specifiedCatVals_;
- RooArgList                MultiDimFit::specifiedCatList_;
- std::vector<std::string>  MultiDimFit::specifiedNuis_;
- std::vector<RooRealVar *> MultiDimFit::specifiedVars_;
- std::vector<float>        MultiDimFit::specifiedVals_;
- RooArgList                MultiDimFit::specifiedList_;
- bool MultiDimFit::saveInactivePOI_= false;
+std::string MultiDimFit::saveSpecifiedFuncs_;
+std::string MultiDimFit::saveSpecifiedIndex_;
+std::string MultiDimFit::saveSpecifiedNuis_;
+std::vector<std::string>  MultiDimFit::specifiedFuncNames_;
+std::vector<RooAbsReal*> MultiDimFit::specifiedFunc_;
+std::vector<float>        MultiDimFit::specifiedFuncVals_;
+RooArgList                MultiDimFit::specifiedFuncList_;
+std::vector<std::string>  MultiDimFit::specifiedCatNames_;
+std::vector<RooCategory*> MultiDimFit::specifiedCat_;
+std::vector<int>        MultiDimFit::specifiedCatVals_;
+RooArgList                MultiDimFit::specifiedCatList_;
+std::vector<std::string>  MultiDimFit::specifiedNuis_;
+std::vector<RooRealVar *> MultiDimFit::specifiedVars_;
+std::vector<float>        MultiDimFit::specifiedVals_;
+RooArgList                MultiDimFit::specifiedList_;
+bool MultiDimFit::saveInactivePOI_= false;
 
 MultiDimFit::MultiDimFit() :
     FitterAlgoBase("MultiDimFit specific options")
@@ -183,7 +183,13 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     if(w->var("r")) {w->var("r")->Print();}
     if ( loadedSnapshot_ || res.get() || keepFailures_) {
         for (int i = 0, n = poi_.size(); i < n; ++i) {
-            poiVals_[i] = poiVars_[i]->getVal();
+            RooAbsArg *rfloat = (*res).floatParsFinal().find(poi_[i].c_str());
+            if (!rfloat) {
+                rfloat = (*res).constPars().find(poi_[i].c_str());
+            }
+            RooRealVar *rf = dynamic_cast<RooRealVar*>(rfloat);
+            if (algo_ == Singles) poiVals_[i] = rf->getVal();//for Singles we store the RooFitResults values
+            else poiVals_[i] = poiVars_[i]->getVal();
         }
         //if (algo_ != None) {
 	for(unsigned int j=0; j<specifiedNuis_.size(); j++){
@@ -195,7 +201,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
 		specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
 	}
-	//Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
+	Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
 	//}
     }
    
@@ -237,8 +243,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
         case Stitch2D: doStitch2D(w,*nll); break;
         case Impact: if (res.get()) doImpact(*res, *nll); break;
     }
-    Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.);  
-
+    
     Combine::toggleGlobalFillTree(false);
     return true;
 }


### PR DESCRIPTION
When storing the fit results as first point, the values of the parameters are taken from the initial fit, not the best fit. For example a ZZ4l cards gives (singles algorithm):
```
--- MultiDimFit ---
best fit parameter values and profile-likelihood uncertainties:
     r_VBF :    +0.055   -0.055/+1.020 (68%)
     r_ggH :    +1.200   -0.208/+0.222 (68%)
     r_VH_had :    +0.001   -0.001/+2.825 (68%)
     r_ttH :    +0.000   -0.000/+1.185 (68%)
     r_VH_lep :    +0.000   -0.000/+2.660 (68%)
```
While the output root file content is:
```
root [1] limit->Scan("quantileExpected:r_ggH:r_VBF:r_VH_had")
************************************************************
*    Row   * quantileE *     r_ggH *     r_VBF *  r_VH_had *
************************************************************
*        0 *                -1 * 1.2000466 * 0.0493246 * 1.984e-06 *
*        1 * 0.3199999 * 1.2000466 *                  0 * 1.984e-06 *
*        2 * 0.3199999 * 1.2000466 * 1.0746451 * 1.984e-06 *
*        3 * 0.3199999 * 0.9917837 * 0.0547219 * 1.984e-06 *
*        4 * 0.3199999 * 1.4220094 * 0.0547219 * 1.984e-06 *
*        5 * 0.3199999 * 1.2000926 * 0.0547219 *         0 *
*        6 * 0.3199999 * 1.2000926 * 0.0547219 * 2.8250184 *
*        7 * 0.3199999 * 1.2000926 * 0.0547219 * 0.0005002 *
*        8 * 0.3199999 * 1.2000926 * 0.0547219 * 0.0005002 *
*        9 * 0.3199999 * 1.2000926 * 0.0547219 * 0.0005002 *
*       10 * 0.3199999 * 1.2000926 * 0.0547219 * 0.0005002 *
************************************************************
(Long64_t) 11
```
Where row 0 does not match the best fit values. Moving the storing of the best fit point at the end fix this.