### PR TITLE
More robust hessian/covariance matrix calculator

### DIFF
--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -50,6 +50,7 @@ protected:
   static bool	     saveWorkspace_;
   static bool        reuseParams_;
   static bool        customStartingPoint_;
+  static bool       robustHesse_;
   int currentToy_, nToys;
   int overallBins_,overallNorms_,overallNuis_,overallCons_;
   int fitStatus_, numbadnll_;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -39,6 +39,10 @@ protected:
   static float preFitValue_;
 
   static bool robustFit_, do95_, forceRecreateNLL_;
+  static bool robustHesse_;
+  static std::string robustHesseLoad_;
+  static std::string robustHesseSave_;
+
   static float stepSize_;
   static int   maxFailedSteps_;
 

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -39,9 +39,6 @@ protected:
   static float preFitValue_;
 
   static bool robustFit_, do95_, forceRecreateNLL_;
-  static bool robustHesse_;
-  static std::string robustHesseLoad_;
-  static std::string robustHesseSave_;
 
   static float stepSize_;
   static int   maxFailedSteps_;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -39,7 +39,6 @@ protected:
   static float preFitValue_;
 
   static bool robustFit_, do95_, forceRecreateNLL_;
-
   static float stepSize_;
   static int   maxFailedSteps_;
 

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -56,6 +56,10 @@ protected:
   static std::string fixedPointPOIs_;
   static float centeredRange_;
 
+  static bool robustHesse_;
+  static std::string robustHesseLoad_;
+  static std::string robustHesseSave_;
+
   static std::string saveSpecifiedFuncs_;
   static std::string saveSpecifiedNuis_;
   static std::string saveSpecifiedIndex_;

--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -15,7 +15,10 @@
 
 class RooFitResultBuilder : public RooFitResult {
  public:
-  RooFitResultBuilder() : RooFitResult(){};
+  RooFitResultBuilder() : RooFitResult(){
+    this->RooFitResult::setInitParList(RooArgList());
+    this->RooFitResult::setConstParList(RooArgList());
+  };
 
   RooFitResultBuilder(RooFitResult const& other) : RooFitResult(other) {}
 

--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -1,0 +1,69 @@
+#ifndef HiggsAnalysis_CombinedLimit_RobustHesse_h
+#define HiggsAnalysis_CombinedLimit_RobustHesse_h
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+// #include <TGraphAsymmErrors.h>
+// #include <TString.h>
+// #include <RooHistError.h>
+// #include <RooFitResult.h>
+// #include <TH1.h>
+#include "RooAbsReal.h"
+#include "RooRealVar.h"
+
+class RobustHesse {
+ public:
+  RobustHesse(RooAbsReal &nll);
+
+  void SaveHessianToFile(std::string const& filename);
+  void LoadHessianFromFile(std::string const& filename);
+
+  int hesse();
+
+ private:
+  int factorial(int n) {
+    if (n > 1)
+      return n * factorial(n - 1);
+    else
+      return 1;
+  }
+
+  void initialize();
+
+  double deltaNLL();
+  double deltaNLL(std::vector<unsigned> const& indices, std::vector<double> const& vals);
+
+  int setParameterStencil(unsigned i);
+
+
+  std::pair<int, double> findBound(unsigned i, double x, double initialDelta, double initialMult, double scaleMult, double threshold, double hardBound, unsigned maxIters);
+
+  double improveWithBisect(unsigned i, double x, double max, double target, double targetLo, double targetHi, unsigned maxIters);
+
+  std::vector<double> getFdCoeffs(unsigned n, std::vector<double> const& stencil);
+  RooAbsReal * nll_;
+  double nll0_;
+  std::vector<RooRealVar *> v_;
+  std::vector<double> nominal_;
+  std::vector<std::vector<double>> stencils_;
+  std::vector<std::vector<double>> d1coeffs_;
+  std::vector<std::vector<double>> d2coeffs_;
+  std::vector<double> rescales_;
+  std::vector<std::vector<double>> sampled_;
+
+
+  // Parameters that control the behaviour
+  double targetNllForStencils_;
+  double minNllForStencils_;
+  double maxNllForStencils_;
+
+  bool doRescale_;
+
+  std::string saveFile_;
+  std::string loadFile_;
+
+  std::map<std::pair<unsigned, double>, double> nllcache_;
+};
+
+#endif

--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -7,11 +7,24 @@
 // #include <TGraphAsymmErrors.h>
 // #include <TString.h>
 // #include <RooHistError.h>
-// #include <RooFitResult.h>
+#include "RooFitResult.h"
 // #include <TH1.h>
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 #include "TMatrixDSymEigen.h"
+
+class RooFitResultBuilder : public RooFitResult {
+ public:
+  RooFitResultBuilder() : RooFitResult(){};
+
+  RooFitResultBuilder(RooFitResult const& other) : RooFitResult(other) {}
+
+  void setFinalParList(RooArgList const& pars) { this->RooFitResult::setFinalParList(pars); }
+
+  void setCovarianceMatrix(TMatrixDSym & matrix) { this->RooFitResult::setCovarianceMatrix(matrix); }
+
+  RooFitResult Get() { return *this; }
+};
 
 class RobustHesse {
  public:
@@ -23,6 +36,7 @@ class RobustHesse {
   int hesse();
 
   void WriteOutputFile(std::string const& outputFileName) const;
+  RooFitResult * GetRooFitResult(RooFitResult const* current) const;
 
  private:
   int factorial(int n) {

--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -21,7 +21,7 @@ class RooFitResultBuilder : public RooFitResult {
 
   void setFinalParList(RooArgList const& pars) { this->RooFitResult::setFinalParList(pars); }
 
-  void setCovarianceMatrix(TMatrixDSym & matrix) { this->RooFitResult::setCovarianceMatrix(matrix); }
+  void setCovarianceMatrix(TMatrixDSym & matrix) { this->RooFitResult::setCovarianceMatrix(matrix);}
 
   RooFitResult Get() { return *this; }
 };
@@ -32,6 +32,9 @@ class RobustHesse {
 
   void SaveHessianToFile(std::string const& filename);
   void LoadHessianFromFile(std::string const& filename);
+
+  void ProtectArgSet(RooArgSet const& set);
+  void ProtectVars(std::vector<std::string> const& names);
 
   int hesse();
 
@@ -104,6 +107,8 @@ class RobustHesse {
   std::map<std::pair<unsigned, double>, double> nllcache_;
   unsigned nllEvals_;
   unsigned nllEvalsCached_;
+
+  std::set<std::string> proctected_;
 
   int verbosity_;
 };

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -264,6 +264,7 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
 
   if (res_b && robustHesse_) {
     RobustHesse robustHesse(*nll, verbose - 1);
+    robustHesse.ProtectArgSet(*mc_s->GetParametersOfInterest());
     robustHesse.hesse();
     auto res_b_new = robustHesse.GetRooFitResult(res_b);
     delete res_b;
@@ -355,6 +356,7 @@ bool FitDiagnostics::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
 
   if (res_s && robustHesse_) {
     RobustHesse robustHesse(*nll, verbose - 1);
+    robustHesse.ProtectArgSet(*mc_s->GetParametersOfInterest());
     robustHesse.hesse();
     auto res_s_new = robustHesse.GetRooFitResult(res_s);
     delete res_s;

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -236,7 +236,6 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     nllValue_ =  nll->getVal() - nll0;
     if (!ok && !keepFailures_) { std::cout << "Initial minimization failed. Aborting." << std::endl; return 0; }
     if (doHesse) minim.hesse();
-
     sentry.clear();
     ret = (saveFitResult || rs.getSize() ? minim.save() : new RooFitResult("dummy","success"));
     if (verbose > 1 && ret != 0 && (saveFitResult || rs.getSize())) { ret->Print("V");  }

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -49,10 +49,6 @@ int         FitterAlgoBase::minimizerStrategyForMinos_ = 0;  // also default fro
 float       FitterAlgoBase::preFitValue_ = 1.0;
 float       FitterAlgoBase::stepSize_ = 0.1;
 bool        FitterAlgoBase::robustFit_ = false;
-bool        FitterAlgoBase::robustHesse_ = false;
-std::string FitterAlgoBase::robustHesseLoad_ = "";
-std::string FitterAlgoBase::robustHesseSave_ = "";
-
 int         FitterAlgoBase::maxFailedSteps_ = 5;
 bool        FitterAlgoBase::do95_ = false;
 bool        FitterAlgoBase::forceRecreateNLL_ = false;
@@ -75,9 +71,6 @@ FitterAlgoBase::FitterAlgoBase(const char *title) :
         ("preFitValue",        boost::program_options::value<float>(&preFitValue_)->default_value(preFitValue_),  "Value of signal strength pre-fit, also used for pre-fit plots, normalisations and uncertainty calculations (note this overrides --expectSignal for these features)")
         ("do95",       boost::program_options::value<bool>(&do95_)->default_value(do95_),  "Compute also 2-sigma interval from delta(nll) = 1.92 instead of 0.5")
         ("robustFit",  boost::program_options::value<bool>(&robustFit_)->default_value(robustFit_),  "Search manually for 1 and 2 sigma bands instead of using Minos")
-        ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
-        ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
-        ("robustHesseSave",  boost::program_options::value<std::string>(&robustHesseSave_)->default_value(robustHesseSave_),  "Save the calculated Hessian")
         ("maxFailedSteps",  boost::program_options::value<int>(&maxFailedSteps_)->default_value(maxFailedSteps_),  "How many failed steps to retry before giving up")
         ("stepSize",        boost::program_options::value<float>(&stepSize_)->default_value(stepSize_),  "Step size for robust fits (multiplier of the range)")
         ("setRobustFitAlgo",      boost::program_options::value<std::string>(&minimizerAlgoForMinos_)->default_value(minimizerAlgoForMinos_), "Choice of minimizer (Minuit vs Minuit2) for profiling in robust fits")
@@ -242,8 +235,7 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     nll0Value_ =  nll0;
     nllValue_ =  nll->getVal() - nll0;
     if (!ok && !keepFailures_) { std::cout << "Initial minimization failed. Aborting." << std::endl; return 0; }
-    // if (doHesse) minim.hesse();
-    if (doHesse && !robustHesse_) minim.hesse();
+    if (doHesse) minim.hesse();
 
     sentry.clear();
     ret = (saveFitResult || rs.getSize() ? minim.save() : new RooFitResult("dummy","success"));

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -26,6 +26,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CloseCoutSentry.h"
 #include "HiggsAnalysis/CombinedLimit/interface/utils.h"
 #include "HiggsAnalysis/CombinedLimit/interface/ToyMCSamplerOpt.h"
+#include "HiggsAnalysis/CombinedLimit/interface/RobustHesse.h"
 
 #include "HiggsAnalysis/CombinedLimit/interface/ProfilingTools.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CachingNLL.h"
@@ -48,6 +49,10 @@ int         FitterAlgoBase::minimizerStrategyForMinos_ = 0;  // also default fro
 float       FitterAlgoBase::preFitValue_ = 1.0;
 float       FitterAlgoBase::stepSize_ = 0.1;
 bool        FitterAlgoBase::robustFit_ = false;
+bool        FitterAlgoBase::robustHesse_ = false;
+std::string FitterAlgoBase::robustHesseLoad_ = "";
+std::string FitterAlgoBase::robustHesseSave_ = "";
+
 int         FitterAlgoBase::maxFailedSteps_ = 5;
 bool        FitterAlgoBase::do95_ = false;
 bool        FitterAlgoBase::forceRecreateNLL_ = false;
@@ -70,6 +75,9 @@ FitterAlgoBase::FitterAlgoBase(const char *title) :
         ("preFitValue",        boost::program_options::value<float>(&preFitValue_)->default_value(preFitValue_),  "Value of signal strength pre-fit, also used for pre-fit plots, normalisations and uncertainty calculations (note this overrides --expectSignal for these features)")
         ("do95",       boost::program_options::value<bool>(&do95_)->default_value(do95_),  "Compute also 2-sigma interval from delta(nll) = 1.92 instead of 0.5")
         ("robustFit",  boost::program_options::value<bool>(&robustFit_)->default_value(robustFit_),  "Search manually for 1 and 2 sigma bands instead of using Minos")
+        ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
+        ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
+        ("robustHesseSave",  boost::program_options::value<std::string>(&robustHesseSave_)->default_value(robustHesseSave_),  "Save the calculated Hessian")
         ("maxFailedSteps",  boost::program_options::value<int>(&maxFailedSteps_)->default_value(maxFailedSteps_),  "How many failed steps to retry before giving up")
         ("stepSize",        boost::program_options::value<float>(&stepSize_)->default_value(stepSize_),  "Step size for robust fits (multiplier of the range)")
         ("setRobustFitAlgo",      boost::program_options::value<std::string>(&minimizerAlgoForMinos_)->default_value(minimizerAlgoForMinos_), "Choice of minimizer (Minuit vs Minuit2) for profiling in robust fits")
@@ -234,7 +242,9 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     nll0Value_ =  nll0;
     nllValue_ =  nll->getVal() - nll0;
     if (!ok && !keepFailures_) { std::cout << "Initial minimization failed. Aborting." << std::endl; return 0; }
-    if (doHesse) minim.hesse();
+    // if (doHesse) minim.hesse();
+    if (doHesse && !robustHesse_) minim.hesse();
+
     sentry.clear();
     ret = (saveFitResult || rs.getSize() ? minim.save() : new RooFitResult("dummy","success"));
     if (verbose > 1 && ret != 0 && (saveFitResult || rs.getSize())) { ret->Print("V");  }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -17,6 +17,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CascadeMinimizer.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CloseCoutSentry.h"
 #include "HiggsAnalysis/CombinedLimit/interface/utils.h"
+#include "HiggsAnalysis/CombinedLimit/interface/RobustHesse.h"
 
 #include <Math/Minimizer.h>
 #include <Math/MinimizerOptions.h>
@@ -213,6 +214,13 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	Combine::commitPoint(/*expected=*/false, /*quantile=*/-1.); // Combine will not commit a point anymore at -1 so can do it here 
 	//}
     }
+
+    RobustHesse robustHesse(*nll);
+    robustHesse.SaveHessianToFile("hessian_full2.root");
+    robustHesse.LoadHessianFromFile("hessian_full.root");
+    // might do some configuration here...
+    robustHesse.hesse();
+
    
     //set snapshot for best fit
     if (savingSnapshot_) w->saveSnapshot("MultiDimFit",utils::returnAllVars(w));

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -225,6 +225,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 
     if (robustHesse_) {
         RobustHesse robustHesse(*nll, verbose - 1);
+        robustHesse.ProtectArgSet(*mc_s->GetParametersOfInterest());
         if (robustHesseSave_ != "") {
           robustHesse.SaveHessianToFile(robustHesseSave_);
         }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -52,6 +52,10 @@ float MultiDimFit::maxDeltaNLLForProf_ = 200;
 float MultiDimFit::autoRange_ = -1.0;
 std::string MultiDimFit::fixedPointPOIs_ = "";
 float MultiDimFit::centeredRange_ = -1.0;
+bool        MultiDimFit::robustHesse_ = false;
+std::string MultiDimFit::robustHesseLoad_ = "";
+std::string MultiDimFit::robustHesseSave_ = "";
+
 
 
 std::string MultiDimFit::saveSpecifiedFuncs_;
@@ -95,6 +99,10 @@ MultiDimFit::MultiDimFit() :
 	("startFromPreFit",   boost::program_options::value<bool>(&startFromPreFit_)->default_value(startFromPreFit_), "Start each point of the likelihood scan from the pre-fit values")
     ("alignEdges",   boost::program_options::value<bool>(&alignEdges_)->default_value(alignEdges_), "Align the grid points such that the endpoints of the ranges are included")
 	("saveFitResult",  "Save RooFitResult to muiltidimfit.root")
+    ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
+    ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
+    ("robustHesseSave",  boost::program_options::value<std::string>(&robustHesseSave_)->default_value(robustHesseSave_),  "Save the calculated Hessian")
+
       ;
 }
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -176,7 +176,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
     bool doHesse = (algo_ == Singles || algo_ == Impact) || (saveFitResult_) ;
     if ( !skipInitialFit_){
-        res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, false, 1, true, false));
+        res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, (saveFitResult_ && !robustHesse_), 1, true, false));
         if (!res.get()) {
             std::cout << "\n " <<std::endl;
             std::cout << "\n ---------------------------" <<std::endl;
@@ -224,16 +224,18 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     }
 
     if (robustHesse_) {
-
-    RobustHesse robustHesse(*nll, verbose - 1);
-    if (robustHesseSave_ != "") {
-      robustHesse.SaveHessianToFile(robustHesseSave_);
-    }
-    if (robustHesseLoad_ != "") {
-      robustHesse.LoadHessianFromFile(robustHesseLoad_);
-    }
-    robustHesse.hesse();
-    robustHesse.WriteOutputFile("robustHesse"+name_+".root");
+        RobustHesse robustHesse(*nll, verbose - 1);
+        if (robustHesseSave_ != "") {
+          robustHesse.SaveHessianToFile(robustHesseSave_);
+        }
+        if (robustHesseLoad_ != "") {
+          robustHesse.LoadHessianFromFile(robustHesseLoad_);
+        }
+        robustHesse.hesse();
+        if (saveFitResult_) {
+            res.reset(robustHesse.GetRooFitResult(res.get()));
+        }
+        robustHesse.WriteOutputFile("robustHesse"+name_+".root");
     }
 
    

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -57,7 +57,6 @@ std::string MultiDimFit::robustHesseLoad_ = "";
 std::string MultiDimFit::robustHesseSave_ = "";
 
 
-
 std::string MultiDimFit::saveSpecifiedFuncs_;
 std::string MultiDimFit::saveSpecifiedIndex_;
 std::string MultiDimFit::saveSpecifiedNuis_;
@@ -102,7 +101,6 @@ MultiDimFit::MultiDimFit() :
     ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
     ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
     ("robustHesseSave",  boost::program_options::value<std::string>(&robustHesseSave_)->default_value(robustHesseSave_),  "Save the calculated Hessian")
-
       ;
 }
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -216,8 +216,8 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     }
 
     RobustHesse robustHesse(*nll);
-    robustHesse.SaveHessianToFile("hessian_full2.root");
-    robustHesse.LoadHessianFromFile("hessian_full.root");
+    robustHesse.SaveHessianToFile("hessian_full.root");
+    // robustHesse.LoadHessianFromFile("hessian_full.root");
     // might do some configuration here...
     robustHesse.hesse();
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -215,11 +215,18 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 	//}
     }
 
