### PR TITLE
CachingSimNLL leak and AsymptoticLimits asimov dataset fixes

### DIFF
--- a/interface/AsymptoticLimits.h
+++ b/interface/AsymptoticLimits.h
@@ -51,6 +51,8 @@ private:
 
   static bool   strictBounds_;
 
+  static RooAbsData * asimovDataset_;
+
   bool    hasFloatParams_;
   bool    hasDiscreteParams_;
   mutable std::auto_ptr<RooArgSet>  params_;

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -868,6 +868,9 @@ cacheutils::CachingSimNLL::~CachingSimNLL()
     for (std::vector<SimplePoissonConstraint*>::iterator it = constrainPdfsFastPoisson_.begin(), ed = constrainPdfsFastPoisson_.end(); it != ed; ++it, ++ito) {
         if (*ito) { delete *it; }
     }
+    for (std::vector<CachingAddNLL*>::iterator it = pdfs_.begin(); it != pdfs_.end(); ++it){
+        if (*it) { delete *it; }
+    }
     #ifdef TRACE_NLL_EVAL_COUNT
         std::cout << "CachingSimNLLEvalCount: " << ::CachingSimNLLEvalCount << std::endl;
     #endif


### PR DESCRIPTION
Two fixes in this PR:

 - AsymptoticLimits: ensure that each time the method is run, the asimov dataset is regenerated (e.g. for running with -t X toys). Currently the asimov generated from the first toy is reused in all subsequent toys
 - Fix to the longstanding issue of toy fits getting slower the more toys are generated. CachingSimNLL now deletes the CachingAddNLLs that it creates and owns. Previously this was a memory leak and also led to the fit slowing down every time a new CachingSimNLL was created, as the fit parameters remained connected to all previous CachingAddNLLs that didn't get cleaned up, thus increasing the time spent in RooFit's dirty flag propagation during the fit.