### PR TITLE
Added cleanup for parent tmp files in HybridNew

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -1,7 +1,9 @@
 #ifndef HiggsAnalysis_CombinedLimit_Combine_h
 #define HiggsAnalysis_CombinedLimit_Combine_h
 #include <TString.h>
+#include <TFile.h>
 #include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
 #include "RooArgSet.h"
 #include "RooAbsReal.h"
 #include <boost/algorithm/string/split.hpp>
@@ -30,6 +32,20 @@ extern  std::string setPhysicsModelParameterExpression_;
 extern  std::string setPhysicsModelParameterRangeExpression_;
 extern  std::string defineBackgroundOnlyModelParameterExpression_;
 
+namespace { 
+    struct ToCleanUp {
+        TFile *tfile; std::string file, path;
+        ToCleanUp() : tfile(0), file(""), path("") {}
+        ~ToCleanUp() {
+              if (tfile) { tfile->Close(); delete tfile; }
+              if (!file.empty()) {  
+                 unlink(file.c_str());  // FIXME, we should check that the file deleted safely but currently when running HybridNew, we get a status of -1 even though the file is in fact removed?!
+		 //if (unlink(file.c_str()) == -1) std::cerr << "Failed to delete temporary file " << file << ": " << strerror(errno) << std::endl;
+              }
+              if (!path.empty()) {  boost::filesystem::remove_all(path); }
+        }
+    };
+}
 
 class Combine {
 public:

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -233,19 +233,6 @@ bool Combine::mklimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::Mo
   return ret;
 }
 
-namespace { 
-    struct ToCleanUp {
-        TFile *tfile; std::string file, path;
-        ToCleanUp() : tfile(0), file(""), path("") {}
-        ~ToCleanUp() {
-            if (tfile) { tfile->Close(); delete tfile; }
-            if (!file.empty()) {  
-                if (unlink(file.c_str()) == -1) std::cerr << "Failed to delete temporary file " << file << ": " << strerror(errno) << std::endl;
-            }
-            if (!path.empty()) {  boost::filesystem::remove_all(path); }
-        }
-    };
-}
 void Combine::run(TString hlfFile, const std::string &dataset, double &limit, double &limitErr, int &iToy, TTree *tree, int nToys) {
   ToCleanUp garbageCollect; // use this to close and delete temporary files
 

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -276,10 +276,11 @@ void HybridNew::setupPOI(RooStats::ModelConfig *mc_s) {
 bool HybridNew::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) {
     RooFitGlobalKillSentry silence(verbose <= 1 ? RooFit::WARNING : RooFit::DEBUG);
 
-    double minimizerTolerance_  = ROOT::Math::MinimizerOptions::DefaultTolerance();
-    std::string minimizerAlgo_       = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
+    //double minimizerTolerance_  = ROOT::Math::MinimizerOptions::DefaultTolerance();
+    //std::string minimizerAlgo_  = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
+    //std::string minimizerType_  = ROOT::Math::MinimizerOptions::DefaultMinimizerType();
 
-    Significance::MinimizerSentry minimizerConfig(minimizerAlgo_, minimizerTolerance_);
+    //Significance::MinimizerSentry minimizerConfig(minimizerType_+","+minimizerAlgo_, minimizerTolerance_); // These defaults should already be configured via the CascadeMinimizer
     perf_totalToysRun_ = 0; // reset performance counter
     if (rValues_.getSize() == 0) setupPOI(mc_s);
     switch (workingMode_) {
@@ -1293,7 +1294,12 @@ RooStats::HypoTestResult * HybridNew::evalWithFork(RooStats::HybridCalculator &h
     TStopwatch timer;
     std::auto_ptr<RooStats::HypoTestResult> result(0);
     char tmpfile[999]; snprintf(tmpfile, 998, "%s/rstats-XXXXXX", P_tmpdir);
+    
     int fd = mkstemp(tmpfile); close(fd);
+    ToCleanUp garbageCollect;
+    garbageCollect.file = tmpfile;
+    std::cout << tmpfile << std::endl;
+
     unsigned int ich = 0;
     std::vector<UInt_t> newSeeds(fork_);
     for (ich = 0; ich < fork_; ++ich) {


### PR DESCRIPTION
Also removed annoying complaint that tmp file could not be deleted when
running with HybridNew even though it was?!

FIXME - Should look into why return status from unlink was -1 in this case
and revert back to warning if error occurs