### PR TITLE
Enable exclusion of a single process from the BB procedure

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -259,11 +259,12 @@ def parseCard(file, options):
 
                 continue
 	    elif pdf=="autoMCStats":
-	        if len(f)>5: raise RuntimeError, "Syntax for autoMCStats should be 'channel autoMCStats threshold [include-signal = 0] [hist-mode = 0]"
+	        if len(f)>6: raise RuntimeError, "Syntax for autoMCStats should be 'channel autoMCStats threshold [include-signal = 0] [hist-mode = 0] [exclude-process = '']"
 	        statThreshold = float(f[2])
 	        statIncludeSig = bool(int(f[3])) if len(f) >= 4 else False
 	        statHistMode = int(f[4]) if len(f) >= 5 else 1
-	        statFlags = (statThreshold, statIncludeSig, statHistMode)
+                statExcludeProcess = f[5] if len(f) >=6 else None
+	        statFlags = (statThreshold, statIncludeSig, statHistMode, statExcludeProcess)
 		if "*" in lsyst: 
 		  for b in ret.bins: 
 		    	if (not fnmatch.fnmatch(b, lsyst)): continue

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -60,7 +60,7 @@ class ShapeBuilder(ModelBuilder):
             bbb_args = None
             channelBinParFlag = b in self.DC.binParFlags.keys()
             if channelBinParFlag:
-                print 'Channel %s will use autoMCStats with settings: event-threshold=%g, include-signal=%i, hist-mode=%i' % ((b,)+self.DC.binParFlags[b])
+                print 'Channel %s will use autoMCStats with settings: event-threshold=%g, include-signal=%i, hist-mode=%i, exclude-process=%s' % ((b,)+self.DC.binParFlags[b])
             for p in self.DC.exp[b].keys(): # so that we get only self.DC.processes contributing to this bin
                 if self.DC.exp[b][p] == 0: continue
                 if self.physics.getYieldScale(b,p) == 0: continue # exclude really the pdf
@@ -85,7 +85,7 @@ class ShapeBuilder(ModelBuilder):
                 pdf.setStringAttribute("combine.process", p)
                 pdf.setStringAttribute("combine.channel", b)
                 pdf.setAttribute("combine.signal", self.DC.isSignal[p])
-                if channelBinParFlag and self.DC.isSignal[p] and not self.DC.binParFlags[b][1]:
+                if channelBinParFlag and (self.DC.isSignal[p] or p==self.DC.binParFlags[b][3]) and not self.DC.binParFlags[b][1]:
                     pdf.setAttribute('skipForErrorSum')
                 coeff.setStringAttribute("combine.process", p)
                 coeff.setStringAttribute("combine.channel", b)


### PR DESCRIPTION
Hi,

I needed this feature because of helping an analysis that is facing issues with individual statistical uncertainties.

The new syntax for autoMCStats would be:

channel autoMCStats threshold [include-signal = 0] [hist-mode = 0] [exclude-process = '']

I purposefully refrained from allowing an arbitrarily long list of processes, but I can implement it if you think it is useful instead of allowing the exclusion of a single process at a time.

Please let me know if I need to fix anything :sweat_smile:
I tested it by adding [1] to [2], and it looks OK to me

Cheers,
Pietro

[1] * autoMCStats 0 0 0 background
[2] data/tutorials/shapes/simple-shapes-TH1.txt
