### PR TITLE
GoF channel masking

### DIFF
--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -43,6 +43,8 @@ protected:
   static std::vector<std::string>  binNames_;
   static std::vector<float>        qVals_;
 
+  static std::string setParametersForFit_;
+  static std::string setParametersForEval_;
 
   // Return a pdf that matches this data perfectly.
   RooAbsPdf *makeSaturatedPdf(RooAbsData &data);

--- a/src/GoodnessOfFit.cc
+++ b/src/GoodnessOfFit.cc
@@ -43,12 +43,16 @@ bool        GoodnessOfFit::makePlots_ = false;
 TDirectory* GoodnessOfFit::plotDir_ = nullptr;
 std::vector<std::string>  GoodnessOfFit::binNames_;
 std::vector<float>        GoodnessOfFit::qVals_;
+std::string GoodnessOfFit::setParametersForFit_ = "";
+std::string GoodnessOfFit::setParametersForEval_ = "";
 
 GoodnessOfFit::GoodnessOfFit() :
     LimitAlgo("GoodnessOfFit specific options")
 {
     options_.add_options()
         ("algorithm",          boost::program_options::value<std::string>(&algo_), "Goodness of fit algorithm. Supported algorithms are 'saturated', 'KS' and 'AD'.")
+        ("setParametersForFit",   boost::program_options::value<std::string>(&setParametersForFit_)->default_value(""), "Set parameters values for the saturated model fitting step")
+        ("setParametersForEval",   boost::program_options::value<std::string>(&setParametersForEval_)->default_value(""), "Set parameter values for the saturated model NLL eval step")
   //      ("minimizerAlgo",      boost::program_options::value<std::string>(&minimizerAlgo_)->default_value(minimizerAlgo_), "Choice of minimizer (Minuit vs Minuit2)")
   //      ("minimizerTolerance", boost::program_options::value<float>(&minimizerTolerance_)->default_value(minimizerTolerance_),  "Tolerance for minimizer")
   //      ("minimizerStrategy",  boost::program_options::value<int>(&minimizerStrategy_)->default_value(minimizerStrategy_),      "Stragegy for minimizer")
@@ -148,6 +152,12 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
           satsim->addPdf(*saturatedPdfi, cat->getLabel());
           satsim->addOwnedComponents(RooArgSet(*saturatedPdfi));
       }
+      // Transfer the channel masks manually
+      RooSimultaneousOpt* satsimopt = dynamic_cast<RooSimultaneousOpt*>(satsim);
+      RooSimultaneousOpt* simopt = dynamic_cast<RooSimultaneousOpt*>(pdf_nominal);
+      if (satsimopt && simopt) {
+        satsimopt->addChannelMasks(simopt->channelMasks());
+      }
       saturated.reset(satsim);
   } else {
       RooAbsPdf *saturatedPdfi = makeSaturatedPdf(data);
@@ -166,6 +176,9 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
   std::auto_ptr<RooAbsReal> nominal_nll(pdf_nominal->createNLL(data, constrainCmdArg));
   std::auto_ptr<RooAbsReal> saturated_nll(saturated->createNLL(data, constrainCmdArg));
 
+  if (setParametersForFit_ != "") {
+    utils::setModelParameters(setParametersForFit_, w->allVars());
+  }
   CascadeMinimizer minimn(*nominal_nll, CascadeMinimizer::Unconstrained);
  // minimn.setStrategy(minimizerStrategy_);
   minimn.minimize(verbose-2);
@@ -175,8 +188,6 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
   if (dynamic_cast<cacheutils::CachingSimNLL*>(nominal_nll.get())) {
     static_cast<cacheutils::CachingSimNLL*>(nominal_nll.get())->clearConstantZeroPoint();
   }
-  double nll_nominal = nominal_nll->getVal();
-
 
   CascadeMinimizer minims(*saturated_nll, CascadeMinimizer::Unconstrained);
   //minims.setStrategy(minimizerStrategy_);
@@ -184,6 +195,11 @@ bool GoodnessOfFit::runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc
   if (dynamic_cast<cacheutils::CachingSimNLL*>(saturated_nll.get())) {
     static_cast<cacheutils::CachingSimNLL*>(saturated_nll.get())->clearConstantZeroPoint();
   }
+
+  if (setParametersForEval_ != "") {
+    utils::setModelParameters(setParametersForEval_, w->allVars());
+  }
+  double nll_nominal = nominal_nll->getVal();
   double nll_saturated = saturated_nll->getVal();
 
   sentry.clear();


### PR DESCRIPTION
Adding options to GoF that allow channel masking to be set independently for the fit and the saturated test stat evaluation, e.g: `--setParametersForFit mask_SR=1,mask_CR=0 --setParametersForEval mask_SR=0,mask_CR=1`.