### PR TITLE
reset workspace parameters after hintmethod

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -202,6 +202,7 @@ bool Combine::mklimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::Mo
         } else {
             hashint = hintAlgo->run(w, mc_s, mc_b, data, hint, hintErr, 0);
         } 
+	w->loadSnapshot("clean");
     }
     limitErr = 0; // start with 0, as some algorithms don't compute it
     ret = algo->run(w, mc_s, mc_b, data, limit, limitErr, (hashint ? &hint : 0));    


### PR DESCRIPTION
Following the discussion on HN [*], cleanup of workspace after running hintmethod.

[*]
https://hypernews.cern.ch/HyperNews/CMS/get/higgs-combination/1035/1/1/1/1/1.html