### PR TITLE
Need algorithm in 94X

### DIFF
--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -75,7 +75,7 @@ class RobustHesse {
 
   std::vector<double> getFdCoeffs(unsigned n, std::vector<double> const& stencil);
 
-  void RemoveFromHessian(std::vector<unsigned> ids);
+  void RemoveFromHessian(std::vector<unsigned> const& ids);
 
   void ReplaceVars(std::vector<Var> newVars) {
     cVars_ = newVars;

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -283,7 +283,7 @@ std::vector<double> RobustHesse::getFdCoeffs(unsigned n, std::vector<double> con
 }
 
 
-void RobustHesse::RemoveFromHessian(std::vector<unsigned> ids) {
+void RobustHesse::RemoveFromHessian(std::vector<unsigned> const& ids) {
 
   std::unique_ptr<TMatrixDSym> hessian2ptr(new TMatrixDSym(cVars_.size() - ids.size()));
   TMatrixDSym & hessian2 = *(hessian2ptr.get());

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <string>
 #include <memory>
+#include <algorithm>
 #include <typeinfo>
 #include <stdexcept>
 


### PR DESCRIPTION
Otherwise the code gives the following compiler errors:

error: no matching function for call to 'find(std::vector<unsigned int>::iterator, std::vector<unsigned int>::iterator, unsigned int&)'
     ikeep[i] = (std::find(ids.begin(), ids.end(), i) == ids.end());
note: candidate: template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT> >::__type std::find(std::istreambuf_iterator<_CharT>, std::istreambuf_iterator<_CharT>, const _CharT2&)
     find(istreambuf_iterator<_CharT> __first,
note:   template argument deduction/substitution failed:
src/RobustHesse.cc:295:52: note:   '__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int> >' is not derived from 'std::istreambuf_iterator<_CharT>'
     ikeep[i] = (std::find(ids.begin(), ids.end(), i) == ids.end());
/src/RobustHesse.cc: In member function 'int RobustHesse::hesse()':
src/RobustHesse.cc:427:9: error: 'sort' is not a member of 'std'
         std::sort(eigenvec.begin(), eigenvec.end(), [](std::pair<unsigned, double> const& p1, std::pair<unsigned, double> const& p2) {
