### PR TITLE
MultiDimFit --algo grid: add option --alignEdges

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -51,6 +51,7 @@ protected:
   static float maxDeltaNLLForProf_;
   static float autoRange_;
   static bool  startFromPreFit_;
+  static bool  alignEdges_;
   static bool  saveFitResult_;
   static std::string fixedPointPOIs_;
   static float centeredRange_;

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -41,6 +41,7 @@ bool MultiDimFit::fastScan_ = false;
 bool MultiDimFit::loadedSnapshot_ = false;
 bool MultiDimFit::savingSnapshot_ = false;
 bool MultiDimFit::startFromPreFit_ = false;
+bool MultiDimFit::alignEdges_ = false;
 bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
 bool MultiDimFit::squareDistPoiStep_ = false;
 bool MultiDimFit::skipInitialFit_ = false;
@@ -89,7 +90,8 @@ MultiDimFit::MultiDimFit() :
 	("saveSpecifiedFunc",   boost::program_options::value<std::string>(&saveSpecifiedFuncs_)->default_value(""), "Save specified function values (default = none)")
 	("saveSpecifiedIndex",   boost::program_options::value<std::string>(&saveSpecifiedIndex_)->default_value(""), "Save specified indexes/discretes (default = none)")
 	("saveInactivePOI",   boost::program_options::value<bool>(&saveInactivePOI_)->default_value(saveInactivePOI_), "Save inactive POIs in output (1) or not (0, default)")
-	("startFromPreFit",   boost::program_options::value<bool>(&startFromPreFit_)->default_value(startFromPreFit_), "Start each point of the likelihood scan from the pre-fit values")
+  ("startFromPreFit",   boost::program_options::value<bool>(&startFromPreFit_)->default_value(startFromPreFit_), "Start each point of the likelihood scan from the pre-fit values")
+  ("alignEdges",   boost::program_options::value<bool>(&alignEdges_)->default_value(alignEdges_), "Align the grid points such that the endpoints of the ranges are included")
 	("saveFitResult",  "Save RooFitResult to muiltidimfit.root")
       ;
 }
