### PR TITLE
fix digits to be no less precise than the previous behavior

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -340,10 +340,9 @@ def parseCard(file, options):
 
 def FloatToString(inputValue):
     return ('%.10f' % inputValue).rstrip('0').rstrip('.')
-def FloatToStringScientific(inputValue,etype='e'):
+def FloatToStringScientific(inputValue,etype='g'):
     s = FloatToString(inputValue)
     q = s.replace(".","").lstrip('0')
-    f = float(s)
-    nq = len(q)-1
+    nq = max(len(q)-1, 4)
     strcmd = ("%%%c%i%c" % ('.',nq,etype))
-    return (strcmd % f)
+    return (strcmd % inputValue)

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -63,12 +63,12 @@ for ich,fname in enumerate(args):
         for (p,e) in DC.exp[b].items(): # so that we get only self.DC.processes contributing to this bin
             if DC.isSignal[p] == False: continue
             #print "in DC.exp.items:b,p", b,p
-            expline.append("%s" % FloatToString(e)) if (e == 0 or e > 1e-3) else expline.append("%s" % FloatToStringScientific(e,'e'))
+            expline.append("%s" % FloatToString(e)) if (e == 0 or e > 1e-3) else expline.append("%s" % FloatToStringScientific(e))
             keyline.append((bout, p, DC.isSignal[p]))
         for (p,e) in DC.exp[b].items(): # so that we get only self.DC.processes contributing to this bin
             if DC.isSignal[p]: continue
             #print "in DC.exp.items:b,p", b,p
-            expline.append("%s" % FloatToString(e)) if (e == 0 or e > 1e-3) else expline.append("%s" % FloatToStringScientific(e,'e'))
+            expline.append("%s" % FloatToString(e)) if (e == 0 or e > 1e-3) else expline.append("%s" % FloatToStringScientific(e))
             keyline.append((bout, p, DC.isSignal[p]))
     # systematics
     for (lsyst,nofloat,pdf,pdfargs,errline) in DC.systs:


### PR DESCRIPTION
In d15136922b9e07d9b31dad12b241c67ccb55a181 we* added more precision to the output of combineCards.py.  In some cases (really small numbers), the precision is actually 1 digit, and for even smaller numbers it tries to give a precision of 0 digits, which resulted in a bug.

This fixes it so that the precision is no less than 4 digits, as before.

\* (that was actually @usarica's code, I think I cherry picked and messed up somehow so my name is attached to it)