### PR TITLE
Parametric shapes

### DIFF
--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -49,7 +49,7 @@ protected:
    RooRealProxy x;        // dependent variable
    RooListProxy pars;
    RooRealProxy mypdf;
-   TF1 * myfunc;
+   mutable TF1 * myfunc{NULL};
    Int_t xBins;        // X bins
    Double_t xArray[2000]; // xArray[xBins+1]
    Double_t xMax;        // X max

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -139,6 +139,8 @@ Double_t RooParametricShapeBinPdf::evaluate() const
   
   Double_t xLow = xArray[iBin];
   Double_t xHigh = xArray[iBin+1];
+
+  if(myfunc==NULL) myfunc = ((RooAbsPdf*)mypdf.absArg())->asTF( *(RooRealVar*)x.absArg(),pars);
     
   // define the function to be integrated numerically  
   ROOT::Math::WrappedTF1 func(*myfunc);

--- a/src/SequentialMinimizer.cc
+++ b/src/SequentialMinimizer.cc
@@ -465,7 +465,7 @@ namespace cmsmath {
         public:
            SubspaceMultiGenFunction(const ROOT::Math::IMultiGenFunction *f, int nDim, const int *idx, double *xi) :
                 f_(f), nDim_(nDim), idx_(idx), x_(xi) {}
-           virtual IBaseFunctionMultiDim * Clone() const { return new SubspaceMultiGenFunction(*this); }
+           virtual ROOT::Math::IBaseFunctionMultiDim * Clone() const { return new SubspaceMultiGenFunction(*this); }
            virtual unsigned int NDim() const { return nDim_; }
         private:
            virtual double DoEval(const double * x) const {


### PR DESCRIPTION
fix for RooParamatricShapesBinPdf.

still needs some testing for the correctness of the outcome, but the PR may be useful has starting point for the future.

Idea: pointers are not saved in the Workspace, therefore when loaded again are not valid. 
This minimal changes, make it mutable (because evaluate is const), and when it needs to be used, if not properly initialized, initialization is performed.