### PR TITLE
adding option to bypass pdf value caching

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -47,6 +47,7 @@ namespace cacheutils {
             // and it will be up to the caller code to fill the room the new item
             std::pair<std::vector<Double_t> *, bool> get(); 
             void clear();
+            inline void setDirectMode(bool mode) { directMode_ = mode; }
         private:
             struct Item {
                 Item(const RooAbsCollection &set)   : checker(set),   good(false) {}
@@ -58,6 +59,7 @@ namespace cacheutils {
             int size_, maxSize_;
             enum { MaxItems_ = 3 };
             Item *items[MaxItems_];
+            bool directMode_;
     };
 // Part one: cache all values of a pdf
 class CachingPdfBase {

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -88,6 +88,7 @@ class ShapeBuilder(ModelBuilder):
             if self.options.verbose > 1: print "Creating RooAddPdf %s with %s elements" % ("pdf_bin"+b, coeffs.getSize())
             if channelBinParFlag: 
                 prop = ROOT.CMSHistErrorPropagator("prop_bin%s" % b, "", pdfs.at(0).getXVar(), pdfs, coeffs)
+                prop.setAttribute('CachingPdf_Direct', True)
                 if self.DC.binParFlags[b][0] >= 0.:
                     bbb_args = prop.setupBinPars(self.DC.binParFlags[b][0])
                     for bidx in range(bbb_args.getSize()):


### PR DESCRIPTION
Discovered that for the new CMSHistFunc stuff the caching we have in the NLL evaluation actually slows things down by 10-20% since the full sum is treated as one component and will effectively always need to be re-evaluated.

Added a runtime option to skip the caching globally as well as a pdf attribute that will disable it on a per-channel basis. Use the latter by default with CMSHistFunc models.