### PR TITLE
Fix how process and decay are obtained. Add bbH process to SMHiggsBuilder. 

### DIFF
--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -131,7 +131,7 @@ def getHiggsProdDecMode(bin,process,options):
     processSource = process
     decaySource   = options.fileName+":"+bin # by default, decay comes from the datacard name or bin label
     if "_" in process: 
-        (processSource, decaySource) = "_".join(process.split("_")[0]),process.split("_")[-1] # ignore anything in the middle for SM-like higgs
+        (processSource, decaySource) = process.split("_")[0],process.split("_")[-1] # ignore anything in the middle for SM-like higgs
         if decaySource not in ALL_HIGGS_DECAYS:
             print "ERROR", "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)
             #raise RuntimeError, "Validation Error: signal process %s has a postfix %s which is not one recognized higgs decay modes (%s)" % (process,decaySource,ALL_HIGGS_DECAYS)

--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -20,6 +20,7 @@ class SMHiggsBuilder:
         if process == "ttH": self.textToSpline("SM_XS_ttH_"+energy, os.path.join(self.xspath, energy+"-ttH.txt") );
         if process == "WH":  self.textToSpline("SM_XS_WH_"+energy,  os.path.join(self.xspath, energy+"-WH.txt") );
         if process == "ZH":  self.textToSpline("SM_XS_ZH_"+energy,  os.path.join(self.xspath, energy+"-ZH.txt") );
+        if process == "bbH":  self.textToSpline("SM_XS_bbH_"+energy,  os.path.join(self.xspath, energy+"-bbH.txt") );
         if process == "VH":  
             makeXS("WH", energy); makeXS("ZH", energy);
             self.modelBuilder.factory_('sum::SM_XS_VH_'+energy+'(SM_XS_WH_'+energy+',SM_XS_ZH_'+energy+')')


### PR DESCRIPTION
This fixes a typo in the default getHiggsProdDecMode() implementation that gives the wrong process name, resulting in an exception for my cards that worked previously. Also allow the bbH xs spline to be accessed in SMHiggsBuilder.py