### PR TITLE
Don't allow "Pdf" in the substring of a new nusiance name

### DIFF
--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -145,6 +145,8 @@ def doRenameNuisance(datacard, args):
     if len(args) < 4:
         raise RuntimeError, "Missing arguments: the syntax is: nuisance edit rename process channel oldname newname"
     (process, channel, oldname, newname) = args[:4]
+    if "Pdf" in newname: 
+        raise RuntimeError, "Error - cannot use 'Pdf' substring in the new name for a nuisance parameter"
     if process != "*": cprocess = re.compile(process)
     if channel != "*": cchannel = re.compile(channel.replace("+","\+"))
     opts = args[4:]

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -121,6 +121,8 @@ def doRenameNuisance(datacard, args):
     if len(args) == 2: # newname oldname 
       nuisanceID = i = -1
       (oldname, newname) = args[:2]
+      if "Pdf" in newname: 
+          raise RuntimeError, "Error - cannot use 'Pdf' substring in the new name for a nuisance parameter"
       for lsyst,nofloat,pdf0,args0,errline0 in (datacard.systs[:]):
         i+=1
         if lsyst == oldname : # found the nuisance


### PR DESCRIPTION
If the substring "Pdf" is in the new name of a `nuisance edit rename` then there seems to be errors in the Constraint Pdf production. For now, this will cause the python to exit if "Pdf" is in the name. 