### PR TITLE
Piecewise polynomial class

### DIFF
--- a/interface/RooPiecewisePolynomial.h
+++ b/interface/RooPiecewisePolynomial.h
@@ -2,8 +2,9 @@
 #define ROOPIECEWISEPOLYNOMIAL_H
 #include <vector>
 #include "RooAbsReal.h"
-#include "RooRealVar.h"
+#include "RooArgList.h"
 #include "RooRealProxy.h"
+#include "RooListProxy.h"
 
 // Piecewise polynomial that looks like
 // -- . -- ... -- . --
@@ -11,29 +12,28 @@ class RooPiecewisePolynomial : public RooAbsReal{
 protected:
   RooRealProxy xvar;
 
+  // First [0,...,nnodes-1] parameters are nodes
+  // There should be 2*ndof_endfcn+(nfcn-2)*ndof_middlefcn more parameters for the free dofs in the functions
+  // where ndof_endfcn=polyndof-1 and ndof_middlefcn=polyndof-2
+  RooListProxy parList;
+
   const int nfcn; // Number of piecewise functions
   const int polyndof; // Ndof of the polynomial (e.g. 4: cubic)
   const int nnodes; // How many nodes are in between
   const int ndof_endfcn; // Number of degrees of freedom in fcns in the middle of the nodes
   const int ndof_middlefcn; // Number of degrees of freedom in fcns outside the nodes
 
-  // First [0,...,nnodes-1] parameters are nodes
-  // There should be 2*ndof_endfcn+(nfcn-2)*ndof_middlefcn more parameters for the free dofs in the functions
-  // where ndof_endfcn=polyndof-1 and ndof_middlefcn=polyndof-2
-  std::vector<double> par;
-
-  double eval(double x)const;
+  double eval(double x, std::vector<double> const& par)const;
 
 public:
-  RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_);
-  RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_, std::vector<double> pars_);
+  RooPiecewisePolynomial();
+  RooPiecewisePolynomial(const char* name, const char* title);
+  RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, RooArgList const& parList_, const int nfcn_, const int polyndof_);
   RooPiecewisePolynomial(RooPiecewisePolynomial const& other, const char* name=0);
   virtual TObject* clone(const char* newname)const{ return new RooPiecewisePolynomial(*this, newname); }
   inline virtual ~RooPiecewisePolynomial(){}
 
-  void setParameters(std::vector<double> pars_);
-
-  double evaluate()const{ return eval(xvar); }
+  double evaluate()const;
 
   ClassDef(RooPiecewisePolynomial, 1)
 

--- a/interface/RooPiecewisePolynomial.h
+++ b/interface/RooPiecewisePolynomial.h
@@ -1,0 +1,42 @@
+#ifndef ROOPIECEWISEPOLYNOMIAL_H
+#define ROOPIECEWISEPOLYNOMIAL_H
+#include <vector>
+#include "RooAbsReal.h"
+#include "RooRealVar.h"
+#include "RooRealProxy.h"
+
+// Piecewise polynomial that looks like
+// -- . -- ... -- . --
+class RooPiecewisePolynomial : public RooAbsReal{
+protected:
+  RooRealProxy xvar;
+
+  const int nfcn; // Number of piecewise functions
+  const int polyndof; // Ndof of the polynomial (e.g. 4: cubic)
+  const int nnodes; // How many nodes are in between
+  const int ndof_endfcn; // Number of degrees of freedom in fcns in the middle of the nodes
+  const int ndof_middlefcn; // Number of degrees of freedom in fcns outside the nodes
+
+  // First [0,...,nnodes-1] parameters are nodes
+  // There should be 2*ndof_endfcn+(nfcn-2)*ndof_middlefcn more parameters for the free dofs in the functions
+  // where ndof_endfcn=polyndof-1 and ndof_middlefcn=polyndof-2
+  std::vector<double> par;
+
+  double eval(double x)const;
+
+public:
+  RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_);
+  RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_, std::vector<double> pars_);
+  RooPiecewisePolynomial(RooPiecewisePolynomial const& other, const char* name=0);
+  virtual TObject* clone(const char* newname)const{ return new RooPiecewisePolynomial(*this, newname); }
+  inline virtual ~RooPiecewisePolynomial(){}
+
+  void setParameters(std::vector<double> pars_);
+
+  double evaluate()const{ return eval(xvar); }
+
+  ClassDef(RooPiecewisePolynomial, 1)
+
+};
+
+#endif

--- a/interface/RooPiecewisePolynomial.h
+++ b/interface/RooPiecewisePolynomial.h
@@ -15,25 +15,33 @@ protected:
   // First [0,...,nnodes-1] parameters are nodes
   // There should be 2*ndof_endfcn+(nfcn-2)*ndof_middlefcn more parameters for the free dofs in the functions
   // where ndof_endfcn=polyndof-1 and ndof_middlefcn=polyndof-2
+  // For nfcn=4, polyndof=4, the order of parameters is
+  // node 0, node 1, node 2 (nnodes=nfcn-1), and then
+  // a0 + a1*x +        a2*x^2 + not_a_par*x^3 (= fcn 0)
+  // b0 + b1*x + not_a_par*x^2 + not_a_par*x^3 (= fcn 1)
+  // c0 + c1*x + not_a_par*x^2 + not_a_par*x^3 (= fcn 2)
+  // d0 + d1*x + not_a_par*x^2 +        d3*x^3 (= fcn 3)
+  // Continuity between the fcns is guaranteed, but notice that smoothness is not.
   RooListProxy parList;
 
   const int nfcn; // Number of piecewise functions
   const int polyndof; // Ndof of the polynomial (e.g. 4: cubic)
-  const int nnodes; // How many nodes are in between
-  const int ndof_endfcn; // Number of degrees of freedom in fcns in the middle of the nodes
-  const int ndof_middlefcn; // Number of degrees of freedom in fcns outside the nodes
+  const int nnodes; // How many nodes are in between (= nfcn-1)
+  const int ndof_endfcn; // Number of degrees of freedom in fcns in the middle of the nodes (= polyndof-1)
+  const int ndof_middlefcn; // Number of degrees of freedom in fcns outside the nodes (= polyndof-2)
 
   double eval(double x, std::vector<double> const& par)const;
 
 public:
-  RooPiecewisePolynomial();
-  RooPiecewisePolynomial(const char* name, const char* title);
+  RooPiecewisePolynomial(const int nfcn_=1, const int polyndof_=1);
+  RooPiecewisePolynomial(const char* name, const char* title, const int nfcn_=1, const int polyndof_=1);
   RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, RooArgList const& parList_, const int nfcn_, const int polyndof_);
   RooPiecewisePolynomial(RooPiecewisePolynomial const& other, const char* name=0);
   virtual TObject* clone(const char* newname)const{ return new RooPiecewisePolynomial(*this, newname); }
   inline virtual ~RooPiecewisePolynomial(){}
 
   double evaluate()const;
+  double evaluate(double* x, double* p)const; // For calling in a TF1 object
 
   ClassDef(RooPiecewisePolynomial, 1)
 

--- a/src/RooPiecewisePolynomial.cc
+++ b/src/RooPiecewisePolynomial.cc
@@ -63,7 +63,7 @@ RooPiecewisePolynomial::RooPiecewisePolynomial(RooPiecewisePolynomial const& oth
 double RooPiecewisePolynomial::eval(double x, std::vector<double> const& par)const{
   // If we say the form of the polynomial is [0] + [1]*x + [2]*x2 + [3]*x3 + [4]*x4...,
   // use the highest two orders for matching at the nodes and free the rest.
-  const double d_epsilon = 1e-14;
+  const double d_epsilon = 0;
   if ((int) par.size()!=2*ndof_endfcn+(nfcn-2)*ndof_middlefcn+nnodes) assert(0);
 
   int npars_reduced[nfcn];
@@ -180,6 +180,7 @@ double RooPiecewisePolynomial::eval(double x, std::vector<double> const& par)con
 }
 
 double RooPiecewisePolynomial::evaluate()const{
+  if (parList.getSize()==0) return 0;
   std::vector<double> par; par.reserve(parList.getSize());
   for (int ip=0; ip<parList.getSize(); ip++) par.push_back((dynamic_cast<RooAbsReal*>(parList.at(ip)))->getVal());
   return eval(xvar, par);

--- a/src/RooPiecewisePolynomial.cc
+++ b/src/RooPiecewisePolynomial.cc
@@ -1,0 +1,164 @@
+#include "HiggsAnalysis/CombinedLimit/interface/RooPiecewisePolynomial.h"
+#include <iostream>
+#include <cassert>
+#include <cmath>
+#include "TVectorD.h"
+#include "TMatrixD.h"
+
+
+using namespace std;
+
+
+RooPiecewisePolynomial::RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_) :
+  RooAbsReal(name, title),
+  xvar("xvar", "xvar", this, xvar_),
+  nfcn(nfcn_), polyndof(polyndof_),
+  nnodes(nfcn-1), // How many nodes are in between
+  ndof_endfcn(polyndof-1), // 1 degree for the function value
+  ndof_middlefcn(polyndof-2) // +1 for slope of the other node
+{
+  assert((nfcn>2 && polyndof>=2) || (nfcn==2 && polyndof>=1));
+}
+RooPiecewisePolynomial::RooPiecewisePolynomial(const char* name, const char* title, RooAbsReal& xvar_, const int nfcn_, const int polyndof_, std::vector<double> par_) :
+  RooAbsReal(name, title),
+  xvar("xvar", "xvar", this, xvar_),
+  nfcn(nfcn_), polyndof(polyndof_),
+  nnodes(nfcn-1), // How many nodes are in between
+  ndof_endfcn(polyndof-1), // 1 degree for the function value
+  ndof_middlefcn(polyndof-2), // +1 for slope of the other node
+  par(par_)
+{
+  assert((nfcn>2 && polyndof>=2) || (nfcn==2 && polyndof>=1));
+}
+RooPiecewisePolynomial::RooPiecewisePolynomial(RooPiecewisePolynomial const& other, const char* name) :
+  RooAbsReal(other, name),
+  xvar("xvar", this, other.xvar),
+  nfcn(other.nfcn), polyndof(other.polyndof),
+  nnodes(other.nnodes),
+  ndof_endfcn(other.ndof_endfcn),
+  ndof_middlefcn(other.ndof_middlefcn),
+  par(other.par)
+{}
+
+void RooPiecewisePolynomial::setParameters(std::vector<double> par_){ par=par_; }
+
+double RooPiecewisePolynomial::eval(double x)const{
+  // If we say the form of the polynomial is [0] + [1]*x + [2]*x2 + [3]*x3 + [4]*x4...,
+  // use the highest two orders for matching at the nodes and free the rest.
+  const double d_epsilon = 1e-14;
+  if ((int) par.size()!=2*ndof_endfcn+(nfcn-2)*ndof_middlefcn+nnodes) assert(0);
+
+  int npars_reduced[nfcn];
+  for (int index=0; index<nfcn; index++){
+    if (index==0 || index==nfcn-1) npars_reduced[index] = ndof_endfcn;
+    else npars_reduced[index] = ndof_middlefcn;
+  }
+
+  vector<double> node(nnodes, 0); // First [0,...,nnodes-1] parameters are nodes
+  vector<vector<double>> pars_full(nfcn, vector<double>(polyndof, 0)); // The full coefficients array
+
+  for (int ip=0; ip<nnodes; ip++) node[ip] = par[ip];
+  // Check for the nodes to be consecutive
+  for (int ip=0; ip<nnodes; ip++){
+    for (int ip2=ip+1; ip2<nnodes; ip2++){
+      if (node[ip]>node[ip2]) return d_epsilon;
+    }
+  }
+  int pos_ctr = nnodes;
+  for (int index=0; index<nfcn; index++){
+    for (int ipar=0; ipar<npars_reduced[index]; ipar++){
+      if (!(index==(nfcn-1) && ipar==(npars_reduced[index]-1))) pars_full[index][ipar] = par[pos_ctr];
+      else pars_full[index][ipar+1] = par[pos_ctr]; // Special case to avoid singular matrix. This corresponds to having the x^n contribution free instead of x^(n-1)
+      pos_ctr++;
+    }
+  }
+
+  vector<vector<double>> xton(nnodes, vector<double>(polyndof, 0)); // Array of node^power
+  vector<vector<double>> nxtom(nnodes, vector<double>(polyndof, 0)); // Array of power*node^(power-1)
+  for (int inode=0; inode<nnodes; inode++){
+    for (int ipow=0; ipow<polyndof; ipow++){
+      if (ipow==0) xton[inode][ipow]=1; // nxtom==0
+      else if (ipow==1){
+        xton[inode][ipow]=node[inode];
+        nxtom[inode][ipow]=1;
+      }
+      else{
+        xton[inode][ipow]=pow(node[inode], ipow);
+        nxtom[inode][ipow]=((double) ipow)*pow(node[inode], ipow-1);
+      }
+    }
+  }
+
+  vector<double> ysbar_nodes(2*nnodes, 0);
+  vector<vector<double>> coeff_ysbar(2*nnodes, vector<double>(2*nnodes, 0));
+  int cstart=-1;
+  for (int inode=0; inode<nnodes; inode++){
+    int i=inode;
+    int j=i+1;
+    double sign_i = 1, sign_j=-1;
+    for (int ip=0; ip<npars_reduced[i]; ip++){
+      ysbar_nodes[inode] += sign_i*pars_full[i][ip]*xton[inode][ip];
+      ysbar_nodes[nnodes+inode] += sign_i*pars_full[i][ip]*nxtom[inode][ip];
+    }
+    for (int ip=0; ip<npars_reduced[j]; ip++){
+      if (!(j==(nfcn-1) && ip==(npars_reduced[j]-1))){
+        ysbar_nodes[inode] += sign_j*pars_full[j][ip]*xton[inode][ip];
+        ysbar_nodes[nnodes+inode] += sign_j*pars_full[j][ip]*nxtom[inode][ip];
+      }
+      else{
+        ysbar_nodes[inode] += sign_j*pars_full[j][ip+1]*xton[inode][ip+1];
+        ysbar_nodes[nnodes+inode] += sign_j*pars_full[j][ip+1]*nxtom[inode][ip+1];
+      }
+    }
+
+    if (cstart>=0){
+      coeff_ysbar[inode][cstart] = -sign_i*xton[inode][polyndof-2];
+      coeff_ysbar[nnodes + inode][cstart] = -sign_i*nxtom[inode][polyndof-2];
+    }
+    coeff_ysbar[inode][cstart+1] = -sign_i*xton[inode][polyndof-1];
+    coeff_ysbar[nnodes + inode][cstart+1] = -sign_i*nxtom[inode][polyndof-1];
+    coeff_ysbar[inode][cstart+2] = -sign_j*xton[inode][polyndof-2];
+    coeff_ysbar[nnodes + inode][cstart+2] = -sign_j*nxtom[inode][polyndof-2];
+    if ((cstart+3)<2*nnodes){
+      coeff_ysbar[inode][cstart+3] = -sign_j*xton[inode][polyndof-1];
+      coeff_ysbar[nnodes + inode][cstart+3] = -sign_j*nxtom[inode][polyndof-1];
+    }
+    cstart+=2;
+  }
+
+  TVectorD polyvec(2*nnodes, ysbar_nodes.data());
+  TMatrixD polycoeff(2*nnodes, 2*nnodes);
+  for (int i=0; i<2*nnodes; i++){ for (int j=0; j<2*nnodes; j++) polycoeff(i, j)=coeff_ysbar[i][j]; }
+  double testdet=0;
+  TMatrixD polycoeff_inv = polycoeff.Invert(&testdet);
+  if (testdet!=0){
+    TVectorD unknowncoeffs = polycoeff_inv*polyvec;
+    pos_ctr=0;
+    for (int index=0; index<nfcn; index++){
+      for (int ip=npars_reduced[index]; ip<polyndof; ip++){
+        if (!(index==(nfcn-1) && ip==npars_reduced[index])) pars_full[index][ip] = unknowncoeffs[pos_ctr];
+        else pars_full[index][ip-1] = unknowncoeffs[pos_ctr];
+        pos_ctr++;
+      }
+    }
+
+    int index_chosen=0;
+    for (int index=0; index<nnodes-1; index++){
+      if (x>=node[index] && x<node[index+1]){
+        index_chosen = index+1;
+        break;
+      }
+    }
+    if (x>=node[nnodes-1]) index_chosen = nfcn-1;
+
+    double res = 0;
+    for (int ip=0; ip<polyndof; ip++) res += pars_full[index_chosen][ip]*pow(x, ip);
+    return res;
+  }
+  else{
+    cerr << "Something went wrong, and the determinant is 0!" << endl;
+    return d_epsilon;
+  }
+}
+
+ClassImp(RooPiecewisePolynomial)

--- a/src/classes.h
+++ b/src/classes.h
@@ -53,6 +53,8 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
 
+#include "HiggsAnalysis/CombinedLimit/interface/RooPiecewisePolynomial.h"
+
 #include "HiggsAnalysis/CombinedLimit/interface/RooNCSplineCore.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooNCSpline_1D_fast.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooNCSpline_2D_fast.h"

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -84,6 +84,8 @@
 	<class name="HZZ4L_RooSpinZeroPdf_phase_fast" />
 	<class name="VVHZZ4L_RooSpinZeroPdf_1D_fast" />
 
+	<class name="RooPiecewisePolynomial" />
+
 	<class name="RooNCSplineCore" />
 	<class name="RooNCSpline_1D_fast" />
 	<class name="RooNCSpline_2D_fast" />


### PR DESCRIPTION
A RooAbsReal for piecewise polynomial implementation.
- Developed for the MINERvA Experiment, migrated now to CMS for use in mass-dependent resolution parameterizations, or in any other parameterization that involves a piecewise polynomial approximation
- The class allows floating a set of parameters of N+1 polynomials, separated by N>=0 nodes (see description for the ordering and meaning of the parameters).
- The piecewise polynomial is continuous, but its derivative for the general set of coefficients given is not.
- Checked extensively in different ways - and experiments, so it is ready for a merge without affecting any analysis.
- Can be used as a RooFit object, or on its own within a TF1 (see evaluate function overload)
- An example set of different TGraphAsymmErrors fitted via TF1 with this function can be viewed from here: https://usarica.web.cern.ch/usarica/HCombPR474/