### PR TITLE
Optimisation of vertical morphing + bug fix of default minimizer tolerance

### DIFF
--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -182,6 +182,9 @@ class CMSHistFunc : public RooAbsReal {
 
   double vsmooth_par_;
 
+  mutable bool fast_vertical_; //! not to be serialized
+  mutable std::vector<double> vertical_prev_vals_; //! not to be serialized
+
  private:
   void initialize() const;
   void setGlobalCache() const;

--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -144,7 +144,9 @@ class CMSHistFunc : public RooAbsReal {
 
   RooAbsReal const& getXVar() const;
 
+  static void EnableFastVertical();
   friend class CMSHistV<CMSHistFunc>;
+
 
   /*
 
@@ -185,6 +187,8 @@ class CMSHistFunc : public RooAbsReal {
   mutable bool fast_vertical_; //! not to be serialized
   mutable std::vector<double> vertical_prev_vals_; //! not to be serialized
   mutable std::vector<RooAbsReal*> vmorphs_vec_; //! not to be serialized
+
+  static bool enable_fast_vertical_; //! not to be serialized
 
  private:
   void initialize() const;

--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -184,6 +184,7 @@ class CMSHistFunc : public RooAbsReal {
 
   mutable bool fast_vertical_; //! not to be serialized
   mutable std::vector<double> vertical_prev_vals_; //! not to be serialized
+  mutable std::vector<RooAbsReal*> vmorphs_vec_; //! not to be serialized
 
  private:
   void initialize() const;

--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -147,7 +147,6 @@ class CMSHistFunc : public RooAbsReal {
   static void EnableFastVertical();
   friend class CMSHistV<CMSHistFunc>;
 
-
   /*
 
   – RooAbsArg::setVerboseEval(Int_t level) • Level 0 – No messages

--- a/interface/FastTemplate.h
+++ b/interface/FastTemplate.h
@@ -65,6 +65,8 @@ class FastTemplate {
         static void SumDiff(const FastTemplate &h1, const FastTemplate &h2, FastTemplate &sum, FastTemplate &diff);
         /// Does this += x * (diff + (sum)*y)
         void Meld(const FastTemplate & diff, const FastTemplate & sum, T x, T y) ;
+        /// Applies the difference between the new and the old melds
+        void DiffMeld(const FastTemplate & diff, const FastTemplate & sum, T xNew, T yNew, T xOld, T yOld) ;
         /// protect from underflows (*this = max(*this, minimum));
         void CropUnderflows(T minimum=1e-9, bool activebinsonly=true);
 

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -25,6 +25,7 @@ CMSHistFunc::CMSHistFunc() {
   divide_by_width_ = true;
   rebin_ = false;
   vsmooth_par_ = 1.0;
+  fast_vertical_ = false;
 }
 
 CMSHistFunc::CMSHistFunc(const char* name, const char* title, RooRealVar& x,
@@ -44,7 +45,8 @@ CMSHistFunc::CMSHistFunc(const char* name, const char* title, RooRealVar& x,
       mtype_(MomentSetting::Linear),
       vtype_(VerticalSetting::QuadLinear),
       divide_by_width_(divide_by_width),
-      vsmooth_par_(1.0) {
+      vsmooth_par_(1.0),
+      fast_vertical_(false) {
   if (divide_by_width_) {
     for (unsigned i = 0; i < cache_.size(); ++i) {
       cache_[i] /= cache_.GetWidth(i);
@@ -115,7 +117,8 @@ CMSHistFunc::CMSHistFunc(CMSHistFunc const& other, const char* name)
       mtype_(other.mtype_),
       vtype_(other.vtype_),
       divide_by_width_(other.divide_by_width_),
-      vsmooth_par_(other.vsmooth_par_) {
+      vsmooth_par_(other.vsmooth_par_),
+      fast_vertical_(false) {
   // initialize();
 }
 
@@ -295,6 +298,10 @@ void CMSHistFunc::updateCache() const {
 
   if (step1 || step2) {
     if (mcache_.size() == 0) mcache_.resize(storage_.size());
+  }
+
+  if (step1) {
+    fast_vertical_ = false;
   }
 
   if (morph_strategy_ == 0) {
@@ -518,9 +525,17 @@ void CMSHistFunc::updateCache() const {
 #endif
 
       unsigned idx = getIdx(0, global_.p1, 0, 0);
-      mcache_[idx].step2 = mcache_[idx].step1;
-      if (vtype_ == VerticalSetting::LogQuadLinear) {
-        mcache_[idx].step2.Log();
+      // So here we have to decide what to do.
+      // I *think* if step1 is false, and fast_vertical is true then we should skip copying the cache.
+      // fast_vertical will need to be false initially
+      if (vertical_prev_vals_.size() == 0) {
+        vertical_prev_vals_.resize(vmorphs_.getSize());
+      }
+      if (!fast_vertical_) {
+        mcache_[idx].step2 = mcache_[idx].step1;
+        if (vtype_ == VerticalSetting::LogQuadLinear) {
+          mcache_[idx].step2.Log();
+        }
       }
 
 #if HFVERBOSE > 0
@@ -529,12 +544,21 @@ void CMSHistFunc::updateCache() const {
 #endif
 
       for (int v = 0; v < vmorphs_.getSize(); ++v) {
+        double x = ((RooRealVar&)vmorphs_[v]).getVal();
+        // if we're in fast_vertical then need to check if this vmorph value has changed.
+        // if it hasn't then we skip immediately. Where do we store the previous values?
+        // Globally in the HistFunc, or per cache?
+        if (fast_vertical_ && (x != vertical_prev_vals_[v])) continue;
+
         unsigned vidx = getIdx(0, global_.p1, v+1, 0);
 
-        double x = ((RooRealVar&)vmorphs_[v]).getVal();
-
-
-        mcache_[idx].step2.Meld(mcache_[vidx].diff, mcache_[vidx].sum, 0.5*x, smoothStepFunc(x));
+        if (fast_vertical_) {
+          double xold = vertical_prev_vals_[v];
+          mcache_[idx].step2.DiffMeld(mcache_[vidx].diff, mcache_[vidx].sum, 0.5*x, smoothStepFunc(x), 0.5*xold, smoothStepFunc(xold));
+        } else {
+          mcache_[idx].step2.Meld(mcache_[vidx].diff, mcache_[vidx].sum, 0.5*x, smoothStepFunc(x));
+        }
+        vertical_prev_vals_[v] = x;
 
 #if HFVERBOSE > 1
         std::cout << "Morphing for " << vmorphs_[v].GetName() << " with value: " << x << "\n";
@@ -542,15 +566,16 @@ void CMSHistFunc::updateCache() const {
         mcache_[idx].step2.Dump();
 #endif
       }
-      if (vtype_ == VerticalSetting::LogQuadLinear) {
-        mcache_[idx].step2.Exp();
-      }
-      mcache_[idx].step2.CropUnderflows();
       cache_.CopyValues(mcache_[idx].step2);
+      if (vtype_ == VerticalSetting::LogQuadLinear) {
+        cache_.Exp();
+      }
+      cache_.CropUnderflows();
+      fast_vertical_ = true;
 
 #if HFVERBOSE > 0
-        std::cout << "Final cache: " << cache_.Integral() << "\n";
-        cache_.Dump();
+      std::cout << "Final cache: " << cache_.Integral() << "\n";
+      cache_.Dump();
 #endif
 
       vmorph_sentry_.reset();

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -17,6 +17,8 @@
 
 #define HFVERBOSE 0
 
+bool CMSHistFunc::enable_fast_vertical_ = false;
+
 CMSHistFunc::CMSHistFunc() {
   morph_strategy_ = 0;
   initialized_ = false;
@@ -576,7 +578,7 @@ void CMSHistFunc::updateCache() const {
         cache_.Exp();
       }
       cache_.CropUnderflows();
-      fast_vertical_ = true;
+      if (enable_fast_vertical_) fast_vertical_ = true;
 
 #if HFVERBOSE > 0
       std::cout << "Final cache: " << cache_.Integral() << "\n";
@@ -1159,6 +1161,10 @@ CMSHistFuncWrapper const* CMSHistFunc::wrapper() const {
 
 RooAbsReal const& CMSHistFunc::getXVar() const {
   return x_.arg();
+}
+
+void CMSHistFunc::EnableFastVertical() {
+  enable_fast_vertical_ = true;
 }
 
 #undef HFVERBOSE

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -1,6 +1,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
 #include "HiggsAnalysis/CombinedLimit/interface/Accumulators.h"
+
 #include <vector>
 #include <ostream>
 #include <memory>
@@ -130,6 +131,10 @@ void CMSHistFunc::initialize() const {
   vmorph_sentry_.addVars(vmorphs_);
   hmorph_sentry_.setValueDirty();
   vmorph_sentry_.setValueDirty();
+  vmorphs_vec_.resize(vmorphs_.getSize());
+  for (int i = 0; i < vmorphs_.getSize(); ++i) {
+    vmorphs_vec_[i] = (RooAbsReal*)(&vmorphs_[i]);
+  }
 
   setGlobalCache();
 
@@ -544,11 +549,11 @@ void CMSHistFunc::updateCache() const {
 #endif
 
       for (int v = 0; v < vmorphs_.getSize(); ++v) {
-        double x = ((RooRealVar&)vmorphs_[v]).getVal();
+        double x = vmorphs_vec_[v]->getVal();
         // if we're in fast_vertical then need to check if this vmorph value has changed.
         // if it hasn't then we skip immediately. Where do we store the previous values?
         // Globally in the HistFunc, or per cache?
-        if (fast_vertical_ && (x != vertical_prev_vals_[v])) continue;
+        if (fast_vertical_ && (x == vertical_prev_vals_[v])) continue;
 
         unsigned vidx = getIdx(0, global_.p1, v+1, 0);
 

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -1,7 +1,6 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
 #include "HiggsAnalysis/CombinedLimit/interface/Accumulators.h"
-
 #include <vector>
 #include <ostream>
 #include <memory>
@@ -532,9 +531,6 @@ void CMSHistFunc::updateCache() const {
 #endif
 
       unsigned idx = getIdx(0, global_.p1, 0, 0);
-      // So here we have to decide what to do.
-      // I *think* if step1 is false, and fast_vertical is true then we should skip copying the cache.
-      // fast_vertical will need to be false initially
       if (vertical_prev_vals_.size() == 0) {
         vertical_prev_vals_.resize(vmorphs_.getSize());
       }
@@ -553,8 +549,7 @@ void CMSHistFunc::updateCache() const {
       for (int v = 0; v < vmorphs_.getSize(); ++v) {
         double x = vmorphs_vec_[v]->getVal();
         // if we're in fast_vertical then need to check if this vmorph value has changed.
-        // if it hasn't then we skip immediately. Where do we store the previous values?
-        // Globally in the HistFunc, or per cache?
+        // if it hasn't then we skip immediately.
         if (fast_vertical_ && (x == vertical_prev_vals_[v])) continue;
 
         unsigned vidx = getIdx(0, global_.p1, v+1, 0);

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -78,6 +78,7 @@ bool CascadeMinimizer::improve(int verbose, bool cascade)
     std::string nominalType(ROOT::Math::MinimizerOptions::DefaultMinimizerType());
     std::string nominalAlgo(ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo());
     float       nominalTol(ROOT::Math::MinimizerOptions::DefaultTolerance());
+    minimizer_->setEps(nominalTol);
     if (approxPreFitTolerance_ > 0) {
       double tol = std::max(approxPreFitTolerance_, 10. * nominalTol);
       do {

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -59,6 +59,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/AsimovUtils.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CascadeMinimizer.h"
 #include "HiggsAnalysis/CombinedLimit/interface/ProfilingTools.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
 
 #include "HiggsAnalysis/CombinedLimit/interface/Logger.h"
 
@@ -833,6 +834,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
                    "the POI \"r\", use --setParameters to set the "
                    "values of the POIs for toy generation in this model\n";
     }
+  }
+
+  if (runtimedef::get("FAST_VERTICAL_MORPH")) {
+    CMSHistFunc::EnableFastVertical();
   }
 
 

--- a/src/FastTemplate.cc
+++ b/src/FastTemplate.cc
@@ -323,6 +323,11 @@ namespace {
             out[i] += x*(diff[i] + y*sum[i]);
         }
     }
+    void diffmeld(FastTemplate::T * __restrict__ out, unsigned int n, FastTemplate::T  const * __restrict__ diff, FastTemplate::T  const * __restrict__ sum, FastTemplate::T xNew, FastTemplate::T yNew, FastTemplate::T xOld, FastTemplate::T yOld) {
+        for (unsigned int i = 0; i < n; ++i) {
+            out[i] += (xNew - xOld)*diff[i] + (xNew*yNew - xOld*yOld)*sum[i];
+        }
+    }
 }
 
 void FastTemplate::Subtract(const FastTemplate & ref) {
@@ -338,6 +343,10 @@ void FastTemplate::SumDiff(const FastTemplate & h1, const FastTemplate & h2,
 
 void FastTemplate::Meld(const FastTemplate & diff, const FastTemplate & sum, T x, T y) {
     meld(&values_[0], size_, &diff[0], &sum[0], x, y);
+}
+
+void FastTemplate::DiffMeld(const FastTemplate & diff, const FastTemplate & sum, T xNew, T yNew, T xOld, T yOld) {
+    diffmeld(&values_[0], size_, &diff[0], &sum[0], xNew, yNew, xOld, yOld);
 }
 
 void FastTemplate::Log() {


### PR DESCRIPTION
Faster vertical morphing available on demand for CMSHistFunc-based channels. Can add `--X-rtd FAST_VERTICAL_MORPH` at runtime. 

Also fixed propagation of the default minimizer tolerance. We intended this to be 0.1 (same as 74X) but was actually getting 1.0 (roofit default).