### PR TITLE
revert to using "clean" snapshot in frequentist toys

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -878,7 +878,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
                 minim.setStrategy(1);
                 minim.minimize();
                 utils::setAllConstant(*mc->GetParametersOfInterest(), false); 
-                w->saveSnapshot("frequentistPreFit", w->allVars());
+                w->saveSnapshot("clean", w->allVars());
           }
           if (nuisancePdf.get()) systDs = nuisancePdf->generate(*mc->GetGlobalObservables(), nToys);
       } else {
@@ -905,6 +905,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           if (expectSignal_) ((RooRealVar*)POI->find("r"))->setVal(expectSignal_);
         }
 	std::cout << "Generate toy " << iToy << "/" << nToys << std::endl;
+	if (verbose>2){
+	  std::cout << "... from parameter values:"<< std::endl 
+	  w->allVars().Print("v");
+	}
 	if (isExtended) {
           if (newGen_) {
             absdata_toy = newToyMC.generate(weightVar_); // as simple as that


### PR DESCRIPTION
When using "toysFrequentist", correct parameter value snapshot was not being used in random toys. This PR reverts a modification which should now yield the correct behaviour. 

Suggest leaving this open for experts to take a look first. 