-    RobustHesse robustHesse(*nll);
-    robustHesse.SaveHessianToFile("hessian_full.root");
-    // robustHesse.LoadHessianFromFile("hessian_full.root");
-    // might do some configuration here...
+    if (robustHesse_) {
+
+    RobustHesse robustHesse(*nll, verbose - 1);
+    if (robustHesseSave_ != "") {
+      robustHesse.SaveHessianToFile(robustHesseSave_);
+    }
+    if (robustHesseLoad_ != "") {
+      robustHesse.LoadHessianFromFile(robustHesseLoad_);
+    }
     robustHesse.hesse();
+    robustHesse.WriteOutputFile("robustHesse"+name_+".root");
+    }
 
    
     //set snapshot for best fit

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -372,55 +372,55 @@ int RobustHesse::hesse() {
     gDirectory->WriteObject(&hessian, "hessian");
   }
 
-  std::vector<std::string> remove_vars = {"CMS_fake_ele_wh3l", "QCDscale_tt", "CMS_fake_mu_stat_wh3l", "CMS_scale_j_RelativeJERHF_13TeV", "CMS_scale_j_RelativeJEREC2_13TeV", "CMS_ttHl_fakes", "CMS_ttH_ddQCD", "CMS_vhbb_bTagWeightJES_pt3_eta3"};
+  // std::vector<std::string> remove_vars = {"CMS_fake_ele_wh3l", "QCDscale_tt", "CMS_fake_mu_stat_wh3l", "CMS_scale_j_RelativeJERHF_13TeV", "CMS_scale_j_RelativeJEREC2_13TeV", "CMS_ttHl_fakes", "CMS_ttH_ddQCD", "CMS_vhbb_bTagWeightJES_pt3_eta3"};
 
-  std::vector<RooRealVar *> v_new2;
-  std::vector<double> nominal_new2;
-  std::vector<std::vector<double>> stencils_new2;
-  // std::vector<std::vector<double>> d1coeffs_new2;
-  // std::vector<std::vector<double>> d2coeffs_new2;
-  std::vector<double> rescales_new2;
+  // std::vector<RooRealVar *> v_new2;
+  // std::vector<double> nominal_new2;
+  // std::vector<std::vector<double>> stencils_new2;
+  // // std::vector<std::vector<double>> d1coeffs_new2;
+  // // std::vector<std::vector<double>> d2coeffs_new2;
+  // std::vector<double> rescales_new2;
 
-  TMatrixDSym hessian2(v_.size() - remove_vars.size());
+  // TMatrixDSym hessian2(v_.size() - remove_vars.size());
 
-  unsigned inew = 0;
-  unsigned jnew = 0;
-  std::vector<bool> ikeep(v_.size());
+  // unsigned inew = 0;
+  // unsigned jnew = 0;
+  // std::vector<bool> ikeep(v_.size());
 
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    ikeep[i] = (std::find(remove_vars.begin(), remove_vars.end(), v_[i]->GetName()) == remove_vars.end());
-  }
+  // for (unsigned i = 0; i < v_.size(); ++i) {
+  //   ikeep[i] = (std::find(remove_vars.begin(), remove_vars.end(), v_[i]->GetName()) == remove_vars.end());
+  // }
 
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    if (ikeep[i]) {
-      v_new2.push_back(v_[i]);
-      nominal_new2.push_back(nominal_[i]);
-      stencils_new2.push_back(stencils_[i]);
-      rescales_new2.push_back(rescales_[i]);
-    }
-    jnew = inew;
-    if (ikeep[i]) {
-      for (unsigned j = i; j < v_.size(); ++j) {
-        if (ikeep[j]) {
-          hessian2[inew][jnew] = hessian[i][j];
-          hessian2[jnew][inew] = hessian[j][i];
-          ++jnew;
-        }
-      }
-      ++inew;
-    }
-  }
+  // for (unsigned i = 0; i < v_.size(); ++i) {
+  //   if (ikeep[i]) {
+  //     v_new2.push_back(v_[i]);
+  //     nominal_new2.push_back(nominal_[i]);
+  //     stencils_new2.push_back(stencils_[i]);
+  //     rescales_new2.push_back(rescales_[i]);
+  //   }
+  //   jnew = inew;
+  //   if (ikeep[i]) {
+  //     for (unsigned j = i; j < v_.size(); ++j) {
+  //       if (ikeep[j]) {
+  //         hessian2[inew][jnew] = hessian[i][j];
+  //         hessian2[jnew][inew] = hessian[j][i];
+  //         ++jnew;
+  //       }
+  //     }
+  //     ++inew;
+  //   }
+  // }
 
-  v_ = v_new2;
-  nominal_ = nominal_new2;
-  stencils_ = stencils_new2;
-  rescales_ = rescales_new2;
-  hessian.ResizeTo(hessian2);
-  hessian = hessian2;
+  // v_ = v_new2;
+  // nominal_ = nominal_new2;
+  // stencils_ = stencils_new2;
+  // rescales_ = rescales_new2;
+  // hessian.ResizeTo(hessian2);
+  // hessian = hessian2;
 
   // hessian.Print();
 
-  bool print_only_negative = true;
+  bool print_only_negative = false;
   unsigned max = 10;
   for (unsigned ai = 0; ai < max; ++ai) {
     bool have_negative_eigenvalues = false;

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -21,35 +21,35 @@
 #include "TMatrixDSymEigen.h"
 
 
-RobustHesse::RobustHesse(RooAbsReal &nll) : nll_(&nll) {
+RobustHesse::RobustHesse(RooAbsReal &nll, unsigned verbose) : nll_(&nll), verbosity_(verbose) {
   targetNllForStencils_ = 0.1;
   minNllForStencils_ = 0.095;
   maxNllForStencils_ = 0.105;
   doRescale_ = true;
+  maxRemovalsFromHessian_ = 20;
   initialize();
 }
 
 void RobustHesse::initialize() {
   nll0_ = nll_->getVal();
+
+  // Get a list of the floating RooRealVars
   std::unique_ptr<RooArgSet> allpars(nll_->getParameters(RooArgSet()));
   RooFIter iter = allpars->fwdIterator();
   RooAbsArg *item;
+  std::vector<Var> allVars;
   while ((item = iter.next())) {
     RooRealVar *rrv = dynamic_cast<RooRealVar*>(item);
     if (rrv && !rrv->isConstant()) {
-      v_.push_back(rrv);
-      nominal_.push_back(rrv->getVal());
+      allVars.push_back(Var());
+      allVars.back().v = rrv;
+      allVars.back().nominal = rrv->getVal();
+      // rrv->Print();
     }
   }
-  std::cout << ">> Found " << v_.size() << " floating parameters\n";
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    v_[i]->Print();
-  }
+  std::cout << ">> Found " << allVars.size() << " floating parameters\n";
 
-  stencils_.resize(v_.size());
-  d1coeffs_.resize(v_.size());
-  d2coeffs_.resize(v_.size());
-  rescales_.resize(v_.size());
+  ReplaceVars(allVars);
 }
 
 double RobustHesse::deltaNLL() {
@@ -61,34 +61,37 @@ double RobustHesse::deltaNLL(std::vector<unsigned> const& indices, std::vector<d
     std::cout << ">> Error in deltaNLL: number of indices != number of vals\n";
     return 0.;
   }
+  nllEvals_++;
   if (indices.size() == 1) {
     auto it = nllcache_.find(std::make_pair(indices[0], vals[0]));
     if (it == nllcache_.end()) {
       for (unsigned i = 0; i < indices.size(); ++i) {
-        v_[indices[i]]->setVal(vals[i]);
+        cVars_[indices[i]].v->setVal(vals[i]);
       }
       it = nllcache_.emplace(std::make_pair(indices[0], vals[0]), deltaNLL()).first;
       for (unsigned i = 0; i < indices.size(); ++i) {
-        v_[indices[i]]->setVal(nominal_[indices[i]]);
+        cVars_[indices[i]].v->setVal(cVars_[indices[i]].nominal);
       }
+    } else {
+      nllEvalsCached_++;
     }
     return it->second;
   }
   for (unsigned i = 0; i < indices.size(); ++i) {
-    v_[indices[i]]->setVal(vals[i]);
+    cVars_[indices[i]].v->setVal(vals[i]);
   }
   double result = deltaNLL();
 
   for (unsigned i = 0; i < indices.size(); ++i) {
-    v_[indices[i]]->setVal(nominal_[indices[i]]);
+    cVars_[indices[i]].v->setVal(cVars_[indices[i]].nominal);
   }
   return result;
 }
 
 
 int RobustHesse::setParameterStencil(unsigned i) {
-  double x = nominal_[i];
-  RooRealVar *rrv = v_[i];
+  double x = cVars_[i].nominal;
+  RooRealVar *rrv = cVars_[i].v;
 
   double valLo = x - rrv->getError();
   double valHi = x + rrv->getError();
@@ -97,20 +100,16 @@ int RobustHesse::setParameterStencil(unsigned i) {
   double boundLo = rrv->getMin();
   double boundHi = rrv->getMax();
 
-  // Do I have a boundary?
-  // bool hasBoundLo = rrv->hasMin();
-  // bool hasBoundHi = rrv->hasMax();
-
   bool closeToLo = valLo < boundLo;
   bool closeToHi = valHi > boundHi;
 
   if (closeToLo) {
-    std::cout << ">> Parameter " << rrv->GetName() << " is too close to the lower bound: \n";
+    if (verbosity_ > 0) std::cout << ">> Parameter " << rrv->GetName() << " is too close to the lower bound: \n";
     rrv->Print();
     valLo = boundLo + 1E-7;
   }
   if (closeToHi) {
-    std::cout << ">> Parameter " << rrv->GetName() << " is too close to the upper bound: \n";
+    if (verbosity_ > 0) std::cout << ">> Parameter " << rrv->GetName() << " is too close to the upper bound: \n";
     rrv->Print();
     valHi = boundHi + 1E-7;
   }
@@ -129,7 +128,7 @@ int RobustHesse::setParameterStencil(unsigned i) {
   // Note that a very large dNll could just mean the parameter has a very strong anti-correlation
   // with another.
 
-  std::cout << rrv->GetName() << "\t" << dNllLo << "\t" << dNllHi << "\n";
+  // std::cout << rrv->GetName() << "\t" << dNllLo << "\t" << dNllHi << "\n";
 
   bool notViableLo = false;
   bool notViableHi = false;
@@ -142,13 +141,13 @@ int RobustHesse::setParameterStencil(unsigned i) {
       valLo = bound_result.second;
       dNllLo = deltaNLL({i}, {valLo});
       if (dNllLo < minNllForStencils_) {
-        std::cout << ">> dNllLo is still too small after [findBound]\n";
+        if (verbosity_ > 0) std::cout << ">> dNllLo is still too small after [findBound]\n";
         notViableLo = true;
       } else {
-        std::cout << ">> dNllLo is now " << dNllLo << "\n";
+        if (verbosity_ > 0) std::cout << ">> dNllLo is now " << dNllLo << "\n";
       }
     }
-    if (notViableLo) std::cout << ">> dNllLo is not viable\n";
+    if (notViableLo && verbosity_ > 0) std::cout << ">> dNllLo is not viable\n";
   }
 
   if (dNllHi < minNllForStencils_) {
@@ -159,13 +158,13 @@ int RobustHesse::setParameterStencil(unsigned i) {
       valHi = bound_result.second;
       dNllHi = deltaNLL({i}, {valHi});
       if (dNllHi < minNllForStencils_) {
-        std::cout << ">> dNllHi is still too small after [findBound]\n";
+        if (verbosity_ > 0) std::cout << ">> dNllHi is still too small after [findBound]\n";
         notViableHi = true;
       } else {
-        std::cout << ">> dNllHi is now " << dNllHi << "\n";
+        if (verbosity_ > 0) std::cout << ">> dNllHi is now " << dNllHi << "\n";
       }
     }
-    if (notViableHi) std::cout << ">> dNllHi is not viable\n";
+    if (notViableHi && verbosity_ > 0) std::cout << ">> dNllHi is not viable\n";
   }
 
   if (dNllLo > maxNllForStencils_) {
@@ -178,55 +177,56 @@ int RobustHesse::setParameterStencil(unsigned i) {
   }
 
 
-  std::cout << "[setParameterStencil] " << rrv->GetName() << "\t" << x << "\t" << valLo << " (" << dNllLo << ")\t" << valHi << " (" << dNllHi << ")\n";
 
+  // std::cout << "[setParameterStencil] " << rrv->GetName() << "\t" << x << "\t" << valLo << " (" << dNllLo << ")\t" << valHi << " (" << dNllHi << ")\n";
+  if (verbosity_ > 0) printf("%-80s %-10.3f | %-10.3f %-10.3f %-4.i | %-10.3f (%-10.3f) %-4.i \n",
+    rrv->GetName(), x, valLo, dNllLo, !notViableLo, valHi, dNllHi, !notViableHi);
 
-  rescales_[i] = 1.0;
+  cVars_[i].rescale = 1.0;
   if (!notViableLo && !notViableHi) {
     if (doRescale_) {
-      rescales_[i] = (valHi - valLo) / 2.;
+      cVars_[i].rescale = (valHi - valLo) / 2.;
     }
-    stencils_[i] = {(valLo - x) / rescales_[i], 0., (valHi - x) / rescales_[i]};
+    cVars_[i].stencil = {(valLo - x) / cVars_[i].rescale, 0., (valHi - x) / cVars_[i].rescale};
   } else if (notViableLo && !notViableHi) {
     if (doRescale_) {
-      rescales_[i] = (valHi - x);
+      cVars_[i ].rescale = (valHi - x);
     }
-    stencils_[i] = {0.,  (valHi - x) / (2. * rescales_[i]) ,(valHi - x) / rescales_[i]};
+    cVars_[i].stencil = {0.,  (valHi - x) / (2. * cVars_[i].rescale) ,(valHi - x) / cVars_[i].rescale};
   } else if (!notViableLo && notViableHi) {
     if (doRescale_) {
-      rescales_[i] = (x - valLo);
+      cVars_[i].rescale = (x - valLo);
     }
-    stencils_[i] = {(valLo - x) / rescales_[i], (valLo - x) / (2. * rescales_[i]), 0.};
+    cVars_[i].stencil = {(valLo - x) / cVars_[i].rescale, (valLo - x) / (2. * cVars_[i].rescale), 0.};
   } else {
     std::cout << "[setParameterStencil] " << rrv->GetName() << "not viable at all!\n";
   }
-
 
   return 0;
 }
 
 std::pair<int, double> RobustHesse::findBound(unsigned i, double x, double initialDelta, double initialMult, double scaleMult, double threshold, double hardBound, unsigned maxIters) {
-  std::cout << ">> [findBound] for parameter " << i << ", best-fit = " << x << ", initialDelta = " << initialDelta << "\n";
+  if (verbosity_ > 0) std::cout << ">> [findBound] for parameter " << i << ", best-fit = " << x << ", initialDelta = " << initialDelta << "\n";
   double mult = initialMult;
   double trial = x + initialDelta;
   for (unsigned j = 0; j < maxIters; ++j) {
     bool trial_hit_bound = false;
     trial = x + initialDelta * mult;
     if (hardBound > x && trial > hardBound) {
-      std::cout << "Step would go past bound, reducing\n";
+      if (verbosity_ > 0) std::cout << "Step would go past bound, reducing\n";
       trial = hardBound - 1E-7;
       trial_hit_bound = true;
     }
     if (hardBound < x && trial < hardBound) {
-      std::cout << "Step would go past bound, reducing\n";
+      if (verbosity_ > 0) std::cout << "Step would go past bound, reducing\n";
       trial = hardBound + 1E-7;
       trial_hit_bound = true;
     }
 
     double dNll = deltaNLL({i}, {trial});
-    std::cout << ">> dNLL at " << trial << " (x" << mult << " of original delta) = " << dNll << "\n";
+    if (verbosity_ > 0) std::cout << ">> dNLL at " << trial << " (x" << mult << " of original delta) = " << dNll << "\n";
     if ((mult > 1. && dNll > threshold) || (mult <= 1. && dNll < threshold)) {
-      std::cout << ">> This is past the threshold, returning\n";
+      if (verbosity_ > 0) std::cout << ">> This is past the threshold, returning\n";
       return std::make_pair(0, trial);
     } else if (trial_hit_bound) {
       return std::make_pair(1, trial);
@@ -244,7 +244,7 @@ double RobustHesse::improveWithBisect(unsigned i, double x, double max, double t
   for (unsigned j = 0; j < maxIters; ++j) {
     trial = (cmin + cmax) / 2.;
     double dNll = deltaNLL({i}, {trial});
-    std::cout << "[Bisect] " << j << " cmin = " << cmin << ", cmax = " << cmax << ", trial = " << trial << " dNll = " << dNll << "\n";
+    if (verbosity_ > 0) std::cout << "[Bisect] " << j << " cmin = " << cmin << ", cmax = " << cmax << ", trial = " << trial << " dNll = " << dNll << "\n";
     if (dNll > targetLo && dNll < targetHi) {
       break;
     }
@@ -278,176 +278,143 @@ std::vector<double> RobustHesse::getFdCoeffs(unsigned n, std::vector<double> con
 }
 
 
+void RobustHesse::RemoveFromHessian(std::vector<unsigned> ids) {
+
+  std::unique_ptr<TMatrixDSym> hessian2ptr(new TMatrixDSym(cVars_.size() - ids.size()));
+  TMatrixDSym & hessian2 = *(hessian2ptr.get());
+
+  unsigned inew = 0;
+  unsigned jnew = 0;
+  std::vector<bool> ikeep(cVars_.size());
+
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
+    ikeep[i] = (std::find(ids.begin(), ids.end(), i) == ids.end());
+  }
+
+  std::vector<Var> keptVars;
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
+    if (ikeep[i]) {
+      keptVars.push_back(cVars_[i]);
+    } else {
+      removedFromHessianVars_.push_back(cVars_[i]);
+      std::cout << ">> Dropping " << cVars_[i].v->GetName() << " from the hessian\n";
+    }
+    jnew = inew;
+    if (ikeep[i]) {
+      for (unsigned j = i; j < cVars_.size(); ++j) {
+        if (ikeep[j]) {
+          hessian2[inew][jnew] = (*hessian_)[i][j];
+          hessian2[jnew][inew] = (*hessian_)[j][i];
+          ++jnew;
+        }
+      }
+      ++inew;
+    }
+  }
+
+  ReplaceVars(keptVars);
+  hessian_ = std::move(hessian2ptr);
+}
+
+
+
 int RobustHesse::hesse() {
-  // ---- Step 1: figure out stencils for FD
-  // -- Step 1a: determine reasonable uncertainties
-  for (unsigned i = 0; i < v_.size(); ++i) {
+
+  // Step 1: try and set parameter stencils at the target NLL values
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
     setParameterStencil(i);
   }
 
-  std::vector<RooRealVar *> v_new;
-  std::vector<double> nominal_new;
-  std::vector<std::vector<double>> stencils_new;
-  std::vector<std::vector<double>> d1coeffs_new;
-  std::vector<std::vector<double>> d2coeffs_new;
-  std::vector<double> rescales_new;
-
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    if (stencils_[i].size() == 3) {
-      v_new.push_back(v_[i]);
-      nominal_new.push_back(nominal_[i]);
-      stencils_new.push_back(stencils_[i]);
-      rescales_new.push_back(rescales_[i]);
+  std::vector<Var> validStencilVars;
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
+    if (cVars_[i].stencil.size() == 3) {
+      validStencilVars.push_back(cVars_[i]);
+    } else {
+      invalidStencilVars_.push_back(cVars_[i]);
     }
   }
-  d1coeffs_.resize(v_new.size());
-  d2coeffs_.resize(v_new.size());
+  ReplaceVars(validStencilVars);
 
-  v_ = v_new;
-  nominal_ = nominal_new;
-  stencils_ = stencils_new;
-  rescales_ = rescales_new;
-
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    if (stencils_[i].size() == 3) {
-      d1coeffs_[i] = getFdCoeffs(1, stencils_[i]);
-      d2coeffs_[i] = getFdCoeffs(2, stencils_[i]);
-      printf("%-80s %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f\n",
-        v_[i]->GetName(), stencils_[i][0], stencils_[i][1], stencils_[i][2],
-        d1coeffs_[i][0], d1coeffs_[i][1], d1coeffs_[i][2],
-        d2coeffs_[i][0], d2coeffs_[i][1], d2coeffs_[i][2]
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
+    if (cVars_[i].stencil.size() == 3) {
+      cVars_[i].d1coeffs = getFdCoeffs(1, cVars_[i].stencil);
+      cVars_[i].d2coeffs = getFdCoeffs(2, cVars_[i].stencil);
+      if (verbosity_ > 0) printf("%-80s %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f\n",
+        cVars_[i].v->GetName(), cVars_[i].stencil[0], cVars_[i].stencil[1], cVars_[i].stencil[2],
+        cVars_[i].d1coeffs[0], cVars_[i].d1coeffs[1], cVars_[i].d1coeffs[2],
+        cVars_[i].d2coeffs[0], cVars_[i].d2coeffs[1], cVars_[i].d2coeffs[2]
         );
     }
   }
 
-
-
   // Step 2: Calculate and populate hessian
-  TMatrixDSym hessian(v_.size());
-  unsigned ntotal = (((v_.size() * v_.size()) - v_.size()) / 2) + v_.size();
+  hessian_ = std::unique_ptr<TMatrixDSym>(new TMatrixDSym(cVars_.size()));
+  unsigned ntotal = (((cVars_.size() * cVars_.size()) - cVars_.size()) / 2) + cVars_.size();
   unsigned idx = 0;
 
   if (loadFile_ != "") {
     TFile fin(loadFile_.c_str());
-    hessian = *((TMatrixDSym*)gDirectory->Get("hessian"));
+    *hessian_ = *((TMatrixDSym*)gDirectory->Get("hessian"));
   } else {
-    for (unsigned i = 0; i < v_.size(); ++i) {
-      for (unsigned j = i; j < v_.size(); ++j) {
+    for (unsigned i = 0; i < cVars_.size(); ++i) {
+      for (unsigned j = i; j < cVars_.size(); ++j) {
         if (idx % 100 == 0) {
-          std::cout << " - Done " << idx << "/" << ntotal << " terms\n";
+          if (verbosity_ > 0) std::cout << " - Done " << idx << "/" << ntotal << " terms (" << nllEvals_ << " evals, of which " << nllEvalsCached_ << " cached)\n";
         }
         double term = 0.;
         if (i == j) {
-          for (unsigned k = 0; k < stencils_[i].size(); ++k) {
-            if (stencils_[i][k] != 0.) {
-              term += deltaNLL({i}, {nominal_[i] + rescales_[i] * stencils_[i][k]}) * d2coeffs_[i][k];
+          for (unsigned k = 0; k < cVars_[i].stencil.size(); ++k) {
+            if (cVars_[i].stencil[k] != 0.) {
+              term += deltaNLL({i}, {cVars_[i].nominal + cVars_[i].rescale * cVars_[i].stencil[k]}) * cVars_[i].d2coeffs[k];
             }
           }
         } else {
-          for (unsigned k = 0; k < stencils_[i].size(); ++k) {
-            double c1 = d1coeffs_[i][k];
+          for (unsigned k = 0; k < cVars_[i].stencil.size(); ++k) {
+            double c1 = cVars_[i].d1coeffs[k];
             double c2 = 0.;
-            for (unsigned l = 0; l < stencils_[j].size();++l) {
-              if (stencils_[i][k] == 0. && stencils_[j][l] == 0.) {
+            for (unsigned l = 0; l < cVars_[j].stencil.size();++l) {
+              if (cVars_[i].stencil[k] == 0. && cVars_[j].stencil[l] == 0.) {
                 continue;
-              } else if (stencils_[i][k] == 0.) {
-                c2 += deltaNLL({j}, {nominal_[j] + stencils_[j][l] * rescales_[j]}) * d1coeffs_[j][l];
-              } else if (stencils_[j][l] == 0.) {
-                c2 += deltaNLL({i}, {nominal_[i] + stencils_[i][k] * rescales_[i]}) * d1coeffs_[j][l];
+              } else if (cVars_[i].stencil[k] == 0.) {
+                c2 += deltaNLL({j}, {cVars_[j].nominal + cVars_[j].stencil[l] * cVars_[j].rescale}) * cVars_[j].d1coeffs[l];
+              } else if (cVars_[j].stencil[l] == 0.) {
+                c2 += deltaNLL({i}, {cVars_[i].nominal + cVars_[i].stencil[k] * cVars_[i].rescale}) * cVars_[j].d1coeffs[l];
               } else {
-                c2 += deltaNLL({i, j}, {nominal_[i] + stencils_[i][k] * rescales_[i], nominal_[j] + stencils_[j][l] * rescales_[j]}) * d1coeffs_[j][l];
+                c2 += deltaNLL({i, j}, {cVars_[i].nominal + cVars_[i].stencil[k] * cVars_[i].rescale, cVars_[j].nominal + cVars_[j].stencil[l] * cVars_[j].rescale}) * cVars_[j].d1coeffs[l];
               }
             }
             term += (c2 * c1);
           }
         }
-        hessian[i][j] = term;
-        hessian[j][i] = term;
+        (*hessian_)[i][j] = term;
+        (*hessian_)[j][i] = term;
         ++idx;
       }
     }
   }
   if (saveFile_ != "") {
     TFile fout(saveFile_.c_str(), "RECREATE");
-    gDirectory->WriteObject(&hessian, "hessian");
+    gDirectory->WriteObject(hessian_.get(), "hessian");
   }
 
-  // std::vector<std::string> remove_vars = {"CMS_fake_ele_wh3l", "QCDscale_tt", "CMS_fake_mu_stat_wh3l", "CMS_scale_j_RelativeJERHF_13TeV", "CMS_scale_j_RelativeJEREC2_13TeV", "CMS_ttHl_fakes", "CMS_ttH_ddQCD", "CMS_vhbb_bTagWeightJES_pt3_eta3"};
 
-  // std::vector<RooRealVar *> v_new2;
-  // std::vector<double> nominal_new2;
-  // std::vector<std::vector<double>> stencils_new2;
-  // // std::vector<std::vector<double>> d1coeffs_new2;
-  // // std::vector<std::vector<double>> d2coeffs_new2;
-  // std::vector<double> rescales_new2;
 
-  // TMatrixDSym hessian2(v_.size() - remove_vars.size());
-
-  // unsigned inew = 0;
-  // unsigned jnew = 0;
-  // std::vector<bool> ikeep(v_.size());
-
-  // for (unsigned i = 0; i < v_.size(); ++i) {
-  //   ikeep[i] = (std::find(remove_vars.begin(), remove_vars.end(), v_[i]->GetName()) == remove_vars.end());
-  // }
-
-  // for (unsigned i = 0; i < v_.size(); ++i) {
-  //   if (ikeep[i]) {
-  //     v_new2.push_back(v_[i]);
-  //     nominal_new2.push_back(nominal_[i]);
-  //     stencils_new2.push_back(stencils_[i]);
-  //     rescales_new2.push_back(rescales_[i]);
-  //   }
-  //   jnew = inew;
-  //   if (ikeep[i]) {
-  //     for (unsigned j = i; j < v_.size(); ++j) {
-  //       if (ikeep[j]) {
-  //         hessian2[inew][jnew] = hessian[i][j];
-  //         hessian2[jnew][inew] = hessian[j][i];
-  //         ++jnew;
-  //       }
-  //     }
-  //     ++inew;
-  //   }
-  // }
-
-  // v_ = v_new2;
-  // nominal_ = nominal_new2;
-  // stencils_ = stencils_new2;
-  // rescales_ = rescales_new2;
-  // hessian.ResizeTo(hessian2);
-  // hessian = hessian2;
-
-  // hessian.Print();
-
-  bool print_only_negative = false;
-  unsigned max = 10;
-  for (unsigned ai = 0; ai < max; ++ai) {
+  bool print_only_negative = true;
+  for (unsigned ai = 0; ai < maxRemovalsFromHessian_; ++ai) {
+    std::cout << ">> Verifying eigenvalues are all posivtive (iteration " << ai << ")\n";
     bool have_negative_eigenvalues = false;
-    TMatrixDSymEigen eigen(hessian);
+
+    TMatrixDSymEigen eigen(*hessian_);
     auto eigenvals = eigen.GetEigenValues();
     auto eigenvecs = eigen.GetEigenVectors();
 
-    // for (int ei =0; ei < hessian.GetNrows(); ++ei) {
-    //   double diag = hessian[ei][ei];
-    //   double off_diag = 0.;
-    //   for (int ej = 0; ej < hessian.GetNrows(); ++ej) {
-    //     if (ej != ei) {
-    //       off_diag += hessian[ei][ej];
-    //     }
-    //   }
-    //   std::cout << "Diag = " << diag << "\tOff-diag = " << off_diag << " (" << v_[ei]->GetName() << ")\n";
-    // }
-
+    std::vector<unsigned> to_remove;
 
     for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
       if (eigenvals[ei] < 0.) have_negative_eigenvalues = true;
 
-
       std::vector<std::pair<unsigned, double>> eigenvec;
-      double mag2 = 0.;
       for (int ej = 0; ej < eigenvecs.GetNrows(); ++ej) {
-        mag2 += (eigenvecs[ej][ei]) * (eigenvecs[ej][ei]);
         eigenvec.push_back(std::make_pair(unsigned(ej), eigenvecs[ej][ei]));
       }
       if ((!print_only_negative) || (print_only_negative && eigenvals[ei] < 0.)) {
@@ -455,58 +422,30 @@ int RobustHesse::hesse() {
         std::sort(eigenvec.begin(), eigenvec.end(), [](std::pair<unsigned, double> const& p1, std::pair<unsigned, double> const& p2) {
           return std::fabs(p1.second) > std::fabs(p2.second);
         });
-        unsigned n_show = 50;
-        double trial = 0.002;
+        unsigned n_show = 5;
         for (unsigned es = 0; es < TMath::Min(n_show, unsigned(eigenvec.size())); ++es) {
-          // unsigned int hi = eigenvec[es].first;
-          // hessian[hi][hi] = hessian[hi][hi] * (1. + trial * std::pow(std::fabs(eigenvec[es].second), 2.));
-          std::cout << " - " << eigenvec[es].second << "\t" << v_[eigenvec[es].first]->GetName() << "\n";
-          for (unsigned es2 = es; es2 < TMath::Min(n_show, unsigned(eigenvec.size())); ++es2) {
-            if (es != es2) {
-              unsigned int hi = eigenvec[es].first;
-              unsigned int hj = eigenvec[es2].first;
-              double current = hessian[hi][hj];
-              hessian[hi][hj] = current * (1. - trial);
-              hessian[hj][hi] = current * (1. - trial);
-            }
-          }
+          std::cout << " - " << eigenvec[es].second << "\t" << cVars_[eigenvec[es].first].v->GetName() << "\n";
+        }
+
+        // Assume sorted by largest to smallest eigenvalues,
+        // meaning most negative is this one
+        if (ei == (eigenvals.GetNrows() - 1)) {
+          to_remove.push_back(eigenvec[0].first);
         }
       }
     }
     if (!have_negative_eigenvalues) {
+      std::cout << ">> All eigenvalues are positive\n";
       break;
     } else {
-      std::cout << ">> Attempt " << ai << " failed, increasing hessian diagonal elements...\n";
-      // // Try and scale up the diagonal??
-      // for (int ei =0; ei < hessian.GetNrows(); ++ei) {
-      //   hessian[ei][ei] = hessian[ei][ei] * 1.001;
-      // }
+      std::cout << ">> Attempt " << ai << " failed, remove the variable with largest eigenvector component...\n";
+      RemoveFromHessian(to_remove);
     }
   }
 
-  // eigenvecs.Print();
-
-  // Try to fix...
-  // TMatrixD eigenvals_matrix(eigenvals.GetNrows(), eigenvals.GetNrows());
-  // for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
-  //   if (eigenvals[ei] < 1E-6) {
-  //     eigenvals_matrix[ei][ei] = 1E-6;
-  //   } else {
-  //     eigenvals_matrix[ei][ei] = eigenvals[ei];
-  //   }
-  // }
-  // auto invert_eigenvecs = eigenvecs.Invert();
-
-  // TMatrixD new_hessian(eigenvecs * (eigenvals_matrix * invert_eigenvecs));
-  // for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
-  //   for (int ej = 0; ej < eigenvals.GetNrows(); ++ej) {
-  //     hessian[ei][ej] = new_hessian[ei][ej];
-  //   }
-  // }
-
-  TMatrixDSym covariance = hessian;
-  std::cout << " - Inverting Hessian...\n";
-  covariance.Invert();
+  covariance_ = std::unique_ptr<TMatrixDSym>(new TMatrixDSym(*hessian_));
+  std::cout << ">> Inverting Hessian...\n";
+  covariance_->Invert();
 
   // TDecompBK decomp(hessian);
   // std::cout << " - Inverting Hessian...\n";
@@ -514,42 +453,52 @@ int RobustHesse::hesse() {
   // covariance.Invert();
 
 
-  for (unsigned i = 0; i < v_.size(); ++i) {
-    std::cout << v_[i]->GetName() << "\t" << (std::sqrt(covariance[i][i]) * rescales_[i]) << "\n";
-    for (unsigned j = i+1; j < v_.size(); ++j) {
-      double corr = covariance[i][j] / (std::sqrt(covariance[i][i]) * std::sqrt(covariance[j][j]));
-      if (std::abs(corr) > 0.8) {
-        std::cout << " - correlation with " << v_[j]->GetName() << " = " << corr << "\n";
+  if (verbosity_ > 0) {
+    for (unsigned i = 0; i < cVars_.size(); ++i) {
+      std::cout << cVars_[i].v->GetName() << "\t" << (std::sqrt((*covariance_)[i][i]) * cVars_[i].rescale) << "\n";
+      for (unsigned j = i+1; j < cVars_.size(); ++j) {
+        double corr = (*covariance_)[i][j] / (std::sqrt((*covariance_)[i][i]) * std::sqrt((*covariance_)[j][j]));
+        if (std::abs(corr) > 0.8) {
+          std::cout << " - correlation with " << cVars_[j].v->GetName() << " = " << corr << "\n";
+        }
       }
     }
   }
-
-  if (saveFile_ != "") {
-    TFile fout2("covariance_output.root", "RECREATE");
-    TH2F h_cov("covariance", "covariance", v_.size(), 0, v_.size(), v_.size(), 0, v_.size());
-    RooWorkspace w("w", "w");
-    for (unsigned i = 0; i < v_.size(); ++i) {
-      w.import(*(v_[i]));
-      h_cov.GetXaxis()->SetBinLabel(i + 1, v_[i]->GetName());
-      h_cov.GetYaxis()->SetBinLabel(i + 1, v_[i]->GetName());
-      for (unsigned j = i; j < v_.size(); ++j) {
-        h_cov.SetBinContent(i + 1, j + 1, covariance[i][j] * rescales_[i] * rescales_[j]);
-        h_cov.SetBinContent(j + 1, i + 1, covariance[i][j] * rescales_[i] * rescales_[j]);
-      }
-    }
-    gDirectory->WriteObject(&hessian, "hessian");
-    gDirectory->WriteObject(&covariance, "covariance");
-    gDirectory->WriteObject(&h_cov, "h_covariance");
-    w.Write(); 
-    fout2.Close();
-  }
-
-
-
-  // Step 3: Test inversion
-
   return 0;
+}
 
+void RobustHesse::WriteOutputFile(std::string const& outputFileName) const {
+  TFile fout(outputFileName.c_str(), "RECREATE");
+  TH2F h_cov("covariance", "covariance", cVars_.size(), 0, cVars_.size(), cVars_.size(), 0,
+             cVars_.size());
+  TH2F h_cor("correlation", "correlation", cVars_.size(), 0, cVars_.size(), cVars_.size(), 0,
+             cVars_.size());
+  RooArgList arglist("floatParsFinal");
+  for (unsigned i = 0; i < cVars_.size(); ++i) {
+    arglist.addClone(*cVars_[i].v);
+    RooRealVar *rrv = dynamic_cast<RooRealVar*>(arglist.at(i));
+    rrv->setError(std::sqrt((*covariance_)[i][i]) * cVars_[i].rescale);
+    h_cov.GetXaxis()->SetBinLabel(i + 1, cVars_[i].v->GetName());
+    h_cov.GetYaxis()->SetBinLabel(i + 1, cVars_[i].v->GetName());
+    h_cor.GetXaxis()->SetBinLabel(i + 1, cVars_[i].v->GetName());
+    h_cor.GetYaxis()->SetBinLabel(i + 1, cVars_[i].v->GetName());
+    for (unsigned j = i; j < cVars_.size(); ++j) {
+      h_cov.SetBinContent(i + 1, j + 1,
+                          (*covariance_)[i][j] * cVars_[i].rescale * cVars_[j].rescale);
+      h_cov.SetBinContent(j + 1, i + 1,
+                          (*covariance_)[i][j] * cVars_[i].rescale * cVars_[j].rescale);
+      h_cor.SetBinContent(i + 1, j + 1,
+                          (*covariance_)[i][j] / (std::sqrt((*covariance_)[i][i]) * std::sqrt((*covariance_)[j][j])));
+      h_cor.SetBinContent(j + 1, i + 1,
+                          (*covariance_)[i][j] / (std::sqrt((*covariance_)[i][i]) * std::sqrt((*covariance_)[j][j])));
+    }
+  }
+  gDirectory->WriteObject(hessian_.get(), "hessian");
+  gDirectory->WriteObject(covariance_.get(), "covariance");
+  gDirectory->WriteObject(&h_cov, "h_covariance");
+  gDirectory->WriteObject(&h_cor, "h_correlation");
+  gDirectory->WriteObject(arglist.snapshot(), "floatParsFinal");
+  fout.Close();
 }
 
 void RobustHesse::SaveHessianToFile(std::string const& filename) {

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -1,0 +1,562 @@
+#include "HiggsAnalysis/CombinedLimit/interface/RobustHesse.h"
+
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+#include <cmath>
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include <typeinfo>
+#include <stdexcept>
+
+#include "TH2F.h"
+#include "TDirectory.h"
+#include "TFile.h"
+#include "TMatrixD.h"
+#include "TVectorD.h"
+#include "RooWorkspace.h"
+#include "TDecompBK.h"
+#include "TMatrixDSymEigen.h"
+
+
+RobustHesse::RobustHesse(RooAbsReal &nll) : nll_(&nll) {
+  targetNllForStencils_ = 0.1;
+  minNllForStencils_ = 0.095;
+  maxNllForStencils_ = 0.105;
+  doRescale_ = true;
+  initialize();
+}
+
+void RobustHesse::initialize() {
+  nll0_ = nll_->getVal();
+  std::unique_ptr<RooArgSet> allpars(nll_->getParameters(RooArgSet()));
+  RooFIter iter = allpars->fwdIterator();
+  RooAbsArg *item;
+  while ((item = iter.next())) {
+    RooRealVar *rrv = dynamic_cast<RooRealVar*>(item);
+    if (rrv && !rrv->isConstant()) {
+      v_.push_back(rrv);
+      nominal_.push_back(rrv->getVal());
+    }
+  }
+  std::cout << ">> Found " << v_.size() << " floating parameters\n";
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    v_[i]->Print();
+  }
+
+  stencils_.resize(v_.size());
+  d1coeffs_.resize(v_.size());
+  d2coeffs_.resize(v_.size());
+  rescales_.resize(v_.size());
+}
+
+double RobustHesse::deltaNLL() {
+  return nll_->getVal() - nll0_;
+}
+
+double RobustHesse::deltaNLL(std::vector<unsigned> const& indices, std::vector<double> const& vals) {
+  if (indices.size() != vals.size()) {
+    std::cout << ">> Error in deltaNLL: number of indices != number of vals\n";
+    return 0.;
+  }
+  if (indices.size() == 1) {
+    auto it = nllcache_.find(std::make_pair(indices[0], vals[0]));
+    if (it == nllcache_.end()) {
+      for (unsigned i = 0; i < indices.size(); ++i) {
+        v_[indices[i]]->setVal(vals[i]);
+      }
+      it = nllcache_.emplace(std::make_pair(indices[0], vals[0]), deltaNLL()).first;
+      for (unsigned i = 0; i < indices.size(); ++i) {
+        v_[indices[i]]->setVal(nominal_[indices[i]]);
+      }
+    }
+    return it->second;
+  }
+  for (unsigned i = 0; i < indices.size(); ++i) {
+    v_[indices[i]]->setVal(vals[i]);
+  }
+  double result = deltaNLL();
+
+  for (unsigned i = 0; i < indices.size(); ++i) {
+    v_[indices[i]]->setVal(nominal_[indices[i]]);
+  }
+  return result;
+}
+
+
+int RobustHesse::setParameterStencil(unsigned i) {
+  double x = nominal_[i];
+  RooRealVar *rrv = v_[i];
+
+  double valLo = x - rrv->getError();
+  double valHi = x + rrv->getError();
+
+  // Am I near a boundary?
+  double boundLo = rrv->getMin();
+  double boundHi = rrv->getMax();
+
+  // Do I have a boundary?
+  // bool hasBoundLo = rrv->hasMin();
+  // bool hasBoundHi = rrv->hasMax();
+
+  bool closeToLo = valLo < boundLo;
+  bool closeToHi = valHi > boundHi;
+
+  if (closeToLo) {
+    std::cout << ">> Parameter " << rrv->GetName() << " is too close to the lower bound: \n";
+    rrv->Print();
+    valLo = boundLo + 1E-7;
+  }
+  if (closeToHi) {
+    std::cout << ">> Parameter " << rrv->GetName() << " is too close to the upper bound: \n";
+    rrv->Print();
+    valHi = boundHi + 1E-7;
+  }
+
+  double dNllLo = deltaNLL({i}, {valLo});
+  double dNllHi = deltaNLL({i}, {valHi});
+
+  // What sort of problems can we have here?
+  //  a) dNll can be negative => we weren't quite at the minimum,
+  //     but maybe we did just take a very small step
+  //  b) dNLL is too large or too small. Should perform a search to get in the target range
+  //  c) dNLL could be zero, or zero-ish. Might be a non-active parameter in the multipdf
+  // Solution to cases (a) and (b) is the same: perform a search in the allowed range to see if
+  // we can find a better val. If we don't on one side only, then we can use an asymmetric stencil
+  // if we fail on both sides we have a problem.
+  // Note that a very large dNll could just mean the parameter has a very strong anti-correlation
+  // with another.
+
+  std::cout << rrv->GetName() << "\t" << dNllLo << "\t" << dNllHi << "\n";
+
+  bool notViableLo = false;
+  bool notViableHi = false;
+
+  if (dNllLo < minNllForStencils_) {
+    if (closeToLo) {
+      notViableLo = true;
+    } else {
+      auto bound_result = findBound(i, x, valLo - x, 2., 2., targetNllForStencils_, boundLo, 100);
+      valLo = bound_result.second;
+      dNllLo = deltaNLL({i}, {valLo});
+      if (dNllLo < minNllForStencils_) {
+        std::cout << ">> dNllLo is still too small after [findBound]\n";
+        notViableLo = true;
+      } else {
+        std::cout << ">> dNllLo is now " << dNllLo << "\n";
+      }
+    }
+    if (notViableLo) std::cout << ">> dNllLo is not viable\n";
+  }
+
+  if (dNllHi < minNllForStencils_) {
+    if (closeToHi) {
+      notViableHi = true;
+    } else {
+      auto bound_result = findBound(i, x, valHi - x, 2., 2., targetNllForStencils_, boundHi, 100);
+      valHi = bound_result.second;
+      dNllHi = deltaNLL({i}, {valHi});
+      if (dNllHi < minNllForStencils_) {
+        std::cout << ">> dNllHi is still too small after [findBound]\n";
+        notViableHi = true;
+      } else {
+        std::cout << ">> dNllHi is now " << dNllHi << "\n";
+      }
+    }
+    if (notViableHi) std::cout << ">> dNllHi is not viable\n";
+  }
+
+  if (dNllLo > maxNllForStencils_) {
+    valLo = improveWithBisect(i, x, valLo, targetNllForStencils_, minNllForStencils_,  maxNllForStencils_, 20);
+    dNllLo = deltaNLL({i}, {valLo});
+  }
+  if (dNllHi > maxNllForStencils_) {
+    valHi = improveWithBisect(i, x, valHi, targetNllForStencils_, minNllForStencils_,  maxNllForStencils_, 20);
+    dNllHi = deltaNLL({i}, {valHi});
+  }
+
+
+  std::cout << "[setParameterStencil] " << rrv->GetName() << "\t" << x << "\t" << valLo << " (" << dNllLo << ")\t" << valHi << " (" << dNllHi << ")\n";
+
+
+  rescales_[i] = 1.0;
+  if (!notViableLo && !notViableHi) {
+    if (doRescale_) {
+      rescales_[i] = (valHi - valLo) / 2.;
+    }
+    stencils_[i] = {(valLo - x) / rescales_[i], 0., (valHi - x) / rescales_[i]};
+  } else if (notViableLo && !notViableHi) {
+    if (doRescale_) {
+      rescales_[i] = (valHi - x);
+    }
+    stencils_[i] = {0.,  (valHi - x) / (2. * rescales_[i]) ,(valHi - x) / rescales_[i]};
+  } else if (!notViableLo && notViableHi) {
+    if (doRescale_) {
+      rescales_[i] = (x - valLo);
+    }
+    stencils_[i] = {(valLo - x) / rescales_[i], (valLo - x) / (2. * rescales_[i]), 0.};
+  } else {
+    std::cout << "[setParameterStencil] " << rrv->GetName() << "not viable at all!\n";
+  }
+
+
+  return 0;
+}
+
+std::pair<int, double> RobustHesse::findBound(unsigned i, double x, double initialDelta, double initialMult, double scaleMult, double threshold, double hardBound, unsigned maxIters) {
+  std::cout << ">> [findBound] for parameter " << i << ", best-fit = " << x << ", initialDelta = " << initialDelta << "\n";
+  double mult = initialMult;
+  double trial = x + initialDelta;
+  for (unsigned j = 0; j < maxIters; ++j) {
+    bool trial_hit_bound = false;
+    trial = x + initialDelta * mult;
+    if (hardBound > x && trial > hardBound) {
+      std::cout << "Step would go past bound, reducing\n";
+      trial = hardBound - 1E-7;
+      trial_hit_bound = true;
+    }
+    if (hardBound < x && trial < hardBound) {
+      std::cout << "Step would go past bound, reducing\n";
+      trial = hardBound + 1E-7;
+      trial_hit_bound = true;
+    }
+
+    double dNll = deltaNLL({i}, {trial});
+    std::cout << ">> dNLL at " << trial << " (x" << mult << " of original delta) = " << dNll << "\n";
+    if ((mult > 1. && dNll > threshold) || (mult <= 1. && dNll < threshold)) {
+      std::cout << ">> This is past the threshold, returning\n";
+      return std::make_pair(0, trial);
+    } else if (trial_hit_bound) {
+      return std::make_pair(1, trial);
+    }
+    mult *= scaleMult;
+  }
+  return std::make_pair(2, trial);
+}
+
+
+double RobustHesse::improveWithBisect(unsigned i, double x, double max, double target, double targetLo, double targetHi, unsigned maxIters) {
+  double cmin = x;
+  double cmax = max;
+  double trial = max;
+  for (unsigned j = 0; j < maxIters; ++j) {
+    trial = (cmin + cmax) / 2.;
+    double dNll = deltaNLL({i}, {trial});
+    std::cout << "[Bisect] " << j << " cmin = " << cmin << ", cmax = " << cmax << ", trial = " << trial << " dNll = " << dNll << "\n";
+    if (dNll > targetLo && dNll < targetHi) {
+      break;
+    }
+    if (dNll < target) {
+      cmin = trial;
+    } else {
+      cmax = trial;
+    }
+  }
+  return trial;
+}
+
+std::vector<double> RobustHesse::getFdCoeffs(unsigned n, std::vector<double> const& stencil) {
+  std::vector<double> result;
+  unsigned N = stencil.size();
+  TMatrixD smatrix(N, N);
+  TVectorD dvec(N);
+  for (unsigned i = 0; i < N; ++i) {
+    for (unsigned j = 0; j < N; ++j) {
+      smatrix(i, j) = std::pow(stencil[j], double(i));
+    }
+    dvec[i] = double((i == n) ? factorial(n) : 0);
+  }
+  TMatrixD smatrix2 = smatrix;
+  smatrix2.Invert();
+  TVectorD res = (smatrix2 * dvec);
+  for (unsigned i = 0; i < N; ++i) {
+    result.push_back(res[i]);
+  }
+  return result;
+}
+
+
+int RobustHesse::hesse() {
+  // ---- Step 1: figure out stencils for FD
+  // -- Step 1a: determine reasonable uncertainties
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    setParameterStencil(i);
+  }
+
+  std::vector<RooRealVar *> v_new;
+  std::vector<double> nominal_new;
+  std::vector<std::vector<double>> stencils_new;
+  std::vector<std::vector<double>> d1coeffs_new;
+  std::vector<std::vector<double>> d2coeffs_new;
+  std::vector<double> rescales_new;
+
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    if (stencils_[i].size() == 3) {
+      v_new.push_back(v_[i]);
+      nominal_new.push_back(nominal_[i]);
+      stencils_new.push_back(stencils_[i]);
+      rescales_new.push_back(rescales_[i]);
+    }
+  }
+  d1coeffs_.resize(v_new.size());
+  d2coeffs_.resize(v_new.size());
+
+  v_ = v_new;
+  nominal_ = nominal_new;
+  stencils_ = stencils_new;
+  rescales_ = rescales_new;
+
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    if (stencils_[i].size() == 3) {
+      d1coeffs_[i] = getFdCoeffs(1, stencils_[i]);
+      d2coeffs_[i] = getFdCoeffs(2, stencils_[i]);
+      printf("%-80s %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f | %-10.3f %-10.3f %-10.3f\n",
+        v_[i]->GetName(), stencils_[i][0], stencils_[i][1], stencils_[i][2],
+        d1coeffs_[i][0], d1coeffs_[i][1], d1coeffs_[i][2],
+        d2coeffs_[i][0], d2coeffs_[i][1], d2coeffs_[i][2]
+        );
+    }
+  }
+
+
+
+  // Step 2: Calculate and populate hessian
+  TMatrixDSym hessian(v_.size());
+  unsigned ntotal = (((v_.size() * v_.size()) - v_.size()) / 2) + v_.size();
+  unsigned idx = 0;
+
+  if (loadFile_ != "") {
+    TFile fin(loadFile_.c_str());
+    hessian = *((TMatrixDSym*)gDirectory->Get("hessian"));
+  } else {
+    for (unsigned i = 0; i < v_.size(); ++i) {
+      for (unsigned j = i; j < v_.size(); ++j) {
+        if (idx % 100 == 0) {
+          std::cout << " - Done " << idx << "/" << ntotal << " terms\n";
+        }
+        double term = 0.;
+        if (i == j) {
+          for (unsigned k = 0; k < stencils_[i].size(); ++k) {
+            if (stencils_[i][k] != 0.) {
+              term += deltaNLL({i}, {nominal_[i] + rescales_[i] * stencils_[i][k]}) * d2coeffs_[i][k];
+            }
+          }
+        } else {
+          for (unsigned k = 0; k < stencils_[i].size(); ++k) {
+            double c1 = d1coeffs_[i][k];
+            double c2 = 0.;
+            for (unsigned l = 0; l < stencils_[j].size();++l) {
+              if (stencils_[i][k] == 0. && stencils_[j][l] == 0.) {
+                continue;
+              } else if (stencils_[i][k] == 0.) {
+                c2 += deltaNLL({j}, {nominal_[j] + stencils_[j][l] * rescales_[j]}) * d1coeffs_[j][l];
+              } else if (stencils_[j][l] == 0.) {
+                c2 += deltaNLL({i}, {nominal_[i] + stencils_[i][k] * rescales_[i]}) * d1coeffs_[j][l];
+              } else {
+                c2 += deltaNLL({i, j}, {nominal_[i] + stencils_[i][k] * rescales_[i], nominal_[j] + stencils_[j][l] * rescales_[j]}) * d1coeffs_[j][l];
+              }
+            }
+            term += (c2 * c1);
+          }
+        }
+        hessian[i][j] = term;
+        hessian[j][i] = term;
+        ++idx;
+      }
+    }
+  }
+  if (saveFile_ != "") {
+    TFile fout(saveFile_.c_str(), "RECREATE");
+    gDirectory->WriteObject(&hessian, "hessian");
+  }
+
+  std::vector<std::string> remove_vars = {"CMS_fake_ele_wh3l", "QCDscale_tt", "CMS_fake_mu_stat_wh3l", "CMS_scale_j_RelativeJERHF_13TeV", "CMS_scale_j_RelativeJEREC2_13TeV", "CMS_ttHl_fakes", "CMS_ttH_ddQCD", "CMS_vhbb_bTagWeightJES_pt3_eta3"};
+
+  std::vector<RooRealVar *> v_new2;
+  std::vector<double> nominal_new2;
+  std::vector<std::vector<double>> stencils_new2;
+  // std::vector<std::vector<double>> d1coeffs_new2;
+  // std::vector<std::vector<double>> d2coeffs_new2;
+  std::vector<double> rescales_new2;
+
+  TMatrixDSym hessian2(v_.size() - remove_vars.size());
+
+  unsigned inew = 0;
+  unsigned jnew = 0;
+  std::vector<bool> ikeep(v_.size());
+
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    ikeep[i] = (std::find(remove_vars.begin(), remove_vars.end(), v_[i]->GetName()) == remove_vars.end());
+  }
+
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    if (ikeep[i]) {
+      v_new2.push_back(v_[i]);
+      nominal_new2.push_back(nominal_[i]);
+      stencils_new2.push_back(stencils_[i]);
+      rescales_new2.push_back(rescales_[i]);
+    }
+    jnew = inew;
+    if (ikeep[i]) {
+      for (unsigned j = i; j < v_.size(); ++j) {
+        if (ikeep[j]) {
+          hessian2[inew][jnew] = hessian[i][j];
+          hessian2[jnew][inew] = hessian[j][i];
+          ++jnew;
+        }
+      }
+      ++inew;
+    }
+  }
+
+  v_ = v_new2;
+  nominal_ = nominal_new2;
+  stencils_ = stencils_new2;
+  rescales_ = rescales_new2;
+  hessian.ResizeTo(hessian2);
+  hessian = hessian2;
+
+  // hessian.Print();
+
+  bool print_only_negative = true;
+  unsigned max = 10;
+  for (unsigned ai = 0; ai < max; ++ai) {
+    bool have_negative_eigenvalues = false;
+    TMatrixDSymEigen eigen(hessian);
+    auto eigenvals = eigen.GetEigenValues();
+    auto eigenvecs = eigen.GetEigenVectors();
+
+    // for (int ei =0; ei < hessian.GetNrows(); ++ei) {
+    //   double diag = hessian[ei][ei];
+    //   double off_diag = 0.;
+    //   for (int ej = 0; ej < hessian.GetNrows(); ++ej) {
+    //     if (ej != ei) {
+    //       off_diag += hessian[ei][ej];
+    //     }
+    //   }
+    //   std::cout << "Diag = " << diag << "\tOff-diag = " << off_diag << " (" << v_[ei]->GetName() << ")\n";
+    // }
+
+
+    for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
+      if (eigenvals[ei] < 0.) have_negative_eigenvalues = true;
+
+
+      std::vector<std::pair<unsigned, double>> eigenvec;
+      double mag2 = 0.;
+      for (int ej = 0; ej < eigenvecs.GetNrows(); ++ej) {
+        mag2 += (eigenvecs[ej][ei]) * (eigenvecs[ej][ei]);
+        eigenvec.push_back(std::make_pair(unsigned(ej), eigenvecs[ej][ei]));
+      }
+      if ((!print_only_negative) || (print_only_negative && eigenvals[ei] < 0.)) {
+        std::cout << "Eigenvalue " << ei << " : " << eigenvals[ei] << "\n";
+        std::sort(eigenvec.begin(), eigenvec.end(), [](std::pair<unsigned, double> const& p1, std::pair<unsigned, double> const& p2) {
+          return std::fabs(p1.second) > std::fabs(p2.second);
+        });
+        unsigned n_show = 50;
+        double trial = 0.002;
+        for (unsigned es = 0; es < TMath::Min(n_show, unsigned(eigenvec.size())); ++es) {
+          // unsigned int hi = eigenvec[es].first;
+          // hessian[hi][hi] = hessian[hi][hi] * (1. + trial * std::pow(std::fabs(eigenvec[es].second), 2.));
+          std::cout << " - " << eigenvec[es].second << "\t" << v_[eigenvec[es].first]->GetName() << "\n";
+          for (unsigned es2 = es; es2 < TMath::Min(n_show, unsigned(eigenvec.size())); ++es2) {
+            if (es != es2) {
+              unsigned int hi = eigenvec[es].first;
+              unsigned int hj = eigenvec[es2].first;
+              double current = hessian[hi][hj];
+              hessian[hi][hj] = current * (1. - trial);
+              hessian[hj][hi] = current * (1. - trial);
+            }
+          }
+        }
+      }
+    }
+    if (!have_negative_eigenvalues) {
+      break;
+    } else {
+      std::cout << ">> Attempt " << ai << " failed, increasing hessian diagonal elements...\n";
+      // // Try and scale up the diagonal??
+      // for (int ei =0; ei < hessian.GetNrows(); ++ei) {
+      //   hessian[ei][ei] = hessian[ei][ei] * 1.001;
+      // }
+    }
+  }
+
+  // eigenvecs.Print();
+
+  // Try to fix...
+  // TMatrixD eigenvals_matrix(eigenvals.GetNrows(), eigenvals.GetNrows());
+  // for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
+  //   if (eigenvals[ei] < 1E-6) {
+  //     eigenvals_matrix[ei][ei] = 1E-6;
+  //   } else {
+  //     eigenvals_matrix[ei][ei] = eigenvals[ei];
+  //   }
+  // }
+  // auto invert_eigenvecs = eigenvecs.Invert();
+
+  // TMatrixD new_hessian(eigenvecs * (eigenvals_matrix * invert_eigenvecs));
+  // for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
+  //   for (int ej = 0; ej < eigenvals.GetNrows(); ++ej) {
+  //     hessian[ei][ej] = new_hessian[ei][ej];
+  //   }
+  // }
+
+  TMatrixDSym covariance = hessian;
+  std::cout << " - Inverting Hessian...\n";
+  covariance.Invert();
+
+  // TDecompBK decomp(hessian);
+  // std::cout << " - Inverting Hessian...\n";
+  // TMatrixDSym covariance = decomp.Invert();
+  // covariance.Invert();
+
+
+  for (unsigned i = 0; i < v_.size(); ++i) {
+    std::cout << v_[i]->GetName() << "\t" << (std::sqrt(covariance[i][i]) * rescales_[i]) << "\n";
+    for (unsigned j = i+1; j < v_.size(); ++j) {
+      double corr = covariance[i][j] / (std::sqrt(covariance[i][i]) * std::sqrt(covariance[j][j]));
+      if (std::abs(corr) > 0.8) {
+        std::cout << " - correlation with " << v_[j]->GetName() << " = " << corr << "\n";
+      }
+    }
+  }
+
+  if (saveFile_ != "") {
+    TFile fout2("covariance_output.root", "RECREATE");
+    TH2F h_cov("covariance", "covariance", v_.size(), 0, v_.size(), v_.size(), 0, v_.size());
+    RooWorkspace w("w", "w");
+    for (unsigned i = 0; i < v_.size(); ++i) {
+      w.import(*(v_[i]));
+      h_cov.GetXaxis()->SetBinLabel(i + 1, v_[i]->GetName());
+      h_cov.GetYaxis()->SetBinLabel(i + 1, v_[i]->GetName());
+      for (unsigned j = i; j < v_.size(); ++j) {
+        h_cov.SetBinContent(i + 1, j + 1, covariance[i][j] * rescales_[i] * rescales_[j]);
+        h_cov.SetBinContent(j + 1, i + 1, covariance[i][j] * rescales_[i] * rescales_[j]);
+      }
+    }
+    gDirectory->WriteObject(&hessian, "hessian");
+    gDirectory->WriteObject(&covariance, "covariance");
+    gDirectory->WriteObject(&h_cov, "h_covariance");
+    w.Write(); 
+    fout2.Close();
+  }
+
+
+
+  // Step 3: Test inversion
+
+  return 0;
+
+}
+
+void RobustHesse::SaveHessianToFile(std::string const& filename) {
+  saveFile_ = filename;
+}
+void RobustHesse::LoadHessianFromFile(std::string const& filename) {
+  loadFile_ = filename;
+}
+
+

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -136,6 +136,7 @@ toymcoptutils::SinglePdfGenInfo::generateAsimov(RooRealVar *&weightVar, double w
     int nPA = runtimedef::get("TMCSO_PseudoAsimov");  // Will trigger the use of weighted data 
     int boostAPA = runtimedef::get("TMCSO_AdaptivePseudoAsimov");
     if (boostAPA>0) {  // trigger adaptive PA (setting boostAPA=1 will just use internal logic)
+        if ( verbose > 0 ) Logger::instance().log(std::string(Form("ToyMCSamplerOpt.cc: %d -- Using internal logic for binned/unbinned Asimov dataset generation",__LINE__)),Logger::kLogLevelInfo,__func__);
         int nbins = 1;
         RooLinkedListIter iter = observables_.iterator(); 
         for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {

--- a/test/systematicsAnalyzer.py
+++ b/test/systematicsAnalyzer.py
@@ -91,7 +91,11 @@ for (lsyst,nofloat,pdf,pdfargs,errline) in DC.systs:
             if errline[b][p] == 0: continue
 	    numKeysFound+=1
             processes[p] = True
-	    if "shape" in pdf and MB.isShapeSystematic(b,p,lsyst):
+            if pdf == "gmN":
+		minEffect = pdfargs[0] 
+		maxEffect = pdfargs[0]
+	    else: 
+	     if "shape" in pdf and MB.isShapeSystematic(b,p,lsyst):
 		vals = []
 
 		systShapeName = lsyst
@@ -110,8 +114,9 @@ for (lsyst,nofloat,pdf,pdfargs,errline) in DC.systs:
 			errlines[lsyst][b][p] = "NAN/NAN"
 			vals.append(1.)
 			vals.append(1.)
-            else: vals = errline[b][p] if type(errline[b][p]) == list else [ errline[b][p] ]
-            for val in vals:
+	     else: 
+	    	vals = errline[b][p] if type(errline[b][p]) == list else [ errline[b][p] ]
+             for val in vals:
                 if val < 1: val = 1.0/val
                 minEffect = min(minEffect, val)
                 maxEffect = max(maxEffect, val)


### PR DESCRIPTION
Have added a standalone "RobustHesse" class. Usage:

`combine -M MultiDimFit --algo none --robustHesse 1`

Output is written to a separate file: `robustHesse[name].root`.

Main goal is to provide a way of calculating the covariance matrix that:
 - does not suffer as frequently from the "forced positive-definite" problem that we often see from Minuit's HESSE calculation
 - can handle parameters at or very close to boundaries by using forward or backward finite difference formulae instead of central differences
 - knows to ignore parameters that are floating but don't affect the NLL (e.g. Hgg background parameters for the non-selected pdfs)

For the first point, the RobustHesse doesn't try to make the step size for the finite difference as small as possible like Minuit's hesse does, instead it has a target unprofiled deltaNLL that it uses to set the step size for each parameter. Once the step size is determined it makes a co-ordinate transformation such that all step sizes are of order unity. This seems to make the hessian more accurate (and so more likely to be invertible) in the presence of high correlations. In the event that the matrix is still not pos-def, it performs an eigenvector decomposition and drops parameters that dominate the ones with negative eigenvalues until the matrix is pos-def. The user is warned if this happens.

To-do before merging:
 - [x] Currently only in MultiDimFit, could be extended to FitDiagnostics
 - [x] Would be good to build the output into the usual RooFitResult, so existing scripts can be used