### PR TITLE
Cleanup temporary files

### DIFF
--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -1334,6 +1334,7 @@ RooStats::HypoTestResult * HybridNew::evalWithFork(RooStats::HybridCalculator &h
                                           // in 5.27.06 (but not in 5.28)
     }
     if (verbose > 1) { std::cout << "      Evaluation of p-values done in  " << timer.RealTime() << " s" << std::endl; }
+    remove(tmpfile); // Ensure the temporary file is removed -- otherwise it will clog /tmp when running many processes in parallel. True story.
     return result.release();
 }
 


### PR DESCRIPTION
Added a remove command for the rstats-XXXXX temp files, to avoid filling up /tmp/ when running many combine instances on the same machine.