### PR TITLE
FitDiagnostics: Add warning when covariance matrix is inaccurate

### DIFF
--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -51,6 +51,8 @@ protected:
   static bool        reuseParams_;
   static bool        customStartingPoint_;
   static bool       robustHesse_;
+  static bool        saveWithUncertsRequested_;
+  static bool        ignoreCovWarning_;
   int currentToy_, nToys;
   int overallBins_,overallNorms_,overallNuis_,overallCons_;
   int fitStatus_, numbadnll_;


### PR DESCRIPTION
This adds a warning in FitDiagnostics when the covariance matrix is not accurate (ie covQual < 3 ). If this happens the default behaviour is also to ignore the `--saveWithUncertainties` flag. A new flag, `--ignoreCovWarning`, has been added in case the user wants to override this default behaviour and save the uncertainties with the shapes, even though they would be incorrect.

Note that the default behaviour of `--saveShapes` has also been changed slightly: the bin errors will now be set to 0 explicitly. Previously nothing was specified, which means that `TH1::GetBinError()` would default to returning the square root of the bin content, which could lead to confusion and the use of sqrt(bin content) to build uncertainty bands which is not desirable.

Finally I should point out that the warning message(s) that were added currently link to the FAQ page of the combine gitbook. This will have to be updated before merging the PR. I wrote a draft [*] of something that could be added to the gitbook as a subsection of "Fitting Diagnostics" - because legacy gitbook and 'new' accounts don't mix I can't add it to the documentation myself.

[*]
If you get a warning message when running `FitDiagnostics` which says `Unable to determine uncertainties on all fit parameters.`, this means the covariance matrix calculated in FitDiagnostics was not correct. The most common problem is that the covariance matrix is forced positive-definite. In this case the constraints on fit parameters as taken from the covariance matrix are incorrect and should not be used. In particular, if you want to make post-fit plots of the distribution used in the signal extraction fit and are extracting the uncertainties on the signal- and background expectations from the covariance matrix, the resulting values will not reflect the truth if the covariance matrix was incorrect. By default if this happens and you passed the `--saveWithUncertainties` flag when calling FitDiagnostics, this option will be ignored as calculating the uncertainties would lead to incorrect results. This behaviour can be overridden by passing `--ignoreCovWarning`. 

Such problems with the covariance matrix can be caused by a number of things, for example:
- Parameters being close to their boundaries after the fit.
- Strong (anti-) correlations between some parameters.
- A discontinuity in the NLL function or its derivatives at or near the minimum.  

If you are aware that your analysis has any of these features you could try resolving these. Setting `--cminDefaultMinimizerStrategy 0` can also help with this problem. 