### PR TITLE
Minimal fix to compile in 94X and correct printout bug

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -545,7 +545,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	// also set ignoreConstraint flag for constraint PDF 
 	if ( w->pdf(Form("%s_Pdf",arg->GetName())) ) w->pdf(Form("%s_Pdf",arg->GetName()))->setAttribute("ignoreConstraint");
       }
-      if (verbose > 0) std::cout << "Redefining the POIs to be: "; newPOIs.Print("");
+      if (verbose > 0) { std::cout << "Redefining the POIs to be: "; newPOIs.Print(""); }
       mc->SetParametersOfInterest(newPOIs);
       POI = mc->GetParametersOfInterest();
       if (nuisances) {
@@ -566,7 +566,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 
   if (floatNuisances_ != "") {
       RooArgSet toFloat((floatNuisances_=="all")?*nuisances:(w->argSet(floatNuisances_.c_str())));
-      if (verbose > 0) std::cout << "Set floating the following parameters: "; toFloat.Print("");
+      if (verbose > 0) {  std::cout << "Set floating the following parameters: "; toFloat.Print(""); }
       utils::setAllConstant(toFloat, false);
   }
   
@@ -597,7 +597,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       }
 
       RooArgSet toFreeze((freezeNuisances_=="all")?*nuisances:(w->argSet(freezeNuisances_.c_str())));
-      if (verbose > 0) std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print("");
+      if (verbose > 0) {  std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print(""); }
       utils::setAllConstant(toFreeze, true);
       if (nuisances) {
           RooArgSet newnuis(*nuisances);
@@ -633,7 +633,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	  toFreeze.add(groupNuisances);
 	}
 	
-        if (verbose > 0) std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print("");
+        if (verbose > 0) {  std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print(""); }
         utils::setAllConstant(toFreeze, true);
         if (nuisances) {
           RooArgSet newnuis(*nuisances);

--- a/src/SequentialMinimizer.cc
+++ b/src/SequentialMinimizer.cc
@@ -465,7 +465,7 @@ namespace cmsmath {
         public:
            SubspaceMultiGenFunction(const ROOT::Math::IMultiGenFunction *f, int nDim, const int *idx, double *xi) :
                 f_(f), nDim_(nDim), idx_(idx), x_(xi) {}
-           virtual IBaseFunctionMultiDim * Clone() const { return new SubspaceMultiGenFunction(*this); }
+           virtual SubspaceMultiGenFunction * Clone() const { return new SubspaceMultiGenFunction(*this); }
            virtual unsigned int NDim() const { return nDim_; }
         private:
            virtual double DoEval(const double * x) const {


### PR DESCRIPTION
 * fix the return type of `SubspaceMultiGenFunction::Clone` (made it covariant, should be fine also in 80X)
 * fix a bug in the printout verbosity that was spotted by the newer gcc of 94X

While I don't mind that the validated release for statistical analysis is still 80X, I do find useful to be able to compile also in 94X to access some of the PDF classes and utilities directly from the analysis environment.
