### PR TITLE
Print number of masked channels

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -754,9 +754,15 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
 
   // Print list of channel masks
-  if (verbose >= 2) {
-    RooSimultaneousOpt *simopt = dynamic_cast<RooSimultaneousOpt*>(mc->GetPdf());
-    if (simopt && simopt->channelMasks().getSize() > 0) {
+  RooSimultaneousOpt *simopt = dynamic_cast<RooSimultaneousOpt*>(mc->GetPdf());
+  if (simopt && simopt->channelMasks().getSize() > 0) {
+    int nChnMasks = simopt->channelMasks().getSize();
+    int nActiveMasks = 0;
+    for (int iMask=0; iMask < nChnMasks; iMask++){
+      if (dynamic_cast<RooRealVar*>(simopt->channelMasks().at(iMask))->getVal() > 0) nActiveMasks++;
+    }
+    std::cout << ">>> "<<nActiveMasks<<" out of "<<nChnMasks<<" channels masked\n"<<std::endl;
+    if (verbose >= 2) {
       std::cout << ">>> Channel masks:\n";
       simopt->channelMasks().Print("v");
     }


### PR DESCRIPTION
This adds a message stating the number of channels masked in case channel masking parameters are present in the workspace. Intended to avoid confusion about how to use channel masking. 