### PR TITLE
Boundary conditions to NCSplines

### DIFF
--- a/interface/RooNCSplineCore.h
+++ b/interface/RooNCSplineCore.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINECORE
-#define RooNCSPLINECORE  
+#ifndef ROONCSPLINECORE
+#define ROONCSPLINECORE  
 
 #include <vector>
 #include "Accumulators.h"
@@ -22,6 +22,16 @@ public:
     kSilent,
     kError,
     kVerbose
+  };
+
+  enum BoundaryCondition{
+    bcApproximatedSlope, // D1 is the same as deltaY/deltaX in the first/last segment
+    bcClamped, // D1=0 at endpoint
+    bcApproximatedSecondDerivative, // D2 is approximated
+    bcNaturalSpline, // D2=0 at endpoint
+    bcQuadratic, // Coefficient D=0
+    bcQuadraticWithNullSlope, // Coefficient D=0 and D1=0 at endpoint
+    NBoundaryConditions
   };
 
   RooNCSplineCore();
@@ -82,15 +92,15 @@ protected:
   virtual T interpolateFcn(Int_t code, const char* rangeName=0)const = 0;
   virtual Double_t evaluate()const = 0;
 
-  virtual void getBArray(const std::vector<T>& kappas, const std::vector<T>& fcnList, std::vector<T>& BArray)const;
-  virtual void getAArray(const std::vector<T>& kappas, std::vector<std::vector<T>>& AArray)const;
-  virtual std::vector<std::vector<T>> getCoefficientsAlongDirection(const std::vector<T>& kappas, const TMatrix_t& Ainv, const std::vector<T>& fcnList, const Int_t pickBin)const;
+  virtual void getBArray(const std::vector<T>& kappas, const std::vector<T>& fcnList, std::vector<T>& BArray, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd)const;
+  virtual void getAArray(const std::vector<T>& kappas, std::vector<std::vector<T>>& AArray, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd)const;
+  virtual std::vector<std::vector<T>> getCoefficientsAlongDirection(const std::vector<T>& kappas, const TMatrix_t& Ainv, const std::vector<T>& fcnList, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd, const Int_t pickBin)const;
   virtual std::vector<T> getCoefficients(const TVector_t& S, const std::vector<T>& kappas, const std::vector<T>& fcnList, const Int_t& bin)const;
 
   virtual T evalSplineSegment(const std::vector<T>& coefs, const T& kappa, const T& tup, const T& tdn, Bool_t doIntegrate=false)const;
 
 
-  ClassDef(RooNCSplineCore, 1)
+  ClassDef(RooNCSplineCore, 3)
 
 };
  

--- a/interface/RooNCSplineFactory_1D.h
+++ b/interface/RooNCSplineFactory_1D.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINEFACTORY_1D
-#define RooNCSPLINEFACTORY_1D
+#ifndef ROONCSPLINEFACTORY_1D
+#define ROONCSPLINEFACTORY_1D
 
 #include <vector>
 #include <utility>