@@ -512,90 +514,103 @@ void MultiDimFit::doImpact(RooFitResult &res, RooAbsReal &nll) {
 
 
 void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) {
-    unsigned int n = poi_.size();
-    double nll0 = nll.getVal();
-    if (startFromPreFit_) w->loadSnapshot("clean");
+  unsigned int n = poi_.size();
+  double nll0 = nll.getVal();
+  if (startFromPreFit_) w->loadSnapshot("clean");
 
-    std::vector<double> p0(n), pmin(n), pmax(n);
-    for (unsigned int i = 0; i < n; ++i) {
-        p0[i] = poiVars_[i]->getVal();
-        pmin[i] = poiVars_[i]->getMin();
-        pmax[i] = poiVars_[i]->getMax();
-        poiVars_[i]->setConstant(true);
-    std::cout<<" POI: "<<poiVars_[i]->GetName()<<"= "<<p0[i]<<" -> ["<<pmin[i]<<","<<pmax[i]<<"]"<<std::endl;
+  std::vector<double> p0(n), pmin(n), pmax(n);
+  for (unsigned int i = 0; i < n; ++i) {
+      p0[i] = poiVars_[i]->getVal();
+      pmin[i] = poiVars_[i]->getMin();
+      pmax[i] = poiVars_[i]->getMax();
+      poiVars_[i]->setConstant(true);
+  std::cout<<" POI: "<<poiVars_[i]->GetName()<<"= "<<p0[i]<<" -> ["<<pmin[i]<<","<<pmax[i]<<"]"<<std::endl;
+  }
+
+
+  CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
+  if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
+  if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
+  minim.setStrategy(minimizerStrategy_);
+  std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
+  RooArgSet snap; params->snapshot(snap);
+  //snap.Print("V");
+
+  if (n == 1) {
+    double xspacing = (pmax[0]-pmin[0]) / points_;
+    double xspacingOffset = 0.5;
+    if (alignEdges_) {
+      xspacing = (pmax[0]-pmin[0]) / (points_ - 1);
+      if (points_ == 1) xspacing = 0;
+      xspacingOffset = 0.0;
     }
-
-
-    CascadeMinimizer minim(nll, CascadeMinimizer::Constrained);
-    if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
-    if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
-    minim.setStrategy(minimizerStrategy_);
-    std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
-    RooArgSet snap; params->snapshot(snap);
-    //snap.Print("V");
-    if (n == 1) {
-	    // can do a more intellegent spacing of points
-	    double xbestpoint = (p0[0] - pmin[0]) / ((pmax[0]-pmin[0]) / points_);
-	    if (lastPoint_ == std::numeric_limits<unsigned int>::max()) {
-        lastPoint_ = points_ - 1;
+    // can do a more intellegent spacing of points
+    double xbestpoint = (p0[0] - pmin[0]) / xspacing;
+    if (lastPoint_ == std::numeric_limits<unsigned int>::max()) {
+      lastPoint_ = points_ - 1;
+    }
+    for (unsigned int i = 0; i < points_; ++i) {
+      if (i < firstPoint_) continue;
+      if (i > lastPoint_)  break;
+      double x = pmin[0] + (i + xspacingOffset) * xspacing;
+      // If we're aligning with the edges and this is the last point,
+      // set x to pmax[0] exactly
+      if (alignEdges_ && i == (points_ - 1)) {
+        x = pmax[0];
       }
-      for (unsigned int i = 0; i < points_; ++i) {
-        if (i < firstPoint_) continue;
-        if (i > lastPoint_)  break;
-        double x = pmin[0] + (i + 0.5) * (pmax[0] - pmin[0]) / points_;
-        if (xbestpoint > lastPoint_) {
-          int ireverse = lastPoint_ - i + firstPoint_ ;
-          x = pmin[0] + (ireverse+0.5)*(pmax[0]-pmin[0])/points_;
-        }
+      if (xbestpoint > lastPoint_) {
+        int ireverse = lastPoint_ - i + firstPoint_;
+        x = pmin[0] + (ireverse + xspacingOffset) * xspacing;
+      }
 
-        if (squareDistPoiStep_) {
-          // distance between steps goes as ~square of distance from middle or range (could this be changed to from best fit value?)
-          double phalf = (pmax[0]-pmin[0]) / 2;
-          if (i < (unsigned int)points_ / 2) {
-            x = pmin[0] + TMath::Sqrt(2 * i * (phalf) * (phalf) / points_);
-          } else {
-            x = pmax[0] - TMath::Sqrt(2 * (points_-i) * (phalf) * (phalf) / points_);
-          }
+      if (squareDistPoiStep_) {
+        // distance between steps goes as ~square of distance from middle or range (could this be changed to from best fit value?)
+        double phalf = (pmax[0] - pmin[0]) / 2;
+        if (x < (pmin[0] + phalf)) {
+          x = pmin[0] + TMath::Sqrt((x - pmin[0]) / phalf) * phalf;
+        } else {
+          x = pmax[0] - TMath::Sqrt((pmax[0] - x) / phalf) * phalf;
         }
+      }
 
-        std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
-        *params = snap;
-        poiVals_[0] = x;
-        poiVars_[0]->setVal(x);
-        // now we minimize
-        nll.clearEvalErrorLog();
+      std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
+      *params = snap;
+      poiVals_[0] = x;
+      poiVars_[0]->setVal(x);
+      // now we minimize
+      nll.clearEvalErrorLog();
+      deltaNLL_ = nll.getVal() - nll0;
+      if (nll.numEvalErrors() > 0) {
+        deltaNLL_ = 9990;
+        for (unsigned int j = 0; j < specifiedNuis_.size(); j++) {
+          specifiedVals_[j] = specifiedVars_[j]->getVal();
+        }
+        for (unsigned int j = 0; j < specifiedFuncNames_.size(); j++) {
+          specifiedFuncVals_[j] = specifiedFunc_[j]->getVal();
+        }
+        Combine::commitPoint(true, /*quantile=*/0);
+        continue;
+      }
+      bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ?
+                true :
+                minim.minimize(verbose-1);
+      if (ok) {
         deltaNLL_ = nll.getVal() - nll0;
-        if (nll.numEvalErrors() > 0) {
-          deltaNLL_ = 9990;
-          for (unsigned int j = 0; j < specifiedNuis_.size(); j++) {
-            specifiedVals_[j] = specifiedVars_[j]->getVal();
-          }
-          for (unsigned int j = 0; j < specifiedFuncNames_.size(); j++) {
-            specifiedFuncVals_[j] = specifiedFunc_[j]->getVal();
-          }
-          Combine::commitPoint(true, /*quantile=*/0);
-          continue;
-        }
-        bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ?
-                  true :
-                  minim.minimize(verbose-1);
-        if (ok) {
-          deltaNLL_ = nll.getVal() - nll0;
-          double qN = 2*(deltaNLL_);
-          double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-		      for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-		      	specifiedVals_[j]=specifiedVars_[j]->getVal();
-		      }
-		      for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-		      	specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		      }
-		      for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-		      	specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		      }
-          Combine::commitPoint(true, /*quantile=*/prob);
-        }
+        double qN = 2*(deltaNLL_);
+        double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+	      for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+	      	specifiedVals_[j]=specifiedVars_[j]->getVal();
+	      }
+	      for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+	      	specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+	      }
+	      for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+	      	specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+	      }
+        Combine::commitPoint(true, /*quantile=*/prob);
       }
-    } else if (n == 2) {
+    }
+  } else if (n == 2) {
       unsigned int sqrn = ceil(sqrt(double(points_)));
       unsigned int ipoint = 0;
       unsigned int nprint = ceil(0.005 * sqrn * sqrn);
@@ -603,13 +618,23 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) {
       CloseCoutSentry sentry(verbose < 2);
       double deltaX = (pmax[0] - pmin[0]) / sqrn;
       double deltaY = (pmax[1] - pmin[1]) / sqrn;
+      double spacingOffset = 0.5;
+      if (alignEdges_) {
+        deltaX = (pmax[0] - pmin[0]) / (sqrn - 1);
+        deltaY = (pmax[1] - pmin[1]) / (sqrn - 1);
+        spacingOffset = 0.0;
+        if (sqrn == 1) {
+          deltaX = 0;
+          deltaY = 0;
+        }
+      }
       for (unsigned int i = 0; i < sqrn; ++i) {
         for (unsigned int j = 0; j < sqrn; ++j, ++ipoint) {
           if (ipoint < firstPoint_) continue;
           if (ipoint > lastPoint_)  break;
           *params = snap;
-          double x =  pmin[0] + (i + 0.5) * deltaX;
-          double y =  pmin[1] + (j + 0.5) * deltaY;
+          double x =  pmin[0] + (i + spacingOffset) * deltaX;
+          double y =  pmin[1] + (j + spacingOffset) * deltaY;
           if (verbose && (ipoint % nprint == 0)) {
             fprintf(sentry.trueStdOut(), "Point %d/%d, (i,j) = (%d,%d), %s = %f, %s = %f\n",
                            ipoint, sqrn * sqrn, i, j, poiVars_[0]->GetName(), x, poiVars_[1]->GetName(), y);
@@ -718,43 +743,52 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) {
           }
         }
       }
-    } else { // Use utils routine if n > 2
-      unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
-      unsigned int ipoint = 0, nprint = ceil(0.005*TMath::Power((double)rootn,(double)n));
+  } else { // Use utils routine if n > 2
+    unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
+    unsigned int ipoint = 0, nprint = ceil(0.005*TMath::Power((double)rootn,(double)n));
 
-      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-      CloseCoutSentry sentry(verbose < 2);
-      // Create permutations
-      std::vector<int> axis_points;
-      for (unsigned int poi_i=0;poi_i<n;poi_i++){
-	      axis_points.push_back((int)rootn);
-    	}
+    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
+    CloseCoutSentry sentry(verbose < 2);
+    // Create permutations
+    std::vector<int> axis_points;
+    for (unsigned int poi_i=0;poi_i<n;poi_i++){
+      axis_points.push_back((int)rootn);
+  	}
 
-      std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
-      // Step through points
-      std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
-      int npermutations = permutations.size();
-      for (; perm_it != permutations.end(); perm_it++) {
-        if (ipoint < firstPoint_) {
-          ipoint++;
-          continue;
-        }
-        if (ipoint > lastPoint_) break;
-        *params = snap;
-        if (verbose && (ipoint % nprint == 0)) {
-           fprintf(sentry.trueStdOut(), "Point %d/%d, ",
-                        ipoint,npermutations);
-        }
-        for (unsigned int poi_i = 0; poi_i < n; poi_i++) {
-          int ip = (*perm_it)[poi_i];
-          double deltaXi = (pmax[poi_i]-pmin[poi_i])/rootn;
-          double xi = pmin[poi_i]+deltaXi*(ip+0.5);
-          poiVals_[poi_i] = xi; poiVars_[poi_i]->setVal(xi);
-          if (verbose && (ipoint % nprint == 0)) {
-            fprintf(sentry.trueStdOut(), " %s = %f ",
-                    poiVars_[poi_i]->GetName(), xi);
+    std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
+    // Step through points
+    std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
+    int npermutations = permutations.size();
+    for (; perm_it != permutations.end(); perm_it++) {
+      if (ipoint < firstPoint_) {
+        ipoint++;
+        continue;
+      }
+      if (ipoint > lastPoint_) break;
+      *params = snap;
+      if (verbose && (ipoint % nprint == 0)) {
+         fprintf(sentry.trueStdOut(), "Point %d/%d, ",
+                      ipoint,npermutations);
+      }
+      for (unsigned int poi_i = 0; poi_i < n; poi_i++) {
+        int ip = (*perm_it)[poi_i];
+        double deltaXi = (pmax[poi_i] - pmin[poi_i]) / rootn;
+        double spacingOffset = 0.5;
+        if (alignEdges_) {
+          deltaXi = (pmax[poi_i] - pmin[poi_i]) / (rootn - 1);
+          if (rootn == 1) {
+            deltaXi = 0.;
           }
+          spacingOffset = 0.0;
         }
+        double xi = pmin[poi_i] + deltaXi * (ip + spacingOffset);
+        poiVals_[poi_i] = xi;
+        poiVars_[poi_i]->setVal(xi);
+        if (verbose && (ipoint % nprint == 0)) {
+          fprintf(sentry.trueStdOut(), " %s = %f ",
+                  poiVars_[poi_i]->GetName(), xi);
+        }
+      }
       if (verbose && (ipoint % nprint == 0)) fprintf(sentry.trueStdOut(), "\n");
       nll.clearEvalErrorLog(); nll.getVal();
       if (nll.numEvalErrors() > 0) {
@@ -789,7 +823,7 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) {
         }
         Combine::commitPoint(true, /*quantile=*/prob);
       }
-      ipoint++;
+    ipoint++;
     }
   }
 }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -511,10 +511,8 @@ void MultiDimFit::doImpact(RooFitResult &res, RooAbsReal &nll) {
 }
 
 
-void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) 
-{
+void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll) {
     unsigned int n = poi_.size();
-    //if (poi_.size() > 2) throw std::logic_error("Don't know how to do a grid with more than 2 POIs.");
     double nll0 = nll.getVal();
     if (startFromPreFit_) w->loadSnapshot("clean");
 
@@ -536,261 +534,264 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
     RooArgSet snap; params->snapshot(snap);
     //snap.Print("V");
     if (n == 1) {
-	// can do a more intellegent spacing of points
-	double xbestpoint = (p0[0] - pmin[0]) / ((pmax[0]-pmin[0])/points_) ;
-	if ( lastPoint_ == std::numeric_limits<unsigned int>::max()) lastPoint_ = points_-1;
-        for (unsigned int i = 0; i < points_; ++i) {
-            if (i < firstPoint_) continue;
-            if (i > lastPoint_)  break;
-            double x =  pmin[0] + (i+0.5)*(pmax[0]-pmin[0])/points_; 
-	    if( xbestpoint > lastPoint_ ){
-		int ireverse = lastPoint_ - i + firstPoint_ ;
-		x = pmin[0] + (ireverse+0.5)*(pmax[0]-pmin[0])/points_; 
-	    }
-
-	    if (squareDistPoiStep_){
-		// distance between steps goes as ~square of distance from middle or range (could this be changed to from best fit value?)
-		double phalf = (pmax[0]-pmin[0])/2;
-		if (i<(unsigned int)points_/2) x = pmin[0]+TMath::Sqrt(2*i*(phalf)*(phalf)/points_);
-		else x = pmax[0]-TMath::Sqrt(2*(points_-i)*(phalf)*(phalf)/points_);
-	    }
-
-            //if (verbose > 1) std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
-             std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
-            *params = snap; 
-            poiVals_[0] = x;
-            poiVars_[0]->setVal(x);
-            // now we minimize
-            nll.clearEvalErrorLog();
-            deltaNLL_ = nll.getVal() - nll0;
-            if (nll.numEvalErrors() > 0) {
-                deltaNLL_ = 9990;
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-                Combine::commitPoint(true, /*quantile=*/0);
-                continue;
-            }
-            bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ? 
-                        true : 
-                        minim.minimize(verbose-1);
-            if (ok) {
-                deltaNLL_ = nll.getVal() - nll0;
-                double qN = 2*(deltaNLL_);
-                double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		}
-                Combine::commitPoint(true, /*quantile=*/prob);
-            }
+	    // can do a more intellegent spacing of points
+	    double xbestpoint = (p0[0] - pmin[0]) / ((pmax[0]-pmin[0]) / points_);
+	    if (lastPoint_ == std::numeric_limits<unsigned int>::max()) {
+        lastPoint_ = points_ - 1;
+      }
+      for (unsigned int i = 0; i < points_; ++i) {
+        if (i < firstPoint_) continue;
+        if (i > lastPoint_)  break;
+        double x = pmin[0] + (i + 0.5) * (pmax[0] - pmin[0]) / points_;
+        if (xbestpoint > lastPoint_) {
+          int ireverse = lastPoint_ - i + firstPoint_ ;
+          x = pmin[0] + (ireverse+0.5)*(pmax[0]-pmin[0])/points_;
         }
+
+        if (squareDistPoiStep_) {
+          // distance between steps goes as ~square of distance from middle or range (could this be changed to from best fit value?)
+          double phalf = (pmax[0]-pmin[0]) / 2;
+          if (i < (unsigned int)points_ / 2) {
+            x = pmin[0] + TMath::Sqrt(2 * i * (phalf) * (phalf) / points_);
+          } else {
+            x = pmax[0] - TMath::Sqrt(2 * (points_-i) * (phalf) * (phalf) / points_);
+          }
+        }
+
+        std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
+        *params = snap;
+        poiVals_[0] = x;
+        poiVars_[0]->setVal(x);
+        // now we minimize
+        nll.clearEvalErrorLog();
+        deltaNLL_ = nll.getVal() - nll0;
+        if (nll.numEvalErrors() > 0) {
+          deltaNLL_ = 9990;
+          for (unsigned int j = 0; j < specifiedNuis_.size(); j++) {
+            specifiedVals_[j] = specifiedVars_[j]->getVal();
+          }
+          for (unsigned int j = 0; j < specifiedFuncNames_.size(); j++) {
+            specifiedFuncVals_[j] = specifiedFunc_[j]->getVal();
+          }
+          Combine::commitPoint(true, /*quantile=*/0);
+          continue;
+        }
+        bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ?
+                  true :
+                  minim.minimize(verbose-1);
+        if (ok) {
+          deltaNLL_ = nll.getVal() - nll0;
+          double qN = 2*(deltaNLL_);
+          double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+		      for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+		      	specifiedVals_[j]=specifiedVars_[j]->getVal();
+		      }
+		      for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+		      	specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+		      }
+		      for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+		      	specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+		      }
+          Combine::commitPoint(true, /*quantile=*/prob);
+        }
+      }
     } else if (n == 2) {
-        unsigned int sqrn = ceil(sqrt(double(points_)));
-        unsigned int ipoint = 0, nprint = ceil(0.005*sqrn*sqrn);
-        RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-        CloseCoutSentry sentry(verbose < 2);
-        double deltaX =  (pmax[0]-pmin[0])/sqrn, deltaY = (pmax[1]-pmin[1])/sqrn;
-        for (unsigned int i = 0; i < sqrn; ++i) {
-            for (unsigned int j = 0; j < sqrn; ++j, ++ipoint) {
-                if (ipoint < firstPoint_) continue;
-                if (ipoint > lastPoint_)  break;
-                *params = snap; 
-                double x =  pmin[0] + (i+0.5)*deltaX; 
-                double y =  pmin[1] + (j+0.5)*deltaY; 
-                if (verbose && (ipoint % nprint == 0)) {
-                         fprintf(sentry.trueStdOut(), "Point %d/%d, (i,j) = (%d,%d), %s = %f, %s = %f\n",
-                                        ipoint,sqrn*sqrn, i,j, poiVars_[0]->GetName(), x, poiVars_[1]->GetName(), y);
-                }
-                poiVals_[0] = x;
-                poiVals_[1] = y;
-                poiVars_[0]->setVal(x);
-                poiVars_[1]->setVal(y);
-                nll.clearEvalErrorLog(); nll.getVal();
-                if (nll.numEvalErrors() > 0) { 
-			for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-				specifiedVals_[j]=specifiedVars_[j]->getVal();
-			}
-			for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-				specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-			}
-			for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-				specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-			}
-                    deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0); 
-                    if (gridType_ == G3x3) {
-                        for (int i2 = -1; i2 <= +1; ++i2) {
-                            for (int j2 = -1; j2 <= +1; ++j2) {
-                                if (i2 == 0 && j2 == 0) continue;
-                                poiVals_[0] = x + 0.33333333*i2*deltaX;
-                                poiVals_[1] = y + 0.33333333*j2*deltaY;
-				for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-					specifiedVals_[j]=specifiedVars_[j]->getVal();
-				}
-				for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-					specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-				}
-				for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-					specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-				}
-                                deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0); 
-                            }
-                        }
-                    }
-                    continue;
-                }
-                // now we minimize
-                bool skipme = hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_;
-                bool ok = fastScan_ || skipme ? true :  minim.minimize(verbose-1);
-                if (ok) {
-                    deltaNLL_ = nll.getVal() - nll0;
-                    double qN = 2*(deltaNLL_);
-                    double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-		    for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			    specifiedVals_[j]=specifiedVars_[j]->getVal();
-		    }
-		    for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		    }
-		    for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		    }
-                    Combine::commitPoint(true, /*quantile=*/prob);
-                }
-                if (gridType_ == G3x3) {
-                    bool forceProfile = !fastScan_ && std::min(fabs(deltaNLL_ - 1.15), fabs(deltaNLL_ - 2.995)) < 0.5;
-                    utils::CheapValueSnapshot center(*params);
-                    double x0 = x, y0 = y;
-                    for (int i2 = -1; i2 <= +1; ++i2) {
-                        for (int j2 = -1; j2 <= +1; ++j2) {
-                            if (i2 == 0 && j2 == 0) continue;
-                            center.writeTo(*params);
-                            x = x0 + 0.33333333*i2*deltaX;
-                            y = y0 + 0.33333333*j2*deltaY;
-                            poiVals_[0] = x; poiVars_[0]->setVal(x);
-                            poiVals_[1] = y; poiVars_[1]->setVal(y);
-                            nll.clearEvalErrorLog(); nll.getVal();
-                            if (nll.numEvalErrors() > 0) { 
-				    for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-					    specifiedVals_[j]=specifiedVars_[j]->getVal();
-				    }
-				    for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-					    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-				    }
-				    for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-					    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-				    }
-                                deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0); 
-                                continue;
-                            }
-                            deltaNLL_ = nll.getVal() - nll0;
-                            if (forceProfile || (!fastScan_ && std::min(fabs(deltaNLL_ - 1.15), fabs(deltaNLL_ - 2.995)) < 0.5)) {
-                                minim.minimize(verbose-1);
-                                deltaNLL_ = nll.getVal() - nll0;
-                            }
-                            double qN = 2*(deltaNLL_);
-                            double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-			    for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-				    specifiedVals_[j]=specifiedVars_[j]->getVal();
-			    }
-			    for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-				    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-			    }
-			    for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-				    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-			    }
-                            Combine::commitPoint(true, /*quantile=*/prob);
-                        }
-                    }
-                }
-            }
-        }
-
-    } else { // Use utils routine if n > 2 
-
-        unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
-        unsigned int ipoint = 0, nprint = ceil(0.005*TMath::Power((double)rootn,(double)n));
-	
-        RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-        CloseCoutSentry sentry(verbose < 2);
-	
-	// Create permutations 
-        std::vector<int> axis_points;
-	
-        for (unsigned int poi_i=0;poi_i<n;poi_i++){
-	  axis_points.push_back((int)rootn);
-    	}
-
-        std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
-	// Step through points
-        std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
-	int npermutations = permutations.size();
-    	for (;perm_it!=permutations.end(); perm_it++){
-
-          if (ipoint < firstPoint_) {ipoint++; continue;}
+      unsigned int sqrn = ceil(sqrt(double(points_)));
+      unsigned int ipoint = 0;
+      unsigned int nprint = ceil(0.005 * sqrn * sqrn);
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
+      CloseCoutSentry sentry(verbose < 2);
+      double deltaX = (pmax[0] - pmin[0]) / sqrn;
+      double deltaY = (pmax[1] - pmin[1]) / sqrn;
+      for (unsigned int i = 0; i < sqrn; ++i) {
+        for (unsigned int j = 0; j < sqrn; ++j, ++ipoint) {
+          if (ipoint < firstPoint_) continue;
           if (ipoint > lastPoint_)  break;
-          *params = snap; 
-
+          *params = snap;
+          double x =  pmin[0] + (i + 0.5) * deltaX;
+          double y =  pmin[1] + (j + 0.5) * deltaY;
           if (verbose && (ipoint % nprint == 0)) {
-             fprintf(sentry.trueStdOut(), "Point %d/%d, ",
-                          ipoint,npermutations);
-          }	  
-          for (unsigned int poi_i=0;poi_i<n;poi_i++){
-	    int ip = (*perm_it)[poi_i];
-            double deltaXi = (pmax[poi_i]-pmin[poi_i])/rootn;
-	    double xi = pmin[poi_i]+deltaXi*(ip+0.5);
-            poiVals_[poi_i] = xi; poiVars_[poi_i]->setVal(xi);
-	    if (verbose && (ipoint % nprint == 0)){
-             fprintf(sentry.trueStdOut(), " %s = %f ",
-                          poiVars_[poi_i]->GetName(), xi);
-	    }
-	  }
-	  if (verbose && (ipoint % nprint == 0)) fprintf(sentry.trueStdOut(), "\n");
-
+            fprintf(sentry.trueStdOut(), "Point %d/%d, (i,j) = (%d,%d), %s = %f, %s = %f\n",
+                           ipoint, sqrn * sqrn, i, j, poiVars_[0]->GetName(), x, poiVars_[1]->GetName(), y);
+          }
+          poiVals_[0] = x;
+          poiVals_[1] = y;
+          poiVars_[0]->setVal(x);
+          poiVars_[1]->setVal(y);
           nll.clearEvalErrorLog(); nll.getVal();
-          if (nll.numEvalErrors() > 0) { 
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		}
-               deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
-               ipoint++;
-	       continue;
-	  }
+          if (nll.numEvalErrors() > 0) {
+            for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+            	specifiedVals_[j]=specifiedVars_[j]->getVal();
+            }
+            for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+            	specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+            }
+            for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+            	specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+            }
+            deltaNLL_ = 9999;
+            Combine::commitPoint(true, /*quantile=*/0);
+            if (gridType_ == G3x3) {
+              for (int i2 = -1; i2 <= +1; ++i2) {
+                for (int j2 = -1; j2 <= +1; ++j2) {
+                  if (i2 == 0 && j2 == 0) continue;
+                  poiVals_[0] = x + 0.33333333*i2*deltaX;
+                  poiVals_[1] = y + 0.33333333*j2*deltaY;
+                  for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+                  	specifiedVals_[j]=specifiedVars_[j]->getVal();
+                  }
+                  for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+                  	specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+                  }
+                  for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+                  	specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+                  }
+                  deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
+                }
+              }
+            }
+            continue;
+          }
           // now we minimize
           bool skipme = hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_;
-          bool ok = fastScan_ || skipme ? true :  minim.minimize(verbose-1);
+          bool ok = fastScan_ || skipme ? true : minim.minimize(verbose-1);
           if (ok) {
-               deltaNLL_ = nll.getVal() - nll0;
-               double qN = 2*(deltaNLL_);
-               double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		}
-               Combine::commitPoint(true, /*quantile=*/prob);
+            deltaNLL_ = nll.getVal() - nll0;
+            double qN = 2 * (deltaNLL_);
+            double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+            for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+              specifiedVals_[j]=specifiedVars_[j]->getVal();
+            }
+            for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+              specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+            }
+            for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+              specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+            }
+            Combine::commitPoint(true, /*quantile=*/prob);
           }
-	  ipoint++;	
-	} 
+          if (gridType_ == G3x3) {
+            bool forceProfile = !fastScan_ && std::min(fabs(deltaNLL_ - 1.15), fabs(deltaNLL_ - 2.995)) < 0.5;
+            utils::CheapValueSnapshot center(*params);
+            double x0 = x, y0 = y;
+            for (int i2 = -1; i2 <= +1; ++i2) {
+              for (int j2 = -1; j2 <= +1; ++j2) {
+                if (i2 == 0 && j2 == 0) continue;
+                center.writeTo(*params);
+                x = x0 + 0.33333333*i2*deltaX;
+                y = y0 + 0.33333333*j2*deltaY;
+                poiVals_[0] = x; poiVars_[0]->setVal(x);
+                poiVals_[1] = y; poiVars_[1]->setVal(y);
+                nll.clearEvalErrorLog(); nll.getVal();
+                if (nll.numEvalErrors() > 0) {
+                  for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+                    specifiedVals_[j]=specifiedVars_[j]->getVal();
+                  }
+                  for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+                    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+                  }
+                  for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+                    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+                  }
+                  deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
+                  continue;
+                }
+                deltaNLL_ = nll.getVal() - nll0;
+                if (forceProfile || (!fastScan_ && std::min(fabs(deltaNLL_ - 1.15), fabs(deltaNLL_ - 2.995)) < 0.5)) {
+                  minim.minimize(verbose-1);
+                  deltaNLL_ = nll.getVal() - nll0;
+                }
+                double qN = 2*(deltaNLL_);
+                double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+                for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+                  specifiedVals_[j]=specifiedVars_[j]->getVal();
+                }
+                for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+                  specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+                }
+                for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+                  specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+                }
+                Combine::commitPoint(true, /*quantile=*/prob);
+              }
+            }
+          }
+        }
+      }
+    } else { // Use utils routine if n > 2
+      unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
+      unsigned int ipoint = 0, nprint = ceil(0.005*TMath::Power((double)rootn,(double)n));
+
+      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
+      CloseCoutSentry sentry(verbose < 2);
+      // Create permutations
+      std::vector<int> axis_points;
+      for (unsigned int poi_i=0;poi_i<n;poi_i++){
+	      axis_points.push_back((int)rootn);
+    	}
+
+      std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
+      // Step through points
+      std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
+      int npermutations = permutations.size();
+      for (; perm_it != permutations.end(); perm_it++) {
+        if (ipoint < firstPoint_) {
+          ipoint++;
+          continue;
+        }
+        if (ipoint > lastPoint_) break;
+        *params = snap;
+        if (verbose && (ipoint % nprint == 0)) {
+           fprintf(sentry.trueStdOut(), "Point %d/%d, ",
+                        ipoint,npermutations);
+        }
+        for (unsigned int poi_i = 0; poi_i < n; poi_i++) {
+          int ip = (*perm_it)[poi_i];
+          double deltaXi = (pmax[poi_i]-pmin[poi_i])/rootn;
+          double xi = pmin[poi_i]+deltaXi*(ip+0.5);
+          poiVals_[poi_i] = xi; poiVars_[poi_i]->setVal(xi);
+          if (verbose && (ipoint % nprint == 0)) {
+            fprintf(sentry.trueStdOut(), " %s = %f ",
+                    poiVars_[poi_i]->GetName(), xi);
+          }
+        }
+      if (verbose && (ipoint % nprint == 0)) fprintf(sentry.trueStdOut(), "\n");
+      nll.clearEvalErrorLog(); nll.getVal();
+      if (nll.numEvalErrors() > 0) {
+        for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+          specifiedVals_[j]=specifiedVars_[j]->getVal();
+        }
+        for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+          specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+        }
+        for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+          specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+        }
+        deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
+        ipoint++;
+        continue;
+      }
+      // now we minimize
+      bool skipme = hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_;
+      bool ok = fastScan_ || skipme ? true :  minim.minimize(verbose-1);
+      if (ok) {
+        deltaNLL_ = nll.getVal() - nll0;
+        double qN = 2*(deltaNLL_);
+        double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+        for(unsigned int j=0; j<specifiedNuis_.size(); j++){
+          specifiedVals_[j]=specifiedVars_[j]->getVal();
+        }
+        for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
+          specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+        }
+        for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
+          specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+        }
+        Combine::commitPoint(true, /*quantile=*/prob);
+      }
+      ipoint++;
     }
+  }
 }
 
 void MultiDimFit::doRandomPoints(RooWorkspace *w, RooAbsReal &nll) 


### PR DESCRIPTION
This option (off by default) causes the points to be aligned with the endpoints of the parameter ranges. For example, by default:

`combine -M MultiDimFit --algo grid --rMin 0 --rMax 5 --points 5` gives points `0.5, 1.5, 2.5, 3.5, 4.5`.

Whereas 

`combine -M MultiDimFit --algo grid --rMin 0 --rMax 5 --points 6 --alignEdges 1` will now give `0, 1, 2, 3, 4, 5` (NB - the number of points has been increased by 1)