### PR TITLE
fix groups for rate params

### DIFF
--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -228,3 +228,15 @@ MB.doModel()
         Return thenumber of expected events for a given bin and process.
         """
         return self.exp[bin][proc]
+    
+    def getAllVariables(self):
+    	"""
+	Return all variables defined in the datacard
+	"""
+	allVars = tuple([syst[0] for syst in self.systs]+self.flatParamNuisances.keys()+self.extArgs.keys()+self.discretes)
+	for rp in self.rateParams: 
+	  p = self.rateParams[rp][0][0][0] 
+	  allVars+=tuple([p])
+
+	return list(set(allVars))
+

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -235,8 +235,8 @@ MB.doModel()
 	"""
 	allVars = tuple([syst[0] for syst in self.systs]+self.flatParamNuisances.keys()+self.extArgs.keys()+self.discretes)
 	for rp in self.rateParams: 
-	  p = self.rateParams[rp][0][0][0] 
-	  allVars+=tuple([p])
+	  modifiers = self.rateParams[rp]
+	  for p in modifiers : allVars+=tuple([p[0][0]])
 
 	return list(set(allVars))
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -476,7 +476,8 @@ class ModelBuilder(ModelBuilderBase):
     def doNuisancesGroups(self):
         # Prepare a dictionary of which group a certain nuisance belongs to
         groupsFor = {}
-        existingNuisanceNames = tuple(set([syst[0] for syst in self.DC.systs]+self.DC.flatParamNuisances.keys()+self.DC.rateParams.keys()+self.DC.extArgs.keys()+self.DC.discretes))
+        #existingNuisanceNames = tuple(set([syst[0] for syst in self.DC.systs]+self.DC.flatParamNuisances.keys()+self.DC.rateParams.keys()+self.DC.extArgs.keys()+self.DC.discretes))
+	existingNuisanceNames  = self.DC.getAllVariables()
         for groupName,nuisanceNames in self.DC.groups.iteritems():
             for nuisanceName in nuisanceNames:
                 if nuisanceName not in existingNuisanceNames:
@@ -495,7 +496,13 @@ class ModelBuilder(ModelBuilderBase):
                 if self.options.verbose > 1:
                     print 'Nuisance "%(n)s" is assigned to the following nuisance groups: %(groupNames)s' % locals()
                 for groupName in groupNames:
-                    self.out.var(n).setAttribute('group_'+groupName,True)
+		    try:
+                     self.out.var(n).setAttribute('group_'+groupName,True)
+		    except:
+		     try:
+                      self.out.cat(n).setAttribute('group_'+groupName,True)
+		     except: raise RuntimeError, 'Nuisance group "%(groupName)s" refers to nuisance but it is not an independant parameter.' % locals()
+
 
         for groupName,nuisanceNames in self.DC.groups.iteritems():
             nuisanceargset = ROOT.RooArgSet()


### PR DESCRIPTION
Before this users could not include `rateParam` type nuisances in their groups. Now this will allow it but also check to make sure that the `rateParam` is not a function/RooObject which cannot be set to floating/frozen etc 