### PR TITLE
CombDataSetFactory: check for weighted RooDataSets on input

### DIFF
--- a/src/CombDataSetFactory.cc
+++ b/src/CombDataSetFactory.cc
@@ -27,6 +27,7 @@ void CombDataSetFactory::addSetAny(const char *label, RooDataHist *set) {
 
 
 void CombDataSetFactory::addSetAny(const char *label, RooDataSet *set) {
+    if (set->isWeighted() && weight_ == 0) weight_ = new RooRealVar("_weight_","",1);
     mapUB_[label] = set;
 }
 


### PR DESCRIPTION
Sometimes users will want to supply a pre-weighted RooDataSet, but if only RooDataSets are given as input then the weights are ignored by CombDataSetFactory. This adds an extra check when adding RooDataSets and creates the `_weight_` var if necessary.