### PR TITLE
Allow for renaming param nuisances

### DIFF
--- a/data/tutorials/shapes/simple-shapes-parametric.txt
+++ b/data/tutorials/shapes/simple-shapes-parametric.txt
@@ -16,4 +16,4 @@ process      0          1
 rate         1          1
 --------------------------------
 lumi    lnN  1.1       1.0
-sigma   param 1.0      0.1
+vogian_sigma   param 1.0      0.1

--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -39,8 +39,11 @@ class Datacard():
         ## dirct of {name of uncert, boolean to indicate whether this nuisance is floating or not}
         self.frozenNuisances = set()
 
-	# Allows for nuisance renaming 
+	# Allows for nuisance renaming of "shape" systematics
 	self.systematicsShapeMap = {}
+	
+	# Allows for nuisance renaming of "param" systematics 
+	self.systematicsParamMap = {}
 
         # Keep edits 
 	self.nuisanceEditLines = []

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -88,6 +88,27 @@ def doDropNuisance(datacard, args):
 
 
 def doRenameNuisance(datacard, args):
+    if len(args) == 2: # newname oldname 
+      nuisanceID = i = -1
+      (oldname, newname) = args[:2]
+      for lsyst,nofloat,pdf0,args0,errline0 in (datacard.systs[:]):
+        i+=1
+        if lsyst == oldname : # found the nuisance
+	  nuisanceID = i
+	  if pdf0 != "param": 
+            raise RuntimeError, "Missing arguments: the syntax is: nuisance edit rename process channel oldname newname"	  
+          for lsyst2,nofloat2,pdf02,args02,errline02 in datacard.systs[:]:
+	    if lsyst2 == newname:
+	     if pdf02 != "param":
+	      if (args0[0]) not in ["0.0","0"] or (args0[1]) not in ["1.0","1"] : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with G(0,1) constraint!" % (lsyst,args0[0],args0[1],lsyst2)
+             else: 
+	      if (args0[0])!=(args02[0])  or float(args0[1])!=float(args02[0]) : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with Gaussian pdf G(%s,%s) constraint!" % (lsyst,args0[0],args0[1],lsyst2,args02[0],args02[1])
+	  break
+      if nuisanceID: 
+      	datacard.systs[nuisanceID][0]=newname 
+	datacard.systematicsParamMap[newname]=oldname
+      return
+
     if len(args) < 4:
         raise RuntimeError, "Missing arguments: the syntax is: nuisance edit rename process channel oldname newname"
     (process, channel, oldname, newname) = args[:4]

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -117,7 +117,7 @@ def doRenameNuisance(datacard, args):
     opts = args[4:]
     foundChann, foundProc = False, False
     for lsyst,nofloat,pdf0,args0,errline0 in datacard.systs[:]:
-
+	if pdf0=="param" : raise RuntimeError, "Incorrect syntax. Cannot specify process and channel for %s with pdf %s. Use 'nuisance edit rename oldname newname'"% (lsyst,pdf0)
         lsystnew = re.sub(oldname,newname,lsyst)
         if lsystnew != lsyst:
             found = False

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -97,16 +97,18 @@ def doRenameNuisance(datacard, args):
 	  nuisanceID = i
 	  if pdf0 != "param": 
             raise RuntimeError, "Missing arguments: the syntax is: nuisance edit rename process channel oldname newname"	  
-          for lsyst2,nofloat2,pdf02,args02,errline02 in datacard.systs[:]:
+          for lsyst2,nofloat2,pdf02,args02,errline02 in (datacard.systs[:]):
+	    print lsyst2,nofloat2,pdf02,args02,errline02
 	    if lsyst2 == newname:
 	     if pdf02 != "param":
-	      if (args0[0]) not in ["0.0","0"] or (args0[1]) not in ["1.0","1"] : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with G(0,1) constraint!" % (lsyst,args0[0],args0[1],lsyst2)
+	      if (args0[0]) not in ["0.0","0.","0"] or (args0[1]) not in ["1.0","1.","1"] : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with G(0,1) constraint!" % (lsyst,args0[0],args0[1],lsyst2)
              else: 
-	      if (args0[0])!=(args02[0])  or float(args0[1])!=float(args02[0]) : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with Gaussian pdf G(%s,%s) constraint!" % (lsyst,args0[0],args0[1],lsyst2,args02[0],args02[1])
+	      if (args0[0])!=(args02[0])  or float(args0[1])!=float(args02[1]) : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with Gaussian pdf G(%s,%s) constraint!" % (lsyst,args0[0],args0[1],lsyst2,args02[0],args02[1])
 	  break
       if nuisanceID: 
       	datacard.systs[nuisanceID][0]=newname 
 	datacard.systematicsParamMap[newname]=oldname
+      else: raise RuntimeError, "No nuisance parameter found with name %s"%oldname 
       return
 
     if len(args) < 4:

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -222,7 +222,18 @@ class ShapeBuilder(ModelBuilder):
                     simPdf.addExtraConstraints(self.out.nuisPdfs)
                 if self.options.verbose:
                     stderr.write("Importing combined pdf %s\n" % simPdf.GetName()); stderr.flush()
-                self.out._import(simPdf, ROOT.RooFit.RecycleConflictNodes())
+
+		# take care of any variables which were renamed (eg for "param")
+		renameParamString = [] 
+		paramString       = []
+      		for n in self.DC.systematicsParamMap.keys():
+		  paramString.append(self.DC.systematicsParamMap[n])
+		  renameParamString.append(n)
+		if len(renameParamString): 
+		  renameParamString=",".join(renameParamString)
+		  paramString=",".join(paramString)
+                  self.out._import(simPdf, ROOT.RooFit.RecycleConflictNodes(),ROOT.RooFit.RenameVariable(paramString,renameParamString))
+                else: self.out._import(simPdf, ROOT.RooFit.RecycleConflictNodes())
                 if self.options.noBOnly: break
         else:
             self.out._import(self.getObj("pdf_bin%s"       % self.DC.bins[0]).clone("model_s"), ROOT.RooFit.Silence())


### PR DESCRIPTION
Can change the name of "param" type nuisances (changes name inside workspace) using 
`nuisance edit rename oldname newname`

Also checks for correct syntax with using new option