### PR TITLE
Moving to single-character branch types in FitDiagnostics

### DIFF
--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -1039,28 +1039,28 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 	 t_fit_b_  = new TTree("tree_fit_b","tree_fit_b");
 	 t_fit_sb_ = new TTree("tree_fit_sb","tree_fit_sb");
 
-    	 t_fit_b_->Branch("fit_status",&fitStatus_,"fit_status/Int_t");
-   	 t_fit_sb_->Branch("fit_status",&fitStatus_,"fit_status/Int_t");
+    	 t_fit_b_->Branch("fit_status",&fitStatus_,"fit_status/I");
+   	 t_fit_sb_->Branch("fit_status",&fitStatus_,"fit_status/I");
 
-	 t_fit_b_->Branch(poiName.c_str(),&mu_,Form("%s/Double_t",poiName.c_str()));
-	 t_fit_sb_->Branch(poiName.c_str(),&mu_,Form("%s/Double_t",poiName.c_str()));
+	 t_fit_b_->Branch(poiName.c_str(),&mu_,Form("%s/D",poiName.c_str()));
+	 t_fit_sb_->Branch(poiName.c_str(),&mu_,Form("%s/D",poiName.c_str()));
 	 
-	 t_fit_b_->Branch(Form("%sErr",poiName.c_str()),&muErr_,Form("%sErr/Double_t",poiName.c_str()));
-	 t_fit_sb_->Branch(Form("%sErr",poiName.c_str()),&muErr_,Form("%sErr/Double_t",poiName.c_str()));
+	 t_fit_b_->Branch(Form("%sErr",poiName.c_str()),&muErr_,Form("%sErr/D",poiName.c_str()));
+	 t_fit_sb_->Branch(Form("%sErr",poiName.c_str()),&muErr_,Form("%sErr/D",poiName.c_str()));
 
-	 t_fit_b_->Branch(Form("%sLoErr",poiName.c_str()),&muLoErr_,Form("%sLoErr/Double_t",poiName.c_str()));
-	 t_fit_sb_->Branch(Form("%sLoErr",poiName.c_str()),&muLoErr_,Form("%sLoErr/Double_t",poiName.c_str()));
+	 t_fit_b_->Branch(Form("%sLoErr",poiName.c_str()),&muLoErr_,Form("%sLoErr/D",poiName.c_str()));
+	 t_fit_sb_->Branch(Form("%sLoErr",poiName.c_str()),&muLoErr_,Form("%sLoErr/D",poiName.c_str()));
 
-	 t_fit_b_->Branch(Form("%sHiErr",poiName.c_str()),&muHiErr_,Form("%sHiErr/Double_t",poiName.c_str()));
-	 t_fit_sb_->Branch(Form("%sHiErr",poiName.c_str()),&muHiErr_,Form("%sHiErr/Double_t",poiName.c_str()));
+	 t_fit_b_->Branch(Form("%sHiErr",poiName.c_str()),&muHiErr_,Form("%sHiErr/D",poiName.c_str()));
+	 t_fit_sb_->Branch(Form("%sHiErr",poiName.c_str()),&muHiErr_,Form("%sHiErr/D",poiName.c_str()));
 
-	 t_fit_b_->Branch("numbadnll",&numbadnll_,"numbadnll/Int_t");
-	 t_fit_sb_->Branch("numbadnll",&numbadnll_,"numbadnll/Int_t");
+	 t_fit_b_->Branch("numbadnll",&numbadnll_,"numbadnll/I");
+	 t_fit_sb_->Branch("numbadnll",&numbadnll_,"numbadnll/I");
 
-	 t_fit_b_->Branch("nll_min",&nll_bonly_,"nll_min/Double_t");
-	 t_fit_sb_->Branch("nll_min",&nll_sb_,"nll_min/Double_t");
+	 t_fit_b_->Branch("nll_min",&nll_bonly_,"nll_min/D");
+	 t_fit_sb_->Branch("nll_min",&nll_sb_,"nll_min/D");
 
-	 t_fit_sb_->Branch("nll_nll0",&nll_nll0_,"nll_nll0/Double_t");
+	 t_fit_sb_->Branch("nll_nll0",&nll_nll0_,"nll_nll0/D");
 
 	 int count=0; 
          // fill the maps for the nuisances, and global observables
@@ -1104,9 +1104,9 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
                  RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);        
 		 std::string name = rrv->GetName();
 		 globalObservables_[count]=0;
-		 t_fit_sb_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/Double_t",name.c_str()));
-		 t_fit_b_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/Double_t",name.c_str()));
-		 t_prefit_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/Double_t",name.c_str()));
+		 t_fit_sb_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/D",name.c_str()));
+		 t_fit_b_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/D",name.c_str()));
+		 t_prefit_->Branch(name.c_str(),&(globalObservables_[count]),Form("%s/D",name.c_str()));
 		 count++;
 	  }         
 	  count = 0;
@@ -1115,9 +1115,9 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
                  RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);        
 		 std::string name = rrv->GetName();
 		 nuisanceParameters_[count] = 0;
-		 t_fit_sb_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/Double_t",name.c_str()));
-		 t_fit_b_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/Double_t",name.c_str()));
-		 t_prefit_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/Double_t",name.c_str()));
+		 t_fit_sb_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/D",name.c_str()));
+		 t_fit_b_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/D",name.c_str()));
+		 t_prefit_->Branch(name.c_str(),&(nuisanceParameters_[count]),Form("%s/D",name.c_str()));
 		 count++;
           }
 
@@ -1130,9 +1130,9 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 		 std::string name = rcv->GetName();
 		 processNormalizations_[count] = -999;
 		 //std::cout << " Creating the TREE -- " << count << ", Branch Name =  " << name << ", Param name " << rcv->GetName() << std::endl; 
-		 t_fit_sb_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/Double_t",name.c_str()));
-		 t_fit_b_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/Double_t",name.c_str()));
-		 t_prefit_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/Double_t",name.c_str()));
+		 t_fit_sb_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/D",name.c_str()));
+		 t_fit_b_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/D",name.c_str()));
+		 t_prefit_->Branch(name.c_str(),&(processNormalizations_[count]),Form("%s/D",name.c_str()));
 		 count++;
          }
 	 count = 0;
@@ -1145,9 +1145,9 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 		 for (int iBin = 1; iBin <= bins; iBin++){
 		     processNormalizationsShapes_[count] = -999;
 		     TString label = Form("%s_%d",pair->first.c_str(),iBin);
-		     t_fit_sb_->Branch(label,&(processNormalizationsShapes_[count]),label+"/Double_t");
-		     t_fit_b_->Branch(label,&(processNormalizationsShapes_[count]),label+"/Double_t");
-		     t_prefit_->Branch(label,&(processNormalizationsShapes_[count]),label+"/Double_t");
+		     t_fit_sb_->Branch(label,&(processNormalizationsShapes_[count]),label+"/D");
+		     t_fit_b_->Branch(label,&(processNormalizationsShapes_[count]),label+"/D");
+		     t_prefit_->Branch(label,&(processNormalizationsShapes_[count]),label+"/D");
 		     count++;
 		 }
 		delete hist;


### PR DESCRIPTION
The ROOT version used in CMSSW_102X in principle still supports multi-character branch types, but sends a warning every time a branch is declared in this way. Moving to single-character types to avoid a screen full of warnings.