@@ -13,6 +13,9 @@ class RooNCSplineFactory_1D{
 protected:
   TString appendName;
 
+  RooNCSplineCore::BoundaryCondition bcBeginX;
+  RooNCSplineCore::BoundaryCondition bcEndX;
+
   RooAbsReal* splineVar;
   RooNCSpline_1D_fast* fcn;
   RooFuncPdf* PDF;
@@ -23,11 +26,21 @@ protected:
   void initPDF(const std::vector<std::pair<RooNCSplineCore::T, RooNCSplineCore::T>>& pList);
 
 public:
-  RooNCSplineFactory_1D(RooAbsReal& splineVar_, TString appendName_="");
+  RooNCSplineFactory_1D(
+    RooAbsReal& splineVar_, TString appendName_="",
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline
+  );
   ~RooNCSplineFactory_1D();
 
   RooNCSpline_1D_fast* getFunc(){ return fcn; }
   RooFuncPdf* getPDF(){ return PDF; }
+
+  void setEndConditions(
+    RooNCSplineCore::BoundaryCondition const bcBegin,
+    RooNCSplineCore::BoundaryCondition const bcEnd,
+    const unsigned int direction=0
+  );
 
   void setPoints(TTree* tree);
   void setPoints(TGraph* tg);

--- a/interface/RooNCSplineFactory_2D.h
+++ b/interface/RooNCSplineFactory_2D.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINEFACTORY_2D
-#define RooNCSPLINEFACTORY_2D
+#ifndef ROONCSPLINEFACTORY_2D
+#define ROONCSPLINEFACTORY_2D
 
 #include <vector>
 #include <utility>
@@ -16,11 +16,13 @@ namespace NumUtils{
       value[0]=i1;
       value[1]=i2;
       value[2]=i3;
+
     }
     triplet(T i1){
       value[0]=i1;
       value[1]=i1;
       value[2]=i1;
+
     }
     triplet(){}
     T& operator[](std::size_t ipos){ return value[ipos]; } // Return by reference
@@ -34,9 +36,15 @@ namespace NumUtils{
 
 typedef NumUtils::triplet<RooNCSplineCore::T> splineTriplet_t;
 
+
 class RooNCSplineFactory_2D{
 protected:
   TString appendName;
+
+  RooNCSplineCore::BoundaryCondition bcBeginX;
+  RooNCSplineCore::BoundaryCondition bcEndX;
+  RooNCSplineCore::BoundaryCondition bcBeginY;
+  RooNCSplineCore::BoundaryCondition bcEndY;
 
   RooAbsReal* XVar;
   RooAbsReal* YVar;
@@ -51,11 +59,23 @@ protected:
   void addUnique(std::vector<RooNCSplineCore::T>& list, RooNCSplineCore::T val);
 
 public:
-  RooNCSplineFactory_2D(RooAbsReal& XVar_, RooAbsReal& YVar_, TString appendName_="");
+  RooNCSplineFactory_2D(
+    RooAbsReal& XVar_, RooAbsReal& YVar_, TString appendName_="",
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndY_=RooNCSplineCore::bcNaturalSpline
+  );
   ~RooNCSplineFactory_2D();
 
   RooNCSpline_2D_fast* getFunc(){ return fcn; }
   RooFuncPdf* getPDF(){ return PDF; }
+
+  void setEndConditions(
+    RooNCSplineCore::BoundaryCondition const bcBegin,
+    RooNCSplineCore::BoundaryCondition const bcEnd,
+    const unsigned int direction
+  );
 
   void setPoints(TTree* tree);
   void setPoints(const std::vector<splineTriplet_t>& pList){ initPDF(pList); }

--- a/interface/RooNCSplineFactory_3D.h
+++ b/interface/RooNCSplineFactory_3D.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINEFACTORY_3D
-#define RooNCSPLINEFACTORY_3D
+#ifndef ROONCSPLINEFACTORY_3D
+#define ROONCSPLINEFACTORY_3D
 
 #include <vector>
 #include <utility>
@@ -31,9 +31,17 @@ namespace NumUtils{
 
 typedef NumUtils::quadruplet<RooNCSplineCore::T> splineQuadruplet_t;
 
+
 class RooNCSplineFactory_3D{
 protected:
   TString appendName;
+
+  RooNCSplineCore::BoundaryCondition bcBeginX;
+  RooNCSplineCore::BoundaryCondition bcEndX;
+  RooNCSplineCore::BoundaryCondition bcBeginY;
+  RooNCSplineCore::BoundaryCondition bcEndY;
+  RooNCSplineCore::BoundaryCondition bcBeginZ;
+  RooNCSplineCore::BoundaryCondition bcEndZ;
 
   RooAbsReal* XVar;
   RooAbsReal* YVar;
@@ -49,11 +57,25 @@ protected:
   void addUnique(std::vector<RooNCSplineCore::T>& list, RooNCSplineCore::T val);
 
 public:
-  RooNCSplineFactory_3D(RooAbsReal& XVar_, RooAbsReal& YVar_, RooAbsReal& ZVar_, TString appendName_="");
+  RooNCSplineFactory_3D(
+    RooAbsReal& XVar_, RooAbsReal& YVar_, RooAbsReal& ZVar_, TString appendName_="",
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginZ_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndZ_=RooNCSplineCore::bcNaturalSpline
+  );
   ~RooNCSplineFactory_3D();
 
   RooNCSpline_3D_fast* getFunc(){ return fcn; }
   RooFuncPdf* getPDF(){ return PDF; }
+
+  void setEndConditions(
+    RooNCSplineCore::BoundaryCondition const bcBegin,
+    RooNCSplineCore::BoundaryCondition const bcEnd,
+    const unsigned int direction
+  );
 
   void setPoints(TTree* tree);
   void setPoints(const std::vector<splineQuadruplet_t>& pList){ initPDF(pList); }

--- a/interface/RooNCSpline_1D_fast.h
+++ b/interface/RooNCSpline_1D_fast.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINE_1D_FAST
-#define RooNCSPLINE_1D_FAST
+#ifndef ROONCSPLINE_1D_FAST
+#define ROONCSPLINE_1D_FAST
 
 #include <vector>
 #include "RooAbsPdf.h"
@@ -11,6 +11,9 @@
 
 class RooNCSpline_1D_fast : public RooNCSplineCore{
 protected:
+  BoundaryCondition const bcBeginX;
+  BoundaryCondition const bcEndX;
+
   std::vector<T> FcnList; // List of function values
 
   std::vector<T> kappaX;
@@ -28,6 +31,8 @@ public:
     RooAbsReal& inXVar,
     const std::vector<T>& inXList,
     const std::vector<T>& inFcnList,
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline,
     Bool_t inUseFloor=true,
     T inFloorEval=0,
     T inFloorInt=0
@@ -56,7 +61,7 @@ protected:
   virtual Double_t evaluate()const;
 
 
-  ClassDef(RooNCSpline_1D_fast, 1)
+  ClassDef(RooNCSpline_1D_fast, 2)
 
 };
  

--- a/interface/RooNCSpline_2D_fast.h
+++ b/interface/RooNCSpline_2D_fast.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINE_2D_FAST
-#define RooNCSPLINE_2D_FAST
+#ifndef ROONCSPLINE_2D_FAST
+#define ROONCSPLINE_2D_FAST
 
 #include <vector>
 #include "RooAbsPdf.h"
@@ -12,6 +12,11 @@ class RooNCSpline_2D_fast : public RooNCSplineCore{
 protected:
   T rangeYmin;
   T rangeYmax;
+
+  BoundaryCondition const bcBeginX;
+  BoundaryCondition const bcEndX;
+  BoundaryCondition const bcBeginY;
+  BoundaryCondition const bcEndY;
 
   RooRealProxy theYVar;
   std::vector<T> YList;
@@ -36,6 +41,10 @@ public:
     const std::vector<T>& inXList,
     const std::vector<T>& inYList,
     const std::vector<std::vector<T>>& inFcnList,
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndY_=RooNCSplineCore::bcNaturalSpline,
     Bool_t inUseFloor=true,
     T inFloorEval=0,
     T inFloorInt=0
@@ -61,14 +70,14 @@ protected:
   Bool_t testRangeValidity(const T& val, const Int_t whichDirection)const;
   void cropValueForRange(T& val, const Int_t whichDirection)const;
 
-  virtual std::vector<std::vector<T>> getCoefficientsPerY(const std::vector<T>& kappaX, const TMatrix_t& xAinv, const Int_t& ybin, const Int_t xbin)const; // xbin can be -1, which means push all of them
+  virtual std::vector<std::vector<T>> getCoefficientsPerY(const std::vector<T>& kappaX, const TMatrix_t& xAinv, const Int_t& ybin, RooNCSplineCore::BoundaryCondition const& bcBegin, RooNCSplineCore::BoundaryCondition const& bcEnd, const Int_t xbin)const; // xbin can be -1, which means push all of them
 
   virtual T interpolateFcn(Int_t code, const char* rangeName=0)const;
 
   virtual Double_t evaluate()const;
 
 
-  ClassDef(RooNCSpline_2D_fast, 1)
+  ClassDef(RooNCSpline_2D_fast, 2)
 
 };
  

--- a/interface/RooNCSpline_3D_fast.h
+++ b/interface/RooNCSpline_3D_fast.h
@@ -1,5 +1,5 @@
-#ifndef RooNCSPLINE_3D_FAST
-#define RooNCSPLINE_3D_FAST
+#ifndef ROONCSPLINE_3D_FAST
+#define ROONCSPLINE_3D_FAST
 
 #include <vector>
 #include "RooAbsPdf.h"
@@ -14,6 +14,13 @@ protected:
   T rangeYmax;
   T rangeZmin;
   T rangeZmax;
+
+  BoundaryCondition const bcBeginX;
+  BoundaryCondition const bcEndX;
+  BoundaryCondition const bcBeginY;
+  BoundaryCondition const bcEndY;
+  BoundaryCondition const bcBeginZ;
+  BoundaryCondition const bcEndZ;
 
   RooRealProxy theYVar;
   RooRealProxy theZVar;
@@ -47,6 +54,12 @@ public:
     const std::vector<T>& inYList,
     const std::vector<T>& inZList,
     const std::vector<std::vector<std::vector<T>>>& inFcnList,
+    RooNCSplineCore::BoundaryCondition const bcBeginX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndX_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndY_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcBeginZ_=RooNCSplineCore::bcNaturalSpline,
+    RooNCSplineCore::BoundaryCondition const bcEndZ_=RooNCSplineCore::bcNaturalSpline,
     Bool_t inUseFloor=true,
     T inFloorEval=0,
     T inFloorInt=0
@@ -76,6 +89,7 @@ protected:
   virtual std::vector<std::vector<T>> getCoefficientsPerYPerZ(
     const std::vector<T>& kappaX, const TMatrix_t& xAinv,
     const Int_t& ybin, const Int_t& zbin,
+    RooNCSplineCore::BoundaryCondition const& bcBegin, RooNCSplineCore::BoundaryCondition const& bcEnd,
     const Int_t xbin
     )const; // xbin can be -1, which means push all of them
 
@@ -84,7 +98,7 @@ protected:
   virtual Double_t evaluate()const;
 
 
-  ClassDef(RooNCSpline_3D_fast, 1)
+  ClassDef(RooNCSpline_3D_fast, 2)
 
 };
  

--- a/src/RooNCSplineCore.cc
+++ b/src/RooNCSplineCore.cc
@@ -68,16 +68,55 @@ void RooNCSplineCore::setEvalFloor(RooNCSplineCore::T val){ floorEval = val; }
 void RooNCSplineCore::setIntFloor(RooNCSplineCore::T val){ floorInt = val; }
 void RooNCSplineCore::doFloor(Bool_t flag){ useFloor = flag; }
 
-void RooNCSplineCore::getBArray(const std::vector<RooNCSplineCore::T>& kappas, const vector<RooNCSplineCore::T>& fcnList, std::vector<RooNCSplineCore::T>& BArray)const{
+void RooNCSplineCore::getBArray(const std::vector<RooNCSplineCore::T>& kappas, const vector<RooNCSplineCore::T>& fcnList, std::vector<RooNCSplineCore::T>& BArray, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd)const{
   BArray.clear();
   int npoints=kappas.size();
   if (npoints!=(int)fcnList.size()){
     coutE(InputArguments) << "RooNCSplineCore::getBArray: Dim(kappas)=" << npoints << " != Dim(fcnList)=" << fcnList.size() << endl;
     assert(0);
   }
+  if (
+    bcBegin==bcQuadraticWithNullSlope || bcEnd==bcQuadraticWithNullSlope
+    ||
+    bcBegin==bcQuadratic || bcEnd==bcQuadratic
+    ){
+    int nthr=1+(bcBegin==bcQuadraticWithNullSlope || bcBegin==bcQuadratic ? 1 : 0) + (bcEnd==bcQuadraticWithNullSlope || bcEnd==bcQuadratic ? 1 : 0);
+    if (npoints<=nthr){
+      cerr << "Npoints " << npoints << " <= " << nthr << endl;
+      assert(0);
+    }
+  }
   if (npoints>1){
-    BArray.push_back(3.*(fcnList.at(1)-fcnList.at(0)));
+    RooNCSplineCore::T bcval=0, ecval=0;
+    // First point constraint
+    switch (bcBegin){
+    case bcApproximatedSecondDerivative:
+      bcval=(npoints<3 ? 0 : ((fcnList.at(2)-fcnList.at(1))*kappas.at(1)-(fcnList.at(1)-fcnList.at(0))*kappas.at(0))/(0.5/kappas.at(0)+0.5/kappas.at(1)));
+    case bcNaturalSpline:
+      BArray.push_back(3.*(fcnList.at(1)-fcnList.at(0)) - bcval/2./pow(kappas.at(0), 2));
+      break;
+    case bcApproximatedSlope:
+      bcval=(fcnList.at(1)-fcnList.at(0))*kappas.at(0);
+    case bcClamped:
+      BArray.push_back(bcval/kappas.at(0));
+      break;
+    case bcQuadratic:
+      bcval=2.*(fcnList.at(1)-fcnList.at(0));
+      BArray.push_back(bcval);
+      break;
+    case bcQuadraticWithNullSlope:
+      bcval=2.*(fcnList.at(1)-fcnList.at(0));
+      BArray.push_back(0);
+      BArray.push_back(bcval*kappas.at(0)/kappas.at(1));
+      break;
+    default:
+      cerr << "RooNCSplineCore::getBArray: bcBegin " << bcBegin << " is not implemented!" << endl;
+      assert(0);
+    }
+    // Intermediate point constraint is always D0, D1 and D2 continuous
     for (int j=1; j<npoints-1; j++){
+      if (j==1 && bcBegin==bcQuadraticWithNullSlope) continue;
+      if (j==npoints-2 && bcEnd==bcQuadraticWithNullSlope) continue;
       RooNCSplineCore::T val_j = fcnList.at(j);
       RooNCSplineCore::T val_jpo = fcnList.at(j+1);
       RooNCSplineCore::T val_jmo = fcnList.at(j-1);
@@ -88,26 +127,89 @@ void RooNCSplineCore::getBArray(const std::vector<RooNCSplineCore::T>& kappas, c
       Bval *= 3.;
       BArray.push_back(Bval);
     }
-    BArray.push_back(3.*(fcnList.at(npoints-1)-fcnList.at(npoints-2)));
+    // Last point constraint
+    switch (bcEnd){
+    case bcApproximatedSecondDerivative:
+      ecval=(npoints<3 ? 0 : ((fcnList.at(npoints-1)-fcnList.at(npoints-2))*kappas.at(npoints-2)-(fcnList.at(npoints-2)-fcnList.at(npoints-3))*kappas.at(npoints-3))/(0.5/kappas.at(npoints-3)+0.5/kappas.at(npoints-2)));
+    case bcNaturalSpline:
+      BArray.push_back(3.*(fcnList.at(npoints-1)-fcnList.at(npoints-2)) + ecval/2./pow(kappas.at(npoints-1), 2));
+      break;
+    case bcApproximatedSlope:
+      bcval=(fcnList.at(npoints-1)-fcnList.at(npoints-2))*kappas.at(npoints-2);
+    case bcClamped:
+      BArray.push_back(ecval/kappas.at(npoints-1));
+      break;
+    case bcQuadratic:
+      ecval=2.*(fcnList.at(npoints-1)-fcnList.at(npoints-2));
+      BArray.push_back(ecval);
+      break;
+    case bcQuadraticWithNullSlope:
+      ecval=2.*(fcnList.at(npoints-1)-fcnList.at(npoints-2));
+      BArray.push_back(ecval);
+      BArray.push_back(0);
+      break;
+    default:
+      cerr << "RooNCSplineCore::getAArray: bcEnd " << bcEnd << " is not implemented!" << endl;
+      assert(0);
+    }
   }
   else if (npoints==1) BArray.push_back(0);
 }
-void RooNCSplineCore::getAArray(const vector<RooNCSplineCore::T>& kappas, vector<vector<RooNCSplineCore::T>>& AArray)const{
+void RooNCSplineCore::getAArray(const vector<RooNCSplineCore::T>& kappas, vector<vector<RooNCSplineCore::T>>& AArray, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd)const{
   AArray.clear();
   Int_t npoints = kappas.size();
   for (int i=0; i<npoints; i++){
     vector<RooNCSplineCore::T> Ai(npoints, 0.);
     if (npoints==1) Ai[0]=1;
-    else if (i==0){ Ai[0]=2; Ai[1]=kappas.at(1)/kappas.at(0); }
-    else if (i==npoints-1){ Ai[npoints-2]=1; Ai[npoints-1]=2.*kappas.at(npoints-1)/kappas.at(npoints-2); }
+    else if (i==0){
+      switch(bcBegin){
+      case bcNaturalSpline:
+      case bcApproximatedSecondDerivative:
+        Ai[0]=2; Ai[1]=kappas.at(1)/kappas.at(0);
+        break;
+      case bcClamped:
+      case bcApproximatedSlope:
+      case bcQuadraticWithNullSlope:
+        Ai[0]=1;
+        break;
+      case bcQuadratic:
+        Ai[0]=1; Ai[1]=kappas.at(1)/kappas.at(0);
+        break;
+      default:
+        cerr << "RooNCSplineCore::getAArray: bcBegin " << bcBegin << " is not implemented!" << endl;
+        assert(0);
+      }
+    }
+    else if (i==npoints-1){
+      switch(bcEnd){
+      case bcNaturalSpline:
+      case bcApproximatedSecondDerivative:
+        Ai[npoints-2]=1; Ai[npoints-1]=2.*kappas.at(npoints-1)/kappas.at(npoints-2);
+        break;
+      case bcClamped:
+      case bcApproximatedSlope:
+      case bcQuadraticWithNullSlope:
+        Ai[npoints-1]=1;
+        break;
+      case bcQuadratic:
+        Ai[npoints-2]=1; Ai[npoints-1]=kappas.at(npoints-1)/kappas.at(npoints-2);
+        break;
+      default:
+        cerr << "RooNCSplineCore::getAArray: bcEnd " << bcEnd << " is not implemented!" << endl;
+        assert(0);
+      }
+    }
     else{
-      RooNCSplineCore::T kappa_j = kappas.at(i);
-      RooNCSplineCore::T kappa_jmo = kappas.at(i-1);
-      RooNCSplineCore::T kappa_jpo = kappas.at(i+1);
+      if ((i==1 && bcBegin==bcQuadraticWithNullSlope) || (i==npoints-2 && bcEnd==bcQuadraticWithNullSlope)) Ai[i]=1;
+      else{
+        RooNCSplineCore::T kappa_j = kappas.at(i);
+        RooNCSplineCore::T kappa_jmo = kappas.at(i-1);
+        RooNCSplineCore::T kappa_jpo = kappas.at(i+1);
 
-      Ai[i-1]=1;
-      Ai[i]=2.*kappa_j/kappa_jmo*(1.+kappa_j/kappa_jmo);
-      Ai[i+1]=kappa_j*kappa_jpo/pow(kappa_jmo, 2);
+        Ai[i-1]=1;
+        Ai[i]=2.*kappa_j/kappa_jmo*(1.+kappa_j/kappa_jmo);
+        Ai[i+1]=kappa_j*kappa_jpo/pow(kappa_jmo, 2);
+      }
     }
     AArray.push_back(Ai);
   }
@@ -141,9 +243,9 @@ vector<RooNCSplineCore::T> RooNCSplineCore::getCoefficients(const TVector_t& S, 
   res.push_back(D);
   return res;
 }
-vector<vector<RooNCSplineCore::T>> RooNCSplineCore::getCoefficientsAlongDirection(const std::vector<RooNCSplineCore::T>& kappas, const TMatrix_t& Ainv, const vector<RooNCSplineCore::T>& fcnList, const Int_t pickBin)const{
+vector<vector<RooNCSplineCore::T>> RooNCSplineCore::getCoefficientsAlongDirection(const std::vector<RooNCSplineCore::T>& kappas, const TMatrix_t& Ainv, const vector<RooNCSplineCore::T>& fcnList, BoundaryCondition const& bcBegin, BoundaryCondition const& bcEnd, const Int_t pickBin)const{
   vector<RooNCSplineCore::T> BArray;
-  getBArray(kappas, fcnList, BArray);
+  getBArray(kappas, fcnList, BArray, bcBegin, bcEnd);
 
   Int_t npoints = BArray.size();
   TVector_t Btrans(npoints);

--- a/src/RooNCSplineFactory_1D.cc
+++ b/src/RooNCSplineFactory_1D.cc
@@ -4,11 +4,16 @@
 using namespace std;
 
 
-RooNCSplineFactory_1D::RooNCSplineFactory_1D(RooAbsReal& splineVar_, TString appendName_) :
-appendName(appendName_),
-splineVar(&splineVar_),
-fcn(0),
-PDF(0)
+RooNCSplineFactory_1D::RooNCSplineFactory_1D(
+  RooAbsReal& splineVar_, TString appendName_,
+  RooNCSplineCore::BoundaryCondition const bcBeginX_,
+  RooNCSplineCore::BoundaryCondition const bcEndX_
+) :
+  appendName(appendName_),
+  bcBeginX(bcBeginX_), bcEndX(bcEndX_),
+  splineVar(&splineVar_),
+  fcn(0),
+  PDF(0)
 {}
 RooNCSplineFactory_1D::~RooNCSplineFactory_1D(){
   destroyPDF();
@@ -61,7 +66,8 @@ void RooNCSplineFactory_1D::initPDF(const std::vector<std::pair<RooNCSplineCore:
     name.Data(),
     title.Data(),
     *splineVar,
-    XList, FcnList
+    XList, FcnList,
+    bcBeginX, bcEndX
     );
 
   name.Prepend("PDF_"); title=name;
@@ -70,4 +76,13 @@ void RooNCSplineFactory_1D::initPDF(const std::vector<std::pair<RooNCSplineCore:
     title.Data(),
     *fcn
     );
+}
+
+void RooNCSplineFactory_1D::setEndConditions(
+  RooNCSplineCore::BoundaryCondition const bcBegin,
+  RooNCSplineCore::BoundaryCondition const bcEnd,
+  const unsigned int /*direction*/
+){
+  bcBeginX=bcBegin;
+  bcEndX=bcEnd;
 }

--- a/src/RooNCSplineFactory_2D.cc
+++ b/src/RooNCSplineFactory_2D.cc
@@ -3,11 +3,19 @@
 using namespace std;
 
 
-RooNCSplineFactory_2D::RooNCSplineFactory_2D(RooAbsReal& XVar_, RooAbsReal& YVar_, TString appendName_) :
-appendName(appendName_),
-XVar(&XVar_), YVar(&YVar_),
-fcn(0),
-PDF(0)
+RooNCSplineFactory_2D::RooNCSplineFactory_2D(
+  RooAbsReal& XVar_, RooAbsReal& YVar_, TString appendName_,
+  RooNCSplineCore::BoundaryCondition const bcBeginX_,
+  RooNCSplineCore::BoundaryCondition const bcEndX_,
+  RooNCSplineCore::BoundaryCondition const bcBeginY_,
+  RooNCSplineCore::BoundaryCondition const bcEndY_
+) :
+  appendName(appendName_),
+  bcBeginX(bcBeginX_), bcEndX(bcEndX_),
+  bcBeginY(bcBeginY_), bcEndY(bcEndY_),
+  XVar(&XVar_), YVar(&YVar_),
+  fcn(0),
+  PDF(0)
 {}
 RooNCSplineFactory_2D::~RooNCSplineFactory_2D(){
   destroyPDF();
@@ -71,7 +79,9 @@ void RooNCSplineFactory_2D::initPDF(const std::vector<splineTriplet_t>& pList){
     name.Data(),
     title.Data(),
     *XVar, *YVar,
-    XList, YList, FcnList
+    XList, YList, FcnList,
+    bcBeginX, bcEndX,
+    bcBeginY, bcEndY
     );
 
   name.Prepend("PDF_"); title=name;
@@ -91,4 +101,24 @@ void RooNCSplineFactory_2D::setPoints(TTree* tree){
   int n = tree->GetEntries();
   for (int ip=0; ip<n; ip++){ tree->GetEntry(ip); pList.push_back(splineTriplet_t(x, y, fcn)); }
   setPoints(pList);
+}
+
+void RooNCSplineFactory_2D::setEndConditions(
+  RooNCSplineCore::BoundaryCondition const bcBegin,
+  RooNCSplineCore::BoundaryCondition const bcEnd,
+  const unsigned int direction
+){
+  switch (direction){
+  case 0:
+    bcBeginX=bcBegin;
+    bcEndX=bcEnd;
+    break;
+  case 1:
+    bcBeginY=bcBegin;
+    bcEndY=bcEnd;
+    break;
+  default:
+    // Do nothing
+    break;
+  }
 }

--- a/src/RooNCSplineFactory_3D.cc
+++ b/src/RooNCSplineFactory_3D.cc
@@ -3,11 +3,22 @@
 using namespace std;
 
 
-RooNCSplineFactory_3D::RooNCSplineFactory_3D(RooAbsReal& XVar_, RooAbsReal& YVar_, RooAbsReal& ZVar_, TString appendName_) :
-appendName(appendName_),
-XVar(&XVar_), YVar(&YVar_), ZVar(&ZVar_),
-fcn(0),
-PDF(0)
+RooNCSplineFactory_3D::RooNCSplineFactory_3D(
+  RooAbsReal& XVar_, RooAbsReal& YVar_, RooAbsReal& ZVar_, TString appendName_,
+  RooNCSplineCore::BoundaryCondition const bcBeginX_,
+  RooNCSplineCore::BoundaryCondition const bcEndX_,
+  RooNCSplineCore::BoundaryCondition const bcBeginY_,
+  RooNCSplineCore::BoundaryCondition const bcEndY_,
+  RooNCSplineCore::BoundaryCondition const bcBeginZ_,
+  RooNCSplineCore::BoundaryCondition const bcEndZ_
+) :
+  appendName(appendName_),
+  bcBeginX(bcBeginX_), bcEndX(bcEndX_),
+  bcBeginY(bcBeginY_), bcEndY(bcEndY_),
+  bcBeginZ(bcBeginZ_), bcEndZ(bcEndZ_),
+  XVar(&XVar_), YVar(&YVar_), ZVar(&ZVar_),
+  fcn(0),
+  PDF(0)
 {}
 RooNCSplineFactory_3D::~RooNCSplineFactory_3D(){
   destroyPDF();
@@ -84,8 +95,11 @@ void RooNCSplineFactory_3D::initPDF(const std::vector<splineQuadruplet_t>& pList
     name.Data(),
     title.Data(),
     *XVar, *YVar, *ZVar,
-    XList, YList, ZList, FcnList
-    );
+    XList, YList, ZList, FcnList,
+    bcBeginX, bcEndX,
+    bcBeginY, bcEndY,
+    bcBeginZ, bcEndZ
+  );
 
   name.Prepend("PDF_"); title=name;
   PDF = new RooFuncPdf(
@@ -105,4 +119,28 @@ void RooNCSplineFactory_3D::setPoints(TTree* tree){
   int n = tree->GetEntries();
   for (int ip=0; ip<n; ip++){ tree->GetEntry(ip); pList.push_back(splineQuadruplet_t(x, y, z, fcn)); }
   setPoints(pList);
+}
+
+void RooNCSplineFactory_3D::setEndConditions(
+  RooNCSplineCore::BoundaryCondition const bcBegin,
+  RooNCSplineCore::BoundaryCondition const bcEnd,
+  const unsigned int direction
+){
+  switch (direction){
+  case 0:
+    bcBeginX=bcBegin;
+    bcEndX=bcEnd;
+    break;
+  case 1:
+    bcBeginY=bcBegin;
+    bcEndY=bcEnd;
+    break;
+  case 2:
+    bcBeginZ=bcBegin;
+    bcEndZ=bcEnd;
+    break;
+  default:
+    // Do nothing
+    break;
+  }
 }

--- a/src/RooNCSpline_1D_fast.cc
+++ b/src/RooNCSpline_1D_fast.cc
@@ -12,14 +12,16 @@ using namespace std;
 ClassImp(RooNCSpline_1D_fast)
 
 RooNCSpline_1D_fast::RooNCSpline_1D_fast() :
-RooNCSplineCore()
+  RooNCSplineCore(),
+  bcBeginX(RooNCSplineCore::bcNaturalSpline), bcEndX(RooNCSplineCore::bcNaturalSpline)
 {}
 
 RooNCSpline_1D_fast::RooNCSpline_1D_fast(
   const char* name,
   const char* title
   ) :
-  RooNCSplineCore(name, title)
+  RooNCSplineCore(name, title),
+  bcBeginX(RooNCSplineCore::bcNaturalSpline), bcEndX(RooNCSplineCore::bcNaturalSpline)
 {}
 
 RooNCSpline_1D_fast::RooNCSpline_1D_fast(
@@ -28,17 +30,20 @@ RooNCSpline_1D_fast::RooNCSpline_1D_fast(
   RooAbsReal& inXVar,
   const std::vector<T>& inXList,
   const std::vector<T>& inFcnList,
+  RooNCSplineCore::BoundaryCondition const bcBeginX_,
+  RooNCSplineCore::BoundaryCondition const bcEndX_,
   Bool_t inUseFloor,
   T inFloorEval,
   T inFloorInt
   ) :
   RooNCSplineCore(name, title, inXVar, inXList, inUseFloor, inFloorEval, inFloorInt),
+  bcBeginX(bcBeginX_), bcEndX(bcEndX_),
   FcnList(inFcnList)
 {
   if (npointsX()>1){
     int npoints;
 
-    vector<vector<RooNCSplineCore::T>> xA; getKappas(kappaX, 0); getAArray(kappaX, xA);
+    vector<vector<RooNCSplineCore::T>> xA; getKappas(kappaX, 0); getAArray(kappaX, xA, bcBeginX, bcEndX);
     npoints=kappaX.size();
     TMatrix_t xAtrans(npoints, npoints);
     for (int i=0; i<npoints; i++){ for (int j=0; j<npoints; j++){ xAtrans[i][j]=xA.at(i).at(j); } }
@@ -49,7 +54,7 @@ RooNCSpline_1D_fast::RooNCSpline_1D_fast(
       assert(0);
     }
 
-    coefficients = getCoefficientsAlongDirection(kappaX, xAinv, FcnList, -1);
+    coefficients = getCoefficientsAlongDirection(kappaX, xAinv, FcnList, bcBeginX, bcEndX, -1);
   }
   else assert(0);
 
@@ -65,6 +70,7 @@ RooNCSpline_1D_fast::RooNCSpline_1D_fast(
   const char* name
   ) :
   RooNCSplineCore(other, name),
+  bcBeginX(other.bcBeginX), bcEndX(other.bcEndX),
   FcnList(other.FcnList),
   kappaX(other.kappaX),
   coefficients(other.coefficients)

--- a/src/RooNCSpline_3D_fast.cc
+++ b/src/RooNCSpline_3D_fast.cc
@@ -12,11 +12,14 @@ using namespace std;
 ClassImp(RooNCSpline_3D_fast)
 
 RooNCSpline_3D_fast::RooNCSpline_3D_fast() :
-RooNCSplineCore(),
-rangeYmin(1), rangeYmax(-1),
-rangeZmin(1), rangeZmax(-1),
-theYVar("theYVar", "theYVar", this),
-theZVar("theZVar", "theZVar", this)
+  RooNCSplineCore(),
+  rangeYmin(1), rangeYmax(-1),
+  rangeZmin(1), rangeZmax(-1),
+  bcBeginX(RooNCSplineCore::bcNaturalSpline), bcEndX(RooNCSplineCore::bcNaturalSpline),
+  bcBeginY(RooNCSplineCore::bcNaturalSpline), bcEndY(RooNCSplineCore::bcNaturalSpline),
+  bcBeginZ(RooNCSplineCore::bcNaturalSpline), bcEndZ(RooNCSplineCore::bcNaturalSpline),
+  theYVar("theYVar", "theYVar", this),
+  theZVar("theZVar", "theZVar", this)
 {}
 
 RooNCSpline_3D_fast::RooNCSpline_3D_fast(
@@ -26,6 +29,9 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
   RooNCSplineCore(name, title),
   rangeYmin(1), rangeYmax(-1),
   rangeZmin(1), rangeZmax(-1),
+  bcBeginX(RooNCSplineCore::bcNaturalSpline), bcEndX(RooNCSplineCore::bcNaturalSpline),
+  bcBeginY(RooNCSplineCore::bcNaturalSpline), bcEndY(RooNCSplineCore::bcNaturalSpline),
+  bcBeginZ(RooNCSplineCore::bcNaturalSpline), bcEndZ(RooNCSplineCore::bcNaturalSpline),
   theYVar("theYVar", "theYVar", this),
   theZVar("theZVar", "theZVar", this)
 {}
@@ -40,6 +46,12 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
   const std::vector<T>& inYList,
   const std::vector<T>& inZList,
   const std::vector<std::vector<std::vector<T>>>& inFcnList,
+  RooNCSplineCore::BoundaryCondition const bcBeginX_,
+  RooNCSplineCore::BoundaryCondition const bcEndX_,
+  RooNCSplineCore::BoundaryCondition const bcBeginY_,
+  RooNCSplineCore::BoundaryCondition const bcEndY_,
+  RooNCSplineCore::BoundaryCondition const bcBeginZ_,
+  RooNCSplineCore::BoundaryCondition const bcEndZ_,
   Bool_t inUseFloor,
   T inFloorEval,
   T inFloorInt
@@ -47,6 +59,9 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
   RooNCSplineCore(name, title, inXVar, inXList, inUseFloor, inFloorEval, inFloorInt),
   rangeYmin(1), rangeYmax(-1),
   rangeZmin(1), rangeZmax(-1),
+  bcBeginX(bcBeginX_), bcEndX(bcEndX_),
+  bcBeginY(bcBeginY_), bcEndY(bcEndY_),
+  bcBeginZ(bcBeginZ_), bcEndZ(bcEndZ_),
   theYVar("theYVar", "theYVar", this, inYVar),
   theZVar("theZVar", "theZVar", this, inZVar),
   YList(inYList),
@@ -58,7 +73,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
     int npoints;
     Double_t det;
 
-    vector<vector<RooNCSplineCore::T>> xA; getKappas(kappaX, 0); getAArray(kappaX, xA);
+    vector<vector<RooNCSplineCore::T>> xA; getKappas(kappaX, 0); getAArray(kappaX, xA, bcBeginX, bcEndX);
     npoints=kappaX.size();
     TMatrix_t xAtrans(npoints, npoints);
     for (int i=0; i<npoints; i++){ for (int j=0; j<npoints; j++){ xAtrans[i][j]=xA.at(i).at(j); } }
@@ -69,7 +84,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
       assert(0);
     }
 
-    vector<vector<RooNCSplineCore::T>> yA; getKappas(kappaY, 1); getAArray(kappaY, yA);
+    vector<vector<RooNCSplineCore::T>> yA; getKappas(kappaY, 1); getAArray(kappaY, yA, bcBeginY, bcEndY);
     npoints=kappaY.size();
     TMatrix_t yAtrans(npoints, npoints);
     for (int i=0; i<npoints; i++){ for (int j=0; j<npoints; j++){ yAtrans[i][j]=yA.at(i).at(j); } }
@@ -80,7 +95,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
       assert(0);
     }
 
-    vector<vector<RooNCSplineCore::T>> zA; getKappas(kappaZ, 2); getAArray(kappaZ, zA);
+    vector<vector<RooNCSplineCore::T>> zA; getKappas(kappaZ, 2); getAArray(kappaZ, zA, bcBeginZ, bcEndZ);
     npoints=kappaZ.size();
     TMatrix_t zAtrans(npoints, npoints);
     for (int i=0; i<npoints; i++){ for (int j=0; j<npoints; j++){ zAtrans[i][j]=zA.at(i).at(j); } }
@@ -112,7 +127,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
 
       vector<vector<vector<RooNCSplineCore::T>>> coefsAlongY; // [xbin][Ax(y),Bx(y),Cx(y),Dx(y)][ybin] in each z
       for (unsigned int j=0; j<npointsY(); j++){
-        vector<vector<RooNCSplineCore::T>> xcoefsAtYjZk = getCoefficientsPerYPerZ(kappaX, xAinv, j, k, -1); // [ix][Ax,Bx,Cx,Dx] at each y_j z_k
+        vector<vector<RooNCSplineCore::T>> xcoefsAtYjZk = getCoefficientsPerYPerZ(kappaX, xAinv, j, k, bcBeginX, bcEndX, -1); // [ix][Ax,Bx,Cx,Dx] at each y_j z_k
         //cout << "\tCoefficients in y line " << j << " are found" << endl;
         if (j==0){
           if (k==0){
@@ -143,7 +158,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
         // Get the x coefficients interpolated across y
         vector<vector<vector<RooNCSplineCore::T>>> xCoefs;
         for (int icx=0; icx<nxpoldim; icx++){
-          vector<vector<RooNCSplineCore::T>> yCoefs = getCoefficientsAlongDirection(kappaY, yAinv, coefsAlongY.at(ix).at(icx), -1); // [iy][A,B,C,D]
+          vector<vector<RooNCSplineCore::T>> yCoefs = getCoefficientsAlongDirection(kappaY, yAinv, coefsAlongY.at(ix).at(icx), bcBeginY, bcEndY, -1); // [iy][A,B,C,D]
           xCoefs.push_back(yCoefs);
         }
         coefficients_perZ.push_back(xCoefs);
@@ -188,7 +203,7 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
         for (int iy=0; iy<nybins; iy++){
           vector<vector<vector<RooNCSplineCore::T>>> yCoefs;
           for (int icy=0; icy<nypoldim; icy++){
-            vector<vector<RooNCSplineCore::T>> yCoefsAlongZ = getCoefficientsAlongDirection(kappaZ, zAinv, coefsAlongZ.at(ix).at(icx).at(iy).at(icy), -1); // [iz][A,B,C,D]
+            vector<vector<RooNCSplineCore::T>> yCoefsAlongZ = getCoefficientsAlongDirection(kappaZ, zAinv, coefsAlongZ.at(ix).at(icx).at(iy).at(icy), bcBeginZ, bcEndZ, -1); // [iz][A,B,C,D]
             yCoefs.push_back(yCoefsAlongZ);
           }
           xCoefsAlongY.push_back(yCoefs);
@@ -217,6 +232,9 @@ RooNCSpline_3D_fast::RooNCSpline_3D_fast(
   RooNCSplineCore(other, name),
   rangeYmin(other.rangeYmin), rangeYmax(other.rangeYmax),
   rangeZmin(other.rangeZmin), rangeZmax(other.rangeZmax),
+  bcBeginX(other.bcBeginX), bcEndX(other.bcEndX),
+  bcBeginY(other.bcBeginY), bcEndY(other.bcEndY),
+  bcBeginZ(other.bcBeginZ), bcEndZ(other.bcEndZ),
   theYVar("theYVar", this, other.theYVar),
   theZVar("theZVar", this, other.theZVar),
   YList(other.YList),
@@ -407,11 +425,12 @@ RooNCSplineCore::T RooNCSpline_3D_fast::getTVar(const vector<RooNCSplineCore::T>
 vector<vector<RooNCSplineCore::T>> RooNCSpline_3D_fast::getCoefficientsPerYPerZ(
   const std::vector<RooNCSplineCore::T>& kappaX, const TMatrix_t& xAinv,
   const Int_t& ybin, const Int_t& zbin,
+  RooNCSplineCore::BoundaryCondition const& bcBegin, RooNCSplineCore::BoundaryCondition const& bcEnd,
   const Int_t xbin
   )const{
   vector<RooNCSplineCore::T> fcnList;
   for (unsigned int bin=0; bin<npointsX(); bin++){ fcnList.push_back(FcnList.at(zbin).at(ybin).at(bin)); }
-  vector<vector<RooNCSplineCore::T>> coefs = getCoefficientsAlongDirection(kappaX, xAinv, fcnList, xbin);
+  vector<vector<RooNCSplineCore::T>> coefs = getCoefficientsAlongDirection(kappaX, xAinv, fcnList, bcBegin, bcEnd, xbin);
   return coefs;
 }
 


### PR DESCRIPTION
This PR introduces alternative boundary conditions for each of the Cartesian coordinates in 1/2/3D natural cubic splines. The splines were previously written to be "natural" (i.e. second derivative at end points is 0), but some applications may require different constraints. Therefore, the splines now support the following conditions at each endpoint separately (as outlined in RooNCSplineCore.h):
- bcApproximatedSlope: First derivative at the end point is approximated with the deltaY/deltaX of the two first/last points
- bcClamped: First derivative is 0 at the endpoint
- bcApproximatedSecondDerivative: Second derivative is approximated from the first/last 3 points
- bcNaturalSpline: Second derivative at endpoints is 0 (default)
- bcQuadratic: First or last piecewise function is explicitly a quadratic instead of a cubic polynomial
- bcQuadraticWithNullSlope: First or last piecewise function is explicitly a quadratic instead of a cubic polynomial and the slope at the endpoint is 0