### PR TITLE
fix shape example datacard line

### DIFF
--- a/data/tutorials/shapes/simple-shapes-parametric.txt
+++ b/data/tutorials/shapes/simple-shapes-parametric.txt
@@ -16,4 +16,4 @@ process      0          1
 rate         1          1
 --------------------------------
 lumi    lnN  1.1       1.0
-sigma   param 1.0      0.1
+vogian_sigma   param 1.0      0.1


### PR DESCRIPTION
The line in the example does not match the name of the parameter in the pdf of the input workspace.