### PR TITLE
Merge nuisances

### DIFF
--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -36,7 +36,9 @@ def doAddNuisance(datacard, args):
             errline = errline0
     if not found:
         datacard.systs.append([name,False,pdf,[],errline])
-    if "/" in value:
+    if isinstance(value, (int, float, list)):
+        pass
+    elif "/" in value:
         value = [ float(x) for x in value.split("/") ]
     else:
         value = float(value)
@@ -197,7 +199,7 @@ def doMergeNuisance(datacard, args):
                     for p in datacard.exp[b]:
                         if process == "*" or cprocess.search(p):
                             foundProc = True
-                            doAddNuisance(datacard, [p+"$", b+"$", name1, pdf2, str(errline2[b][p]), "addq"])
+                            doAddNuisance(datacard, [p+"$", b+"$", name1, pdf2, errline2[b][p], "addq"])
                             errline2[b][p] = 0
 
     if not foundProc and channel != "*":

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -44,7 +44,9 @@ def doAddNuisance(datacard, args):
             for p in datacard.exp[b]:
                 if process == "*" or cprocess.search(p):
                     foundProc = True
-                    if p in errline[b] and errline[b][p] not in [ 0.0, 1.0 ]:
+                    if value in [ 0.0, 1.0 ]:
+                        pass   #do nothing, there's nothing to add
+                    elif p in errline[b] and errline[b][p] not in [ 0.0, 1.0 ]:
                         if "addq" in opts:
                             errline[b][p] = quadratureAdd(pdf, errline[b][p], value, context="nuisance edit add, args = %s" % args)
                         elif "overwrite" in opts:
@@ -192,7 +194,7 @@ def doMergeNuisance(datacard, args):
                     for p in datacard.exp[b]:
                         if process == "*" or cprocess.search(p):
                             foundProc = True
-                            doAddNuisance(datacard, [p, b, name1, pdf2, str(errline2[b][p]), "addq"])
+                            doAddNuisance(datacard, [p+"$", b+"$", name1, pdf2, str(errline2[b][p]), "addq"])
                             errline2[b][p] = 0
 
     if not foundProc and channel != "*":

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -3,12 +3,15 @@ import sys
 from math import log,exp,hypot
 
 def quadratureAdd(pdf, val1, val2, context=None):
+    if type(val1) == list and len(val1) != 2: raise RuntimeError("{} is a list of length != 2".format(val1))
+    if type(val2) == list and len(val2) != 2: raise RuntimeError("{} is a list of length != 2".format(val2))
+
     if type(val1) == list and type(val2) == list:
-        return [ quadratureAdd(pdf, val1[0], val2[0], context), quadratureAdd(pdf, val1[0], val2[0], context) ]
+        return [ quadratureAdd(pdf, val1[0], val2[0], context), quadratureAdd(pdf, val1[1], val2[1], context) ]
     elif type(val1) == list and type(val2) == float:
-        return [ quadratureAdd(pdf, val1[0], 1.0/val2, context), quadratureAdd(pdf, val1[0], val2, context) ]
+        return [ quadratureAdd(pdf, val1[0], 1.0/val2, context), quadratureAdd(pdf, val1[1], val2, context) ]
     elif type(val2) == list and type(val1) == float:
-        return [ quadratureAdd(pdf, 1.0/val1, val2[0], context), quadratureAdd(pdf, val1, val2[0], context) ]
+        return [ quadratureAdd(pdf, 1.0/val1, val2[0], context), quadratureAdd(pdf, val1, val2[1], context) ]
     if pdf in [ "lnN", "lnU" ]:
         if log(val1) * log(val2) < 0:
             raise RuntimeError, "Can't add in quadrature nuisances of pdf %s with values %s, %s that go in different directions (at %s)" % (pdf, val1, val2, context)


### PR DESCRIPTION
- fix when adding asymmetric nuisances
- Add a function to merge two nuisances by adding them process by process.  It won't work if they go in opposite directions for some processes.

Example test: these two inputs give the same results
- [premerged.txt](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/files/1984392/premerged.txt)
- [merge.txt](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/files/1984393/merge.txt)

```combine -n premerged premerged.txt```
```combine -n merge merge.txt```