### PR TITLE
Fix for frequentist toys in models using poisson pdfs for automatic bin-wise stat uncertainties

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -152,19 +152,27 @@ class ShapeBuilder(ModelBuilder):
             elif  self.options.moreOptimizeSimPdf == "cms":
                 if self.options.noOptimizePdf: raise RuntimeError, "--optimize-simpdf-constraints=cms is incompatible with --no-optimize-pdfs"
                 addSyst = False
-            if len(self.DC.systs) and addSyst:
+            if (len(self.DC.systs) or binconstraints.getSize()) and addSyst:
                 ## rename the pdfs
                 sum_s.SetName("pdf_bin%s_nuis" % b); 
                 if not self.options.noBOnly: sum_b.SetName("pdf_bin%s_bonly_nuis" % b)
                 # now we multiply by all the nuisances, but avoiding nested products
                 # so we first make a list of all nuisances plus the RooAddPdf
-                sumPlusNuis_s = ROOT.RooArgList(self.out.nuisPdfs); sumPlusNuis_s.add(sum_s)
+                if len(self.DC.systs):
+                    sumPlusNuis_s = ROOT.RooArgList(self.out.nuisPdfs)
+                else:
+                    sumPlusNuis_s = ROOT.RooArgList()
+                sumPlusNuis_s.add(sum_s)
                 pdf_bins = ROOT.RooProdPdf('pdfbins_bin%s' % b, '', binconstraints)
                 sumPlusNuis_s.add(pdf_bins)
                 # then make RooProdPdf and import it
                 pdf_s = ROOT.RooProdPdf("pdf_bin%s"       % b, "", sumPlusNuis_s) 
                 if not self.options.noBOnly:
-                    sumPlusNuis_b = ROOT.RooArgList(self.out.nuisPdfs); sumPlusNuis_b.add(sum_b)
+                    if len(self.DC.systs):
+                        sumPlusNuis_b = ROOT.RooArgList(self.out.nuisPdfs)
+                    else:
+                        sumPlusNuis_b = ROOT.RooArgList()
+                    sumPlusNuis_b.add(sum_b)
                     sumPlusNuis_b.add(pdf_bins)
                     pdf_b = ROOT.RooProdPdf("pdf_bin%s_bonly" % b, "", sumPlusNuis_b) 
                 if b in self.pdfModes: 

--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -127,27 +127,6 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                     throw std::runtime_error(Form("AsimovUtils: can't find nuisance for constraint term %s", cterm->GetName()));
                 }
                 std::string pdfName(cterm->ClassName());
-                // Handling a special case with the Poisson constraints created by the automatic bin-by-bin tool do not depend on the
-                // mean parameter directly, but rather by a function. We need to set the global observable to the value of this
-                // function and not the parmeter value itself.
-                if ((pdfName == "RooPoisson"  || pdfName == "SimplePoissonConstraint") && !cterm->findServer(*match) && cterm->findServer(rrv)) {
-                    // std::cout << "Special case for " << match->GetName() << ": pdf does not depend on parameter directly\n";
-                    RooFIter sIter = cterm->serverMIterator();
-                    RooAbsArg *server;
-                    while ((server=sIter.next())) {
-                        if (!server->isFundamental()) {
-                            std::auto_ptr<RooArgSet> serverPars(server->getParameters(RooArgSet()));
-                            if (serverPars->contains(*match)) {
-                                RooAbsReal *rServer = dynamic_cast<RooAbsReal*>(server);
-                                if (rServer) {
-                                    //std::cout << "Replacing with value of " << rServer->GetName() << "\n";
-                                    match = rServer;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
                 if (pdfName == "RooGaussian" || pdfName == "SimpleGaussianConstraint"  || pdfName == "RooBifurGauss" || pdfName == "RooPoisson"  || pdfName == "SimplePoissonConstraint" || pdfName == "RooGenericPdf") {
                     // this is easy
                     rrv.setVal(match->getVal());

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -376,16 +376,16 @@ RooArgList * CMSHistErrorPropagator::setupBinPars(double poissonThreshold) {
             double sigma = 7.;
             double rmin = 0.5*ROOT::Math::chisquared_quantile(ROOT::Math::normal_cdf_c(sigma), n_p_r * 2.);
             double rmax = 0.5*ROOT::Math::chisquared_quantile(1. - ROOT::Math::normal_cdf_c(sigma), n_p_r * 2. + 2.);
-            RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i_%s", this->GetName(), j, proc.c_str()), "", 1, rmin/n_p_r, rmax/n_p_r);
-            RooConstVar *cvar = new RooConstVar(TString::Format("%g", n_p_r), "", n_p_r);
+            RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i_%s", this->GetName(), j, proc.c_str()), "", n_p_r, rmin, rmax);
+            RooConstVar *cvar = new RooConstVar(TString::Format("%g", 1. / n_p_r), "", 1. / n_p_r);
             RooProduct *prod = new RooProduct(TString::Format("%s_prod", var->GetName()), "", RooArgList(*var, *cvar));
-            prod->addOwnedComponents(RooArgSet(*var, *cvar));
-            prod->setAttribute("createPoissonConstraint");
-            res->addOwned(*prod);
-            binpars_.add(*var);
+            var->addOwnedComponents(RooArgSet(*prod, *cvar));
+            var->setAttribute("createPoissonConstraint");
+            res->addOwned(*var);
+            binpars_.add(*prod);
 
             std::cout << TString::Format(
-                "      => Product of %s[%.2f,%.2f,%.2f] and const [%.0f] to be poisson constrained\n",
+                "      => Product of %s[%.2f,%.2f,%.2f] and const [%.4f] to be poisson constrained\n",
                 var->GetName(), var->getVal(), var->getMin(), var->getMax(), cvar->getVal());
             bintypes_[j][i] = 2;
           } else {


### PR DESCRIPTION
Unfortunately due to building these poisson constraints in a non-standard way:

x = N
mean = <parameter> * <const=N>

assigning the value of <parameter> to the global observable is wrong. Fixed by defining the <parameter> as the mean directly, and the product <parameter> / <const=N> as the term that gets attached to the error propagator.