### PR TITLE
Fix reset of TestStat when reading toys for TEV

### DIFF
--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -257,8 +257,8 @@ void HybridNew::validateOptions() {
     if (testStat_ == "Profile") std::cout << ">>> using the Profile Likelihood test statistics not modified for upper limits (Q_Profile)" << std::endl;
     if (testStat_ == "MLZ")     std::cout << ">>> using the Maximum likelihood estimator of the signal strength as test statistics" << std::endl;
     
-    if (readHybridResults_ || workingMode_ == MakeTestStatistics || workingMode_ == MakeSignificanceTestStatistics) {
-        // If not generating toys, don't need to fit nuisance parameters
+    if ( (readHybridResults_ || workingMode_ == MakeTestStatistics || workingMode_ == MakeSignificanceTestStatistics) && noUpdateGrid_) {
+        // If not generating toys, don't need to fit nuisance parameters, unless requested to updateGrid 
         fitNuisances_ = false;
     }
     if (reportPVal_ && workingMode_ != MakeSignificance) throw std::invalid_argument("HybridNew: option --pvalue must go together with --significance");


### PR DESCRIPTION
This fixes an issue that by default, combine will re-evaluate the data test-statistic when reading in the grid of points. We shouldn't overwrite the "fitNuisances setting" if this occurs. (fixes #508)