### PR TITLE
RooParametricShapeBinPdf allow functional parameters

### DIFF
--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -3,8 +3,8 @@
 #define ROOPARAMETRICSHAPEBINPDF
 //---------------------------------------------------------------------------
 #include "RooAbsPdf.h"
-#include "RooConstVar.h"
 #include "RooRealProxy.h"
+#include "RooListProxy.h"
 //---------------------------------------------------------------------------
 class RooRealVar;
 class RooAbsReal;
@@ -12,24 +12,12 @@ class RooAbsReal;
 #include "Riostream.h"
 #include "TMath.h"
 #include <TH1.h>
-#include <TF1.h>
-#include "Math/SpecFuncMathCore.h"
-#include "Math/SpecFuncMathMore.h"
-#include "Math/Functor.h"
-#include "Math/WrappedFunction.h"
-#include "Math/WrappedTF1.h"
-#include "Math/IFunction.h"
-#include "Math/Integrator.h"
 
 //---------------------------------------------------------------------------
 class RooParametricShapeBinPdf : public RooAbsPdf
 {
 public:
    RooParametricShapeBinPdf() {} ;
-   /*
-   RooParametricShapeBinPdf(const char *name, const char *title,  const char *formula, 
-		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
-   */
    RooParametricShapeBinPdf(const char *name, const char *title,  RooAbsReal& _pdf, 
 		  RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape );
    RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,
@@ -47,6 +35,7 @@ protected:
    RooRealProxy x;        // dependent variable
    RooListProxy pars;
    RooRealProxy mypdf;
+   //std::vector<const RooAbsReal *> myintegrals;
    Int_t xBins;        // X bins
    Double_t xArray[2000]; // xArray[xBins+1]
    Double_t xMax;        // X max
@@ -67,7 +56,7 @@ private:
        return mypdf.arg().plotOn(frame,cmdList) ;
      }
      
-   ClassDef(RooParametricShapeBinPdf,1) // RooParametricShapeBinPdf function
+   ClassDef(RooParametricShapeBinPdf,2) // RooParametricShapeBinPdf function
     
 };
 //---------------------------------------------------------------------------

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -35,8 +35,6 @@ public:
    RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other,
       const char* name = 0);
    void setTH1Binning(const TH1& _Hnominal);
-   void setAbsTol(double _absTol);
-   void setRelTol(double _relTol);
    RooAbsPdf* getPdf() const;
    virtual TObject* clone(const char* newname) const { return new RooParametricShapeBinPdf(*this,newname); }
    inline virtual ~RooParametricShapeBinPdf() { }
@@ -49,14 +47,10 @@ protected:
    RooRealProxy x;        // dependent variable
    RooListProxy pars;
    RooRealProxy mypdf;
-   TF1 * myfunc;
    Int_t xBins;        // X bins
    Double_t xArray[2000]; // xArray[xBins+1]
    Double_t xMax;        // X max
    Double_t xMin;        // X min
-   Double_t relTol;      //relative tolerance for numerical integration
-   Double_t absTol;      //absolute tolerance for numerical integration
-   Int_t nPars;
 
    Double_t evaluate() const;
 private:

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -24,6 +24,7 @@ public:
       const char* name = 0);
    void setTH1Binning(const TH1& _Hnominal);
    RooAbsPdf* getPdf() const;
+   RooAbsReal* getIntegral(int index) const;
    virtual TObject* clone(const char* newname) const { return new RooParametricShapeBinPdf(*this,newname); }
    inline virtual ~RooParametricShapeBinPdf() { }
 
@@ -34,8 +35,8 @@ protected:
 
    RooRealProxy x;        // dependent variable
    RooListProxy pars;
-   RooRealProxy mypdf;
-   //std::vector<const RooAbsReal *> myintegrals;
+   RooRealProxy mypdf;   
+   RooListProxy myintegrals;
    Int_t xBins;        // X bins
    Double_t xArray[2000]; // xArray[xBins+1]
    Double_t xMax;        // X max

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -39,7 +39,7 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char 
   RooAbsReal* myintegral;
   RooListProxy obs;
   obs.add(x.arg());
-  for (Int_t iBin=0; iBin<xBins+1; iBin++){
+  for (Int_t iBin=0; iBin<xBins; iBin++){
     std::string rangeName  = Form("%s_%s_range_bin%d", GetName(), x.GetName(), iBin);
     if (!x.arg().hasRange(rangeName.c_str())) {
       RooRealVar x_rrv = dynamic_cast<const RooRealVar &>(x.arg());

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -100,8 +100,7 @@ RooAbsPdf* RooParametricShapeBinPdf::getPdf() const {
 //---------------------------------------------------------------------------
 /// Return the bin-by-bin integrals
 RooAbsReal* RooParametricShapeBinPdf::getIntegral(int index) const {
-  RooAbsReal *myintegral = ((RooAbsReal*)myintegrals.at(index));
-  return myintegral;
+  return myintegrals.at(index) ? ((RooAbsReal*)myintegrals.at(index)) : 0;
 }
 //---------------------------------------------------------------------------
 Double_t RooParametricShapeBinPdf::evaluate() const
@@ -119,7 +118,16 @@ Double_t RooParametricShapeBinPdf::evaluate() const
 
   Double_t xLow = xArray[iBin];
   Double_t xHigh = xArray[iBin+1];
-    
+
+  // check again if x variable has the right range already defined 
+  // needed when combining multiple workspaces, and taking variable x from only one of them!
+  std::string rangeName  = Form("%s_%s_range_bin%d", GetName(), x.GetName(), iBin);
+  if (!x.arg().hasRange(rangeName.c_str())) {
+    RooRealVar x_rrv = dynamic_cast<const RooRealVar &>(x.arg());
+    Double_t xLow = xArray[iBin];
+    Double_t xHigh = xArray[iBin+1];
+    x_rrv.setRange(rangeName.c_str(),xLow,xHigh);
+  } 
   integral = getIntegral(iBin)->getVal() / (xHigh-xLow);
   
   if (integral>0.0) {

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -50,6 +50,9 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char 
     myintegral = getPdf()->createIntegral(obs,Range(rangeName.c_str()));
     myintegrals.add(*myintegral);
   }
+  //last one is full integral (no range)
+  myintegral = getPdf()->createIntegral(obs);
+  myintegrals.add(*myintegral);
 }
 //---------------------------------------------------------------------------
 RooParametricShapeBinPdf::RooParametricShapeBinPdf(const RooParametricShapeBinPdf& other, const char* name) : RooAbsPdf(other, name), 
@@ -142,8 +145,7 @@ Double_t RooParametricShapeBinPdf::analyticalIntegral(Int_t code, const char* ra
   obs.add(x.arg());
   
   if (code==1 && xRangeMin<=xMin && xRangeMax>=xMax){
-    RooAbsReal* myintegral = getPdf()->createIntegral(obs);
-    integral = myintegral->getVal();
+    integral = getIntegral(xBins)->getVal();
     return integral;
   }
   else if(code==1) {     


### PR DESCRIPTION
Hi,

This PR generalizes `RooParametricShapeBinPdf` to allow the function to have parameters that are themselves functions (`RooAbsReal`). Our previous implementation only allowed parameters to be variables (`RooRealVar`) due to the use of `RooAbsReal::asTF` (https://root.cern.ch/doc/master/RooAbsReal_8cxx_source.html#l04104), which enforces that.

As a reminder, this binned PDF is intended to act as wrapper to a continuous/analytical PDF, forcing RooFit to correctly calculate the integrals under the curve. This is used in several dijet analyses (and may be used in the combined all-hadronic diboson analysis), where the variable-width bins are very coarse.

Here is a simple script to test the new PR and show the bias introduced by fitting with the usual method: https://gist.github.com/jmduarte/c616c486d4532cdd5a56150c1ccc42d5

Thanks,
Javier