### PR TITLE
Replace auto_ptr with unique_ptr

### DIFF
--- a/interface/AsymptoticLimits.h
+++ b/interface/AsymptoticLimits.h
@@ -55,10 +55,10 @@ private:
 
   bool    hasFloatParams_;
   bool    hasDiscreteParams_;
-  mutable std::auto_ptr<RooArgSet>  params_;
-  mutable std::auto_ptr<RooAbsReal> nllD_, nllA_; 
-  //mutable std::auto_ptr<RooFitResult> fitFreeD_, fitFreeA_;
-  //mutable std::auto_ptr<RooFitResult> fitFixD_,  fitFixA_;
+  mutable std::unique_ptr<RooArgSet>  params_;
+  mutable std::unique_ptr<RooAbsReal> nllD_, nllA_; 
+  //mutable std::unique_ptr<RooFitResult> fitFreeD_, fitFreeA_;
+  //mutable std::unique_ptr<RooFitResult> fitFixD_,  fitFixA_;
   utils::CheapValueSnapshot fitFreeD_, fitFreeA_, fitFixD_,  fitFixA_;
 
   mutable double                      minNllD_,  minNllA_, rBestD_;

--- a/interface/BestFitSigmaTestStat.h
+++ b/interface/BestFitSigmaTestStat.h
@@ -29,8 +29,8 @@ class BestFitSigmaTestStat : public RooStats::TestStatistic {
 
         RooAbsPdf *pdf_;
         RooArgSet snap_, poi_, nuisances_; 
-        std::auto_ptr<RooArgSet> params_;
-        std::auto_ptr<RooAbsReal> nll_;
+        std::unique_ptr<RooArgSet> params_;
+        std::unique_ptr<RooAbsReal> nll_;
         Int_t verbosity_;
 
         // create NLL. if returns true, it can be kept, if false it should be deleted at the end of Evaluate

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -186,14 +186,14 @@ class CachingSimNLL  : public RooAbsReal {
         const RooArgSet   *nuis_;
         RooSetProxy        params_;
         RooArgSet piecesForCloning_;
-        std::auto_ptr<RooSimultaneous>  factorizedPdf_;
+        std::unique_ptr<RooSimultaneous>  factorizedPdf_;
         std::vector<RooAbsPdf *>        constrainPdfs_;
         std::vector<SimpleGaussianConstraint *>  constrainPdfsFast_;
         std::vector<bool>                        constrainPdfsFastOwned_;
         std::vector<SimplePoissonConstraint *>   constrainPdfsFastPoisson_;
         std::vector<bool>                        constrainPdfsFastPoissonOwned_;
         std::vector<CachingAddNLL*>     pdfs_;
-        std::auto_ptr<TList>            dataSets_;
+        std::unique_ptr<TList>            dataSets_;
         std::vector<RooDataSet *>       datasets_;
         static bool noDeepLEE_;
         static bool hasError_;

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -43,7 +43,7 @@ class CascadeMinimizer {
 	std::string algo() {return defaultMinimizerAlgo_;};
     private:
         RooAbsReal & nll_;
-        std::auto_ptr<RooMinimizer> minimizer_;
+        std::unique_ptr<RooMinimizer> minimizer_;
         Mode         mode_;
         static int          strategy_;
         RooRealVar * poi_; 

--- a/interface/DebugProposal.h
+++ b/interface/DebugProposal.h
@@ -14,7 +14,7 @@ class RooAbsData;
 class DebugProposal : public RooStats::ProposalFunction {
 
    public:
-      DebugProposal() : RooStats::ProposalFunction(), prop_(0), nll_(0), params_(), tries_(0)  {}
+      DebugProposal() : RooStats::ProposalFunction(), prop_(0), nll_(nullptr), params_(), tries_(0)  {}
       DebugProposal(RooStats::ProposalFunction *p, RooAbsPdf *pdf, RooAbsData *data, int tries) ;
 
       // Populate xPrime with a new proposed point
@@ -35,7 +35,7 @@ class DebugProposal : public RooStats::ProposalFunction {
 
     private:
         RooStats::ProposalFunction *prop_;
-        std::auto_ptr<RooAbsReal> nll_;
+        std::unique_ptr<RooAbsReal> nll_;
         RooAbsPdf                 *pdf_;
         RooArgSet                 params_;
         int  tries_;

--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -57,7 +57,7 @@ protected:
   int overallBins_,overallNorms_,overallNuis_,overallCons_;
   int fitStatus_, numbadnll_;
   double mu_, muErr_, muLoErr_, muHiErr_, nll_nll0_, nll_bonly_, nll_sb_;
-  std::auto_ptr<TFile> fitOut;
+  std::unique_ptr<TFile> fitOut;
   double* globalObservables_;
   double* nuisanceParameters_;
   double* processNormalizations_;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -50,7 +50,7 @@ protected:
   static std::string autoBoundsPOIs_, autoMaxPOIs_;
   RooArgSet autoBoundsPOISet_, autoMaxPOISet_;
   static double nllValue_, nll0Value_;
-  std::auto_ptr<RooAbsReal> nll;
+  std::unique_ptr<RooAbsReal> nll;
   // method that is implemented in the subclass
   virtual bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) = 0;
 

--- a/interface/HybridNew.h
+++ b/interface/HybridNew.h
@@ -77,20 +77,20 @@ private:
 
   static double EPS;
   // graph, used to compute the limit, not just for plotting!
-  std::auto_ptr<TGraphErrors> limitPlot_;
+  std::unique_ptr<TGraphErrors> limitPlot_;
  
   // performance counter: remember how many toys have been thrown
   unsigned int perf_totalToysRun_;
 
   //----- extra variables used for cross-checking the implementation of frequentist toy tossing in RooStats
   // mutable RooAbsData *realData_;
-  // std::auto_ptr<RooAbsCollection>  snapGlobalObs_;
+  // std::unique_ptr<RooAbsCollection>  snapGlobalObs_;
 
   struct Setup {
     RooStats::ModelConfig modelConfig, modelConfig_bonly;
-    std::auto_ptr<RooStats::TestStatistic> qvar;
-    std::auto_ptr<RooStats::ToyMCSampler>  toymcsampler;
-    std::auto_ptr<RooStats::ProofConfig> pc;
+    std::unique_ptr<RooStats::TestStatistic> qvar;
+    std::unique_ptr<RooStats::ToyMCSampler>  toymcsampler;
+    std::unique_ptr<RooStats::ProofConfig> pc;
     RooArgSet cleanupList;
   };
 
@@ -105,9 +105,9 @@ private:
   std::pair<double,double> eval(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double rVal, bool adaptive=false, double clsTarget=-1)  ;
 
   /// generic version
-  std::auto_ptr<RooStats::HybridCalculator> create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, const RooAbsCollection & rVals, Setup &setup);
+  std::unique_ptr<RooStats::HybridCalculator> create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, const RooAbsCollection & rVals, Setup &setup);
   /// specific version used in unidimensional searches (calls the generic one)
-  std::auto_ptr<RooStats::HybridCalculator> create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double rVal, Setup &setup);
+  std::unique_ptr<RooStats::HybridCalculator> create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double rVal, Setup &setup);
 
   std::pair<double,double> eval(RooStats::HybridCalculator &hc, const RooAbsCollection & rVals, bool adaptive=false, double clsTarget=-1) ;
 

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -38,7 +38,7 @@ protected:
   static float                     deltaNLL_;
 
   static std::string name_;
-  std::auto_ptr<TFile> fitOut;
+  std::unique_ptr<TFile> fitOut;
 
   // options    
   static unsigned int points_, firstPoint_, lastPoint_;

--- a/interface/ProfiledLikelihoodRatioTestStat.h
+++ b/interface/ProfiledLikelihoodRatioTestStat.h
@@ -29,7 +29,7 @@ class ProfiledLikelihoodRatioTestStat : public RooStats::TestStatistic {
         RooAbsPdf *pdfNull_, *pdfAlt_;
         RooArgSet snapNull_, snapAlt_; 
         RooArgSet nuisances_; 
-        std::auto_ptr<RooArgSet> paramsNull_, paramsAlt_;
+        std::unique_ptr<RooArgSet> paramsNull_, paramsAlt_;
 }; // TestSimpleStatistics
 
 

--- a/interface/ProfiledLikelihoodRatioTestStatExt.h
+++ b/interface/ProfiledLikelihoodRatioTestStatExt.h
@@ -35,14 +35,14 @@ class ProfiledLikelihoodRatioTestStatOpt : public RooStats::TestStatistic {
         RooAbsPdf *pdfNull_, *pdfAlt_;
         RooArgSet snapNull_, snapAlt_; 
         RooArgSet nuisances_; 
-        std::auto_ptr<RooArgSet> paramsNull_, paramsAlt_;
-        std::auto_ptr<RooAbsReal> nllNull_, nllAlt_;
+        std::unique_ptr<RooArgSet> paramsNull_, paramsAlt_;
+        std::unique_ptr<RooAbsReal> nllNull_, nllAlt_;
         Int_t verbosity_;
 
         // create NLL. if returns true, it can be kept, if false it should be deleted at the end of Evaluate
-        bool createNLL(RooAbsPdf &pdf, RooAbsData &data, std::auto_ptr<RooAbsReal> &nll) ;
+        bool createNLL(RooAbsPdf &pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &nll) ;
 
-        double minNLL(std::auto_ptr<RooAbsReal> &nll) ;
+        double minNLL(std::unique_ptr<RooAbsReal> &nll) ;
 }; // TestSimpleStatistics
 
 
@@ -68,10 +68,10 @@ class ProfiledLikelihoodTestStatOpt : public RooStats::TestStatistic {
 
         RooAbsPdf *pdf_;
         RooArgSet snap_, poi_; // snapshot of parameters, and of the subset which are POI
-        std::auto_ptr<RooArgSet>  params_;
+        std::unique_ptr<RooArgSet>  params_;
         RooArgSet                 nuisances_; // subset of params which are nuisances (not a snapshot)
         RooArgSet                 poiParams_; // subset of params which are POI (not a snapshot)
-        std::auto_ptr<RooAbsReal> nll_;
+        std::unique_ptr<RooAbsReal> nll_;
         RooArgList gobsParams_, gobs_;
         Int_t verbosity_;
         OneSidedness oneSided_;

--- a/interface/SequentialMinimizer.h
+++ b/interface/SequentialMinimizer.h
@@ -171,7 +171,7 @@ namespace cmsmath {
             bool improve(int smallsteps=5);
             bool doFullMinim(); 
 
-            std::auto_ptr<MinimizerContext> func_;
+            std::unique_ptr<MinimizerContext> func_;
             unsigned int nDim_, nFree_;
 
             // status information
@@ -183,7 +183,7 @@ namespace cmsmath {
             State state_;
 
             // ROOT::Math::Minimizer for strategy 2
-            std::auto_ptr<ROOT::Math::Minimizer> fullMinimizer_;
+            std::unique_ptr<ROOT::Math::Minimizer> fullMinimizer_;
             std::vector<int> subspaceIndices_;
                     
     };

--- a/interface/SimplerLikelihoodRatioTestStat.h
+++ b/interface/SimplerLikelihoodRatioTestStat.h
@@ -42,7 +42,7 @@ class SimplerLikelihoodRatioTestStat : public RooStats::TestStatistic {
     private:
         RooAbsPdf *pdfNull_, *pdfAlt_;
         RooArgSet snapNull_, snapAlt_; 
-        std::auto_ptr<RooArgSet> paramsNull_, paramsAlt_;
+        std::unique_ptr<RooArgSet> paramsNull_, paramsAlt_;
 }; // TestSimpleStatistics
 
 #endif

--- a/interface/SimplerLikelihoodRatioTestStatExt.h
+++ b/interface/SimplerLikelihoodRatioTestStatExt.h
@@ -59,9 +59,9 @@ class SimplerLikelihoodRatioTestStatOpt : public RooStats::TestStatistic {
         /// snapshots of parameters for the two pdfs
         RooArgSet snapNull_, snapAlt_; 
         /// parameter sets to apply snapshots to
-        std::auto_ptr<RooArgSet> paramsNull_, paramsAlt_;
+        std::unique_ptr<RooArgSet> paramsNull_, paramsAlt_;
         /// owned copy of the pdfs after factorizing
-        std::auto_ptr<RooAbsPdf> pdfNullOwned_, pdfAltOwned_;
+        std::unique_ptr<RooAbsPdf> pdfNullOwned_, pdfAltOwned_;
         /// pdfNull, pdfAlt cast to sympdf (may be null) after factorization
         RooSimultaneous *simPdfNull_, *simPdfAlt_;
         /// components of the sim pdfs after factorization, for each bin in sim. category. can contain nulls
@@ -91,8 +91,8 @@ class SimplerLikelihoodRatioTestStatExt : public RooStats::TestStatistic {
     private:
         RooAbsPdf *pdfNull_, *pdfAlt_;
         RooArgSet snapNull_, snapAlt_; 
-        std::auto_ptr<RooArgSet> paramsNull_, paramsAlt_;
-        std::auto_ptr<RooAbsPdf> pdfNullOwned_, pdfAltOwned_;
+        std::unique_ptr<RooArgSet> paramsNull_, paramsAlt_;
+        std::unique_ptr<RooAbsPdf> pdfNullOwned_, pdfAltOwned_;
 }; // TestSimpleStatistics
 #endif
 

--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -78,7 +78,7 @@ class ToyMCSamplerOpt : public RooStats::ToyMCSampler{
         mutable RooRealVar *weightVar_;
         mutable std::map<RooAbsPdf *, toymcoptutils::SimPdfGenInfo *> genCache_;
 
-        mutable std::auto_ptr<RooArgSet> paramsForImportanceSampling_;
+        mutable std::unique_ptr<RooArgSet> paramsForImportanceSampling_;
         mutable std::vector<RooArgSet *> importanceSnapshots_;
 };
 

--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -21,7 +21,7 @@ RooAbsData *asimovutils::asimovDatasetNominal(RooStats::ModelConfig *mc, double 
 
 	if (verbose>2) {
 	    Logger::instance().log(std::string(Form("AsimovUtils.cc: %d -- Parameters after fit for asimov dataset",__LINE__)),Logger::kLogLevelInfo,__func__);
-    	    std::auto_ptr<TIterator> iter(mc->GetPdf()->getParameters((const RooArgSet*) 0)->createIterator());
+    	    std::unique_ptr<TIterator> iter(mc->GetPdf()->getParameters((const RooArgSet*) 0)->createIterator());
     	    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	Logger::instance().log(std::string(Form("AsimovUtils.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -44,8 +44,8 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                 needsFit &= true;
             } else {
                 // Do we have free parameters anyway that need fitting?
-                std::auto_ptr<RooArgSet> params(mc->GetPdf()->getParameters(realdata));
-                std::auto_ptr<TIterator> iter(params->createIterator());
+                std::unique_ptr<RooArgSet> params(mc->GetPdf()->getParameters(realdata));
+                std::unique_ptr<TIterator> iter(params->createIterator());
                 for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
                     RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
                     if ( rrv != 0 && rrv->isConstant() == false ) { needsFit &= true; break; }
@@ -54,7 +54,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
             if (needsFit) {
                 //mc->GetPdf()->fitTo(realdata, RooFit::Minimizer("Minuit2","minimize"), RooFit::Strategy(1), RooFit::Constrain(*mc->GetNuisanceParameters()));
                 const RooCmdArg &constrain = (mc->GetNuisanceParameters() ? RooFit::Constrain(*mc->GetNuisanceParameters()) : RooCmdArg());
-                std::auto_ptr<RooAbsReal> nll(mc->GetPdf()->createNLL(realdata, constrain, RooFit::Extended(mc->GetPdf()->canBeExtended())));
+                std::unique_ptr<RooAbsReal> nll(mc->GetPdf()->createNLL(realdata, constrain, RooFit::Extended(mc->GetPdf()->canBeExtended())));
                 CascadeMinimizer minim(*nll, CascadeMinimizer::Constrained);
                 minim.setStrategy(1);
                 minim.minimize(verbose-1);
@@ -67,7 +67,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
 
 	if (verbose>2) { 
 	    Logger::instance().log(std::string(Form("AsimovUtils.cc: %d -- Parameters after fit for asimov dataset",__LINE__)),Logger::kLogLevelInfo,__func__);
-    	    std::auto_ptr<TIterator> iter(mc->GetPdf()->getParameters(realdata)->createIterator());
+    	    std::unique_ptr<TIterator> iter(mc->GetPdf()->getParameters(realdata)->createIterator());
     	    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	Logger::instance().log(std::string(Form("AsimovUtils.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -89,17 +89,17 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
             gobs.snapshot(snapGlobalObsData);
 
             RooArgSet nuis(*mc->GetNuisanceParameters());
-            std::auto_ptr<RooAbsPdf> nuispdf(utils::makeNuisancePdf(*mc));
+            std::unique_ptr<RooAbsPdf> nuispdf(utils::makeNuisancePdf(*mc));
             RooProdPdf *prod = dynamic_cast<RooProdPdf *>(nuispdf.get());
             if (prod == 0) throw std::runtime_error("AsimovUtils: the nuisance pdf is not a RooProdPdf!");
-            std::auto_ptr<TIterator> iter(prod->pdfList().createIterator());
+            std::unique_ptr<TIterator> iter(prod->pdfList().createIterator());
             for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
                 RooAbsPdf *cterm = dynamic_cast<RooAbsPdf *>(a); 
                 if (!cterm) throw std::logic_error("AsimovUtils: a factor of the nuisance pdf is not a Pdf!");
                 if (!cterm->dependsOn(nuis)) continue; // dummy constraints
                 if (typeid(*cterm) == typeid(RooUniform)) continue;
-                std::auto_ptr<RooArgSet> cpars(cterm->getParameters(&gobs));
-                std::auto_ptr<RooArgSet> cgobs(cterm->getObservables(&gobs));
+                std::unique_ptr<RooArgSet> cpars(cterm->getParameters(&gobs));
+                std::unique_ptr<RooArgSet> cgobs(cterm->getObservables(&gobs));
                 if (cgobs->getSize() != 1) {
                     throw std::runtime_error(Form("AsimovUtils: constraint term %s has multiple global observables", cterm->GetName()));
                 }
@@ -109,7 +109,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                 if (cpars->getSize() == 1) {
                     match = dynamic_cast<RooAbsReal *>(cpars->first());
                 } else {
-                    std::auto_ptr<TIterator> iter2(cpars->createIterator());
+                    std::unique_ptr<TIterator> iter2(cpars->createIterator());
                     for (RooAbsArg *a2 = (RooAbsArg *) iter2->Next(); a2 != 0; a2 = (RooAbsArg *) iter2->Next()) {
                         RooRealVar *rrv2 = dynamic_cast<RooRealVar *>(a2); 
                         if (rrv2 != 0 && !rrv2->isConstant()) {
@@ -139,7 +139,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                     // of the nuisance is the best fit one.
                     // best fit x = (k-1)*theta    ---->  k = x/theta + 1
                     RooArgList leaves; cterm->leafNodeServerList(&leaves);
-                    std::auto_ptr<TIterator> iter2(leaves.createIterator());
+                    std::unique_ptr<TIterator> iter2(leaves.createIterator());
                     RooAbsReal *match2 = 0;
                     for (RooAbsArg *a2 = (RooAbsArg *) iter2->Next(); a2 != 0; a2 = (RooAbsArg *) iter2->Next()) {
                         RooAbsReal *rar = dynamic_cast<RooAbsReal *>(a2);

--- a/src/AsymptoticLimits.cc
+++ b/src/AsymptoticLimits.cc
@@ -107,7 +107,7 @@ bool AsymptoticLimits::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
     */
     hasDiscreteParams_ = false;  
     if (params_.get() == 0) params_.reset(mc_s->GetPdf()->getParameters(data));
-    std::auto_ptr<TIterator> itparam(params_->createIterator());
+    std::unique_ptr<TIterator> itparam(params_->createIterator());
     for (RooAbsArg *a = (RooAbsArg *) itparam->Next(); a != 0; a = (RooAbsArg *) itparam->Next()) {
       if (a->IsA()->InheritsFrom(RooCategory::Class())) { hasDiscreteParams_ = true; break; }
     }
@@ -164,7 +164,7 @@ bool AsymptoticLimits::runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, Ro
   if (params_.get() == 0) params_.reset(mc_s->GetPdf()->getParameters(data));
 
   hasFloatParams_ = false;
-  std::auto_ptr<TIterator> itparam(params_->createIterator());
+  std::unique_ptr<TIterator> itparam(params_->createIterator());
   for (RooAbsArg *a = (RooAbsArg *) itparam->Next(); a != 0; a = (RooAbsArg *) itparam->Next()) {
       RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
       if ( rrv != 0 && rrv != r && rrv->isConstant() == false ) { hasFloatParams_ = true; break; }
@@ -403,7 +403,7 @@ std::vector<std::pair<float,float> > AsymptoticLimits::runLimitExpected(RooWorks
     r->setError(0.1*r->getMax());
     //r->removeMax();
     
-    std::auto_ptr<RooAbsReal> nll(mc_s->GetPdf()->createNLL(*asimov, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
+    std::unique_ptr<RooAbsReal> nll(mc_s->GetPdf()->createNLL(*asimov, RooFit::Constrain(*mc_s->GetNuisanceParameters())));
     CascadeMinimizer minim(*nll, CascadeMinimizer::Unconstrained, r);
     //minim.setStrategy(minimizerStrategy_);
     minim.setErrorLevel(0.5*pow(ROOT::Math::normal_quantile(1-0.5*(1-cl),1.0), 2)); // the 0.5 is because qmu is -2*NLL
@@ -413,7 +413,7 @@ std::vector<std::pair<float,float> > AsymptoticLimits::runLimitExpected(RooWorks
     sentry.clear();
     if (verbose > 1) {
         std::cout << "Fit to asimov dataset:" << std::endl;
-        std::auto_ptr<RooFitResult> res(minim.save());
+        std::unique_ptr<RooFitResult> res(minim.save());
         res->Print("V");
     }
     if (r->getVal()/r->getMax() > 1e-3) {

--- a/src/AtlasPdfs.cxx
+++ b/src/AtlasPdfs.cxx
@@ -700,8 +700,8 @@ Double_t RooBSpline::analyticalIntegralWN(Int_t code, const RooArgSet* /*normSet
      if (cache==0) {
        // cache got sterilized, trigger repopulation of this slot, then try again...
        //std::cout << "Cache got sterilized" << std::endl;
-       std::auto_ptr<RooArgSet> vars( getParameters(RooArgSet()) );
-       std::auto_ptr<RooArgSet> iset(  _cacheMgr.nameSet2ByIndex(code-2)->select(*vars) );
+       std::unique_ptr<RooArgSet> vars( getParameters(RooArgSet()) );
+       std::unique_ptr<RooArgSet> iset(  _cacheMgr.nameSet2ByIndex(code-2)->select(*vars) );
        RooArgSet dummy;
        Int_t code2 = getAnalyticalIntegral(*iset,dummy,rangeName);
        assert(code==code2); // must have revived the right (sterilized) slot...

--- a/src/BayesianFlatPrior.cc
+++ b/src/BayesianFlatPrior.cc
@@ -42,7 +42,7 @@ bool BayesianFlatPrior::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooSta
 
   RooRealVar *r = dynamic_cast<RooRealVar *>(poi.first());
   double rMax = r->getMax();
-  std::auto_ptr<RooStats::ModelConfig> mc_noNuis(0);
+  std::unique_ptr<RooStats::ModelConfig> mc_noNuis{nullptr};
   if (!withSystematics && mc_s->GetNuisanceParameters() != 0) {
     mc_noNuis.reset(new RooStats::ModelConfig(w));
     mc_noNuis->SetPdf(*mc_s->GetPdf());
@@ -55,7 +55,7 @@ bool BayesianFlatPrior::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooSta
     BayesianCalculator bcalc(data, *mc_s);
     bcalc.SetLeftSideTailFraction(0);
     bcalc.SetConfidenceLevel(cl); 
-    std::auto_ptr<SimpleInterval> bcInterval(bcalc.GetInterval());
+    std::unique_ptr<SimpleInterval> bcInterval(bcalc.GetInterval());
     if (bcInterval.get() == 0) return false;
     limit = bcInterval->UpperLimit();
     if (limit >= 0.5*r->getMax()) { 
@@ -71,7 +71,7 @@ bool BayesianFlatPrior::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooSta
     if (verbose > 200) {
       // FIXME!!!!!
       TCanvas c1("c1", "c1");
-      std::auto_ptr<RooPlot> bcPlot(bcalc.GetPosteriorPlot(true, 0.1)); 
+      std::unique_ptr<RooPlot> bcPlot(bcalc.GetPosteriorPlot(true, 0.1)); 
       bcPlot->Draw(); 
       c1.Print("plots/bc_plot.png");
     }

--- a/src/BayesianToyMC.cc
+++ b/src/BayesianToyMC.cc
@@ -61,7 +61,7 @@ bool BayesianToyMC::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
   }
   double rMax = r->getMax();
   
-  std::auto_ptr<RooStats::ModelConfig> mc_noNuis(0);
+  std::unique_ptr<RooStats::ModelConfig> mc_noNuis{nullptr};
   if (!withSystematics && mc_s->GetNuisanceParameters() != 0) {
     mc_noNuis.reset(new RooStats::ModelConfig(w));
     mc_noNuis->SetPdf(*mc_s->GetPdf());
@@ -70,7 +70,7 @@ bool BayesianToyMC::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
     mc_noNuis->SetPriorPdf(*mc_s->GetPriorPdf());
     mc_s = mc_noNuis.get();
   }
-  std::auto_ptr<RooAbsPdf> nuisancePdf;
+  std::unique_ptr<RooAbsPdf> nuisancePdf;
   for (;;) {
     limit = 0; limitErr = 0; bool rerun = false;
     for (unsigned int i = 0; i < tries_; ++i) {
@@ -87,7 +87,7 @@ bool BayesianToyMC::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::
             cacheutils::CachingSimNLL::forceUnoptimizedConstraints();
         }
         // get the interval
-        std::auto_ptr<SimpleInterval> bcInterval(bcalc.GetInterval());
+        std::unique_ptr<SimpleInterval> bcInterval(bcalc.GetInterval());
         if (bcInterval.get() == 0) return false;
         double lim = bcInterval->UpperLimit();
         // check against bound
@@ -147,7 +147,7 @@ bool BayesianToyMC::runBayesFactor(RooWorkspace *w, RooStats::ModelConfig *mc_s,
 std::pair<double,double> BayesianToyMC::priorPredictiveDistribution(RooStats::ModelConfig *mc, RooAbsData &data, const RooArgSet *point, double *offset) {
   // factorize away nuisance pdf
   RooAbsPdf *pdf = mc->GetPdf();
-  std::auto_ptr<RooAbsPdf>  nuisancePdf, nonNuisancePdf; 
+  std::unique_ptr<RooAbsPdf>  nuisancePdf, nonNuisancePdf; 
   if (withSystematics) {
     RooArgList constraints;
     nonNuisancePdf.reset(utils::factorizePdf(*data.get(), *pdf, constraints));
@@ -159,8 +159,8 @@ std::pair<double,double> BayesianToyMC::priorPredictiveDistribution(RooStats::Mo
   std::cout << "Factorized PDF, now creating NLL" << std::endl;
   // create NLL
   const RooCmdArg &constrain  = withSystematics  ? RooFit::Constrain(*mc->GetNuisanceParameters()) : RooCmdArg::none();
-  std::auto_ptr<RooAbsReal> nll(pdf->createNLL(data, constrain, RooFit::Extended(pdf->canBeExtended())));
-  std::auto_ptr<RooArgSet>  params(nll->getParameters(data));
+  std::unique_ptr<RooAbsReal> nll(pdf->createNLL(data, constrain, RooFit::Extended(pdf->canBeExtended())));
+  std::unique_ptr<RooArgSet>  params(nll->getParameters(data));
 
   // Determine which POIs we have to generate, if any
   RooArgSet poiToGen; 
@@ -181,7 +181,7 @@ std::pair<double,double> BayesianToyMC::priorPredictiveDistribution(RooStats::Mo
   // start running
   std::vector<double> results; double sum = 0;
   for (unsigned int t = 0; t < tries_; ++t) {
-      std::auto_ptr<RooDataSet> nuisanceValues, poiValues;
+      std::unique_ptr<RooDataSet> nuisanceValues, poiValues;
       if (withSystematics) nuisanceValues.reset(nuisancePdf->generate(*mc->GetNuisanceParameters(), numIters_));
       if (poiToGen.getSize() > 0) {
         if (mc->GetPriorPdf() == 0) throw std::logic_error(std::string("Missing prior in model: ")+ mc->GetName());

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -114,7 +114,7 @@ namespace { unsigned long CachingSimNLLEvalCount = 0; }
 
 cacheutils::ArgSetChecker::ArgSetChecker(const RooAbsCollection &set) 
 {
-    std::auto_ptr<TIterator> iter(set.createIterator());
+    std::unique_ptr<TIterator> iter(set.createIterator());
     for (RooAbsArg *a  = dynamic_cast<RooAbsArg *>(iter->Next()); 
                     a != 0; 
                     a  = dynamic_cast<RooAbsArg *>(iter->Next())) {
@@ -176,7 +176,7 @@ cacheutils::ValuesCache::ValuesCache(const RooAbsReal &pdf, const RooArgSet &obs
     directMode_(false)
 {
     assert(size <= MaxItems_);
-    std::auto_ptr<RooArgSet> params(pdf.getParameters(obs));
+    std::unique_ptr<RooArgSet> params(pdf.getParameters(obs));
     //std::cout << "Parameters for pdf " << pdf.GetName() << " (" << pdf.ClassName() << "):"; params->Print("");
     items[0] = new Item(*params);
 }
@@ -476,7 +476,7 @@ cacheutils::makeCachingPdf(RooAbsReal *pdf, const RooArgSet *obs) {
     } else if (cbNll && typeid(*pdf) == typeid(RooCBShape)) {
         return new CachingCBPdf(pdf, obs);
     } else if (gaussNll && typeid(*pdf) == typeid(RooExponential)) {
-	std::auto_ptr<RooArgSet> params(pdf->getParameters(obs));
+	std::unique_ptr<RooArgSet> params(pdf->getParameters(obs));
 	if(params->getSize()!=1) {return new CachingPdf(pdf,obs);}
         return new CachingExpoPdf(pdf, obs);
     } else if (gaussNll && typeid(*pdf) == typeid(RooPower)) {
@@ -564,8 +564,8 @@ cacheutils::CachingAddNLL::setup_()
         throw std::invalid_argument(errmsg);
     }
 
-    std::auto_ptr<RooArgSet> params(pdf_->getParameters(*data_));
-    std::auto_ptr<TIterator> iter(params->createIterator());
+    std::unique_ptr<RooArgSet> params(pdf_->getParameters(*data_));
+    std::unique_ptr<TIterator> iter(params->createIterator());
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         //if (rrv != 0 && !rrv->isConstant()) params_.add(*rrv);
@@ -887,7 +887,7 @@ cacheutils::CachingSimNLL::setup_()
 
     //---- Instead of getting the parameters here, we get them from the individual constraint terms and single pdfs ----
     //---- This seems to save memory.
-    //std::auto_ptr<RooArgSet> params(pdfclone->getParameters(*dataOriginal_));
+    //std::unique_ptr<RooArgSet> params(pdfclone->getParameters(*dataOriginal_));
     //params_.add(*params);
     static bool verb  = runtimedef::get("ADDNLL_VERBOSE_CACHING");
 
@@ -939,7 +939,7 @@ cacheutils::CachingSimNLL::setup_()
                 constrainZeroPoints_.push_back(0);
             }
             //std::cout << "Constraint pdf: " << constraints.at(i)->GetName() << std::endl;
-            std::auto_ptr<RooArgSet> params(pdfi->getParameters(*dataOriginal_));
+            std::unique_ptr<RooArgSet> params(pdfi->getParameters(*dataOriginal_));
             params_.add(*params, false);
         }
         if (verb) {
@@ -951,7 +951,7 @@ cacheutils::CachingSimNLL::setup_()
     } else {
         std::cerr << "PDF didn't factorize!" << std::endl;
         std::cout << "Parameters: " << std::endl;
-        std::auto_ptr<RooArgSet> params(pdfclone->getParameters(*dataOriginal_));
+        std::unique_ptr<RooArgSet> params(pdfclone->getParameters(*dataOriginal_));
         params->Print("V");
         std::cout << "Obs: " << std::endl;
         dataOriginal_->get()->Print("V");
@@ -960,7 +960,7 @@ cacheutils::CachingSimNLL::setup_()
     }
 
     
-    std::auto_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) simpdf->indexCat().Clone());
+    std::unique_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) simpdf->indexCat().Clone());
     pdfs_.resize(catClone->numBins(NULL), 0);
     //dataSets_.reset(dataOriginal_->split(pdfOriginal_->indexCat(), true));
     datasets_.resize(pdfs_.size(), 0);
@@ -1080,7 +1080,7 @@ cacheutils::CachingSimNLL::setData(const RooAbsData &data)
 void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const RooAbsCategory& splitCat, Bool_t createEmptyDataSets) {
     RooCategory *cat = dynamic_cast<RooCategory *>(data.get()->find(splitCat.GetName()));
     if (cat == 0) throw std::logic_error("Error: no category");
-    std::auto_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) splitCat.Clone());
+    std::unique_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) splitCat.Clone());
     int nb = cat->numBins((const char *)0), ne = data.numEntries();
     RooArgSet obs(*data.get()); obs.remove(*cat, true, true);
     RooRealVar weight("_weight_","",1);
@@ -1102,7 +1102,7 @@ void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const R
             catClone->setBin(ib);
             RooAbsPdf *pdf = pdfOriginal_->getPdf(catClone->getLabel());
             if (pdf) {
-                std::auto_ptr<RooArgSet> myobs(pdf->getObservables(obs));
+                std::unique_ptr<RooArgSet> myobs(pdf->getObservables(obs));
                 myobs->add(weight);
                 //std::cout << "Observables for bin " << ib << ":"; myobs->Print("");
                 datasets_[ib] = new RooDataSet("", "", *myobs, "_weight_");

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -535,7 +535,7 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
     }
 
     // keep hold of best fitted parameters! 
-    std::auto_ptr<RooArgSet> params;
+    std::unique_ptr<RooArgSet> params;
     params.reset(nll_.getParameters((const RooArgSet *)0) );
     params->remove(CascadeMinimizerGlobalConfigs::O().pdfCategories);
 

--- a/src/ChannelCompatibilityCheck.cc
+++ b/src/ChannelCompatibilityCheck.cc
@@ -56,7 +56,7 @@ bool ChannelCompatibilityCheck::runSpecific(RooWorkspace *w, RooStats::ModelConf
   RooAbsCategoryLValue *cat = (RooAbsCategoryLValue *) sim->indexCat().Clone();
   int nbins = cat->numBins((const char *)0);
   TString satname = TString::Format("%s_freeform", sim->GetName());
-  std::auto_ptr<RooSimultaneous> newsim((typeid(*sim) == typeid(RooSimultaneousOpt)) ? new RooSimultaneousOpt(satname, "", *cat) : new RooSimultaneous(satname, "", *cat)); 
+  std::unique_ptr<RooSimultaneous> newsim((typeid(*sim) == typeid(RooSimultaneousOpt)) ? new RooSimultaneousOpt(satname, "", *cat) : new RooSimultaneous(satname, "", *cat)); 
   std::map<std::string,std::string> rs;
   RooArgList minosVars, minosOneVar; if (runMinos_) minosOneVar.add(*r);
   for (int ic = 0, nc = nbins; ic < nc; ++ic) {
@@ -76,12 +76,12 @@ bool ChannelCompatibilityCheck::runSpecific(RooWorkspace *w, RooStats::ModelConf
 
   CloseCoutSentry sentry(verbose < 2);
   const RooCmdArg &constCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooFit::NumCPU(1); // use something dummy 
-  std::auto_ptr<RooFitResult> result_nominal (doFit(   *sim, data, minosOneVar, constCmdArg, runMinos_)); // let's run Hesse if we want to run Minos
+  std::unique_ptr<RooFitResult> result_nominal (doFit(   *sim, data, minosOneVar, constCmdArg, runMinos_)); // let's run Hesse if we want to run Minos
   if (dynamic_cast<cacheutils::CachingSimNLL*>(nll.get())) {
     static_cast<cacheutils::CachingSimNLL*>(nll.get())->clearConstantZeroPoint();
   }
   double nll_nominal   = nll->getVal();
-  std::auto_ptr<RooFitResult> result_freeform(doFit(*newsim, data, minosVars,   constCmdArg, runMinos_));
+  std::unique_ptr<RooFitResult> result_freeform(doFit(*newsim, data, minosVars,   constCmdArg, runMinos_));
   if (dynamic_cast<cacheutils::CachingSimNLL*>(nll.get())) {
     static_cast<cacheutils::CachingSimNLL*>(nll.get())->clearConstantZeroPoint();
   }

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -297,7 +297,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   if (verbose <= 2) RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
   // Load the model, but going in a temporary directory to avoid polluting the current one with garbage from 'cexpr'
   RooWorkspace *w = 0; RooStats::ModelConfig *mc = 0, *mc_bonly = 0;
-  std::auto_ptr<RooStats::HLFactory> hlf(0);
+  std::unique_ptr<RooStats::HLFactory> hlf{nullptr};
 
   if (isBinary) {
     TFile *fIn = TFile::Open(fileToLoad); 
@@ -577,7 +577,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (verbose > 0) {  
       	std::cout << "Set floating the following parameters: "; toFloat.Print(""); 
         Logger::instance().log(std::string(Form("Combine.cc: %d -- Set floating the following parameters: ",__LINE__)),Logger::kLogLevelInfo,__func__); 
-        std::auto_ptr<TIterator> iter(toFloat.createIterator());
+        std::unique_ptr<TIterator> iter(toFloat.createIterator());
         for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
            Logger::instance().log(std::string(Form("Combine.cc: %d  %s ",__LINE__,a->GetName())),Logger::kLogLevelInfo,__func__); 
 	}
@@ -599,7 +599,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           std::regex rgx( reg_esp, std::regex::ECMAScript);
           
           std::string matchingParams="";
-          std::auto_ptr<TIterator> iter(nuisances->createIterator());
+          std::unique_ptr<TIterator> iter(nuisances->createIterator());
           for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
               const std::string &target = a->GetName();
               std::smatch match;
@@ -625,7 +625,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           std::regex rgx( reg_esp, std::regex::ECMAScript);
           
           std::string matchingParams="";
-          std::auto_ptr<TIterator> iter(w->componentIterator());
+          std::unique_ptr<TIterator> iter(w->componentIterator());
           for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
 
               if ( ! (a->IsA()->InheritsFrom(RooRealVar::Class()) || a->IsA()->InheritsFrom(RooCategory::Class()))) continue;
@@ -664,7 +664,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (verbose > 0) {  
       	std::cout << "Freezing the following parameters: "; toFreeze.Print("");
         Logger::instance().log(std::string(Form("Combine.cc: %d -- Freezing the following parameters: ",__LINE__)),Logger::kLogLevelInfo,__func__); 
-        std::auto_ptr<TIterator> iter(toFreeze.createIterator());
+        std::unique_ptr<TIterator> iter(toFreeze.createIterator());
         for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
            Logger::instance().log(std::string(Form("Combine.cc: %d  %s ",__LINE__,a->GetName())),Logger::kLogLevelInfo,__func__); 
 	}
@@ -802,7 +802,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           std::regex rgx( reg_esp, std::regex::ECMAScript);
 
           RooArgSet allParams(w->allVars());
-          std::auto_ptr<TIterator> iter(allParams.createIterator());
+          std::unique_ptr<TIterator> iter(allParams.createIterator());
           for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
               RooAbsReal *tmp = dynamic_cast<RooAbsReal *>(a);
               const std::string &target = tmp->GetName();
@@ -959,7 +959,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	    // print the values of the parameters used to generate the toy
 	    if (verbose > 2) {
 	      Logger::instance().log(std::string(Form("Combine.cc: %d -- Generate Asimov toy from parameter values ... ",__LINE__)),Logger::kLogLevelInfo,__func__);
-    	      std::auto_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
+    	      std::unique_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
     	      for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	Logger::instance().log(std::string(Form("Combine.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -994,7 +994,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
   
   std::vector<double> limitHistory;
-  std::auto_ptr<RooAbsPdf> nuisancePdf;
+  std::unique_ptr<RooAbsPdf> nuisancePdf;
   if (nToys > 0) {
     if (genPdf == 0) throw std::invalid_argument("You can't generate background-only toys if you have no background-only pdf in the workspace and you have set --noMCbonly");
     toymcoptutils::SimPdfGenInfo newToyMC(*genPdf, *observables, !unbinned_); 
@@ -1016,7 +1016,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
               if (dobs == 0) throw std::logic_error("Cannot use toysFrequentist with no input dataset");
               CloseCoutSentry sentry(verbose < 3);
               //genPdf->fitTo(*dobs, RooFit::Save(1), RooFit::Minimizer("Minuit2","minimize"), RooFit::Strategy(0), RooFit::Hesse(0), RooFit::Constrain(*(expectSignal_ ?mc:mc_bonly)->GetNuisanceParameters()));	
-                std::auto_ptr<RooAbsReal> nll(genPdf->createNLL(*dobs, RooFit::Constrain(*(expectSignal_ ||  setPhysicsModelParameterExpression_ != "" || noMCbonly_ ? mc:mc_bonly)->GetNuisanceParameters()), RooFit::Extended(genPdf->canBeExtended())));
+                std::unique_ptr<RooAbsReal> nll(genPdf->createNLL(*dobs, RooFit::Constrain(*(expectSignal_ ||  setPhysicsModelParameterExpression_ != "" || noMCbonly_ ? mc:mc_bonly)->GetNuisanceParameters()), RooFit::Extended(genPdf->canBeExtended())));
                 CascadeMinimizer minim(*nll, CascadeMinimizer::Constrained);
                 minim.setStrategy(1);
                 minim.minimize();
@@ -1028,7 +1028,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           if (nuisancePdf.get()) systDs = nuisancePdf->generate(*nuisances, nToys);
       } 
     }
-    std::auto_ptr<RooArgSet> vars(genPdf->getVariables());
+    std::unique_ptr<RooArgSet> vars(genPdf->getVariables());
     algo->setNToys(nToys);
 
     for (iToy = 1; iToy <= nToys; ++iToy) {
@@ -1052,7 +1052,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	std::cout << "Generate toy " << iToy << "/" << nToys << std::endl;
 	if (verbose > 2) {
 	  Logger::instance().log(std::string(Form("Combine.cc: %d -- Generating toy %d/%d, from parameter values ... ",__LINE__,iToy,nToys)),Logger::kLogLevelInfo,__func__);
-    	  std::auto_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
+    	  std::unique_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
     	  for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	Logger::instance().log(std::string(Form("Combine.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -1239,7 +1239,7 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
       (CascadeMinimizerGlobalConfigs::O().allRooMultiPdfs).add(*(dynamic_cast<RooMultiPdf*>(arg)));
       RooAbsPdf *pdf = dynamic_cast<RooAbsPdf*>(arg);
       RooArgSet *pdfPars = pdf->getParameters((const RooArgSet*)0);
-      std::auto_ptr<TIterator> iter_v(pdfPars->createIterator());
+      std::unique_ptr<TIterator> iter_v(pdfPars->createIterator());
       for (RooAbsArg *a = (RooAbsArg *) iter_v->Next(); a != 0; a = (RooAbsArg *) iter_v->Next()) {
 	RooRealVar *v = dynamic_cast<RooRealVar *>(a);
 	if (!v) continue;

--- a/src/FeldmanCousins.cc
+++ b/src/FeldmanCousins.cc
@@ -47,7 +47,7 @@ bool FeldmanCousins::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
   fc.SetNBins(10);
   do { 
       if (verbose > 1) std::cout << "scan in range [" << r->getMin() << ", " << r->getMax() << "]" << std::endl;
-      std::auto_ptr<RooStats::PointSetInterval> fcInterval((RooStats::PointSetInterval *)fc.GetInterval());
+      std::unique_ptr<RooStats::PointSetInterval> fcInterval((RooStats::PointSetInterval *)fc.GetInterval());
       if (fcInterval.get() == 0) return false;
       if (verbose > 1) fcInterval->GetParameterPoints()->Print("V"); 
       RooDataHist* parameterScan = (RooDataHist*) fc.GetPointsToScan();

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -141,7 +141,7 @@ bool FitterAlgoBase::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
               break;
       }
 
-      std::auto_ptr<RooArgSet>  params(mc_s->GetPdf()->getParameters(data));
+      std::unique_ptr<RooArgSet>  params(mc_s->GetPdf()->getParameters(data));
       RooLinkedListIter iter = params->iterator(); int i = 0;
       for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next(), ++i) {
           RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
@@ -159,8 +159,8 @@ bool FitterAlgoBase::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
   }
 
   RooAbsData *theData = &data;
-  std::auto_ptr<toymcoptutils::SimPdfGenInfo> generator;
-  std::auto_ptr<RooAbsData> generatedData;
+  std::unique_ptr<toymcoptutils::SimPdfGenInfo> generator;
+  std::unique_ptr<RooAbsData> generatedData;
   if (protectUnbinnedChannels_) {
       RooRealVar *weightVar = 0;
       generator.reset(new toymcoptutils::SimPdfGenInfo(*mc_s->GetPdf(), *mc_s->GetObservables(), false));
@@ -240,7 +240,7 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     ret = (saveFitResult || rs.getSize() ? minim.save() : new RooFitResult("dummy","success"));
     if (verbose > 1 && ret != 0 && (saveFitResult || rs.getSize())) { ret->Print("V");  }
 
-    std::auto_ptr<RooArgSet> allpars(pdf.getParameters(data));
+    std::unique_ptr<RooArgSet> allpars(pdf.getParameters(data));
     RooArgSet* bestFitPars = (RooArgSet*)allpars->snapshot() ;
 
     // I'm done here
@@ -339,7 +339,7 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
             if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
             if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
 
-            std::auto_ptr<RooArgSet> allpars(nll->getParameters((const RooArgSet *)0));
+            std::unique_ptr<RooArgSet> allpars(nll->getParameters((const RooArgSet *)0));
 
             double nll0 = nll->getVal();
             double threshold68 = nll0 + delta68;
@@ -381,8 +381,8 @@ double FitterAlgoBase::findCrossing(CascadeMinimizer &minim, RooAbsReal &nll, Ro
     }
     double rInc = stepSize_*(rBound - rStart);
     r.setVal(rStart); 
-    std::auto_ptr<RooFitResult> checkpoint;
-    std::auto_ptr<RooArgSet>    allpars;
+    std::unique_ptr<RooFitResult> checkpoint;
+    std::unique_ptr<RooArgSet>    allpars;
     bool ok = false;
     {
         CloseCoutSentry sentry(verbose < 3);    
@@ -505,7 +505,7 @@ double FitterAlgoBase::findCrossingNew(CascadeMinimizer &minim, RooAbsReal &nll,
       Logger::instance().log(std::string(Form("FitterAlgoBase.cc: %d -- Searching for crossing at nll = %g in the interval [ %g , %g ] ",__LINE__,level, rStart, rBound)),Logger::kLogLevelInfo,__func__);
     }
 
-    //std::auto_ptr<RooArgSet>    allpars(nll.getParameters((const RooArgSet *)0));
+    //std::unique_ptr<RooArgSet>    allpars(nll.getParameters((const RooArgSet *)0));
     //utils::CheapValueSnapshot checkpoint(*allpars);
     r.setVal(rStart); 
     if (!minim.improve(verbose-1)) { 

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -295,14 +295,14 @@ bool HybridNew::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::Mode
 
 bool HybridNew::runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) {
     HybridNew::Setup setup;
-    std::auto_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rValues_, setup));
-    std::auto_ptr<HypoTestResult> hcResult;
+    std::unique_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rValues_, setup));
+    std::unique_ptr<HypoTestResult> hcResult;
     if (readHybridResults_) {
         hcResult.reset(readToysFromFile(rValues_));
     } else {
         hcResult.reset(evalGeneric(*hc));
         for (unsigned int i = 1; i < iterations_; ++i) {
-            std::auto_ptr<HypoTestResult> more(evalGeneric(*hc));
+            std::unique_ptr<HypoTestResult> more(evalGeneric(*hc));
             hcResult->Append(more.get());
             if (verbose) std::cout << "\t1 - CLb = " << hcResult->CLb() << " +/- " << hcResult->CLbError() << std::endl;
         }
@@ -370,7 +370,7 @@ bool HybridNew::runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
 
       if (!gridFile_.empty()) {
         if (grid_.empty()) {
-            std::auto_ptr<TFile> gridFile(TFile::Open(gridFile_.c_str()));
+            std::unique_ptr<TFile> gridFile(TFile::Open(gridFile_.c_str()));
             if (gridFile.get() == 0) throw std::runtime_error(("Can't open grid file "+gridFile_).c_str());
             TDirectory *toyDir = gridFile->GetDirectory("toys");
             if (!toyDir) throw std::logic_error("Cannot use readHypoTestResult: empty toy dir in input file empty");
@@ -642,12 +642,12 @@ bool HybridNew::runSinglePoint(RooWorkspace *w, RooStats::ModelConfig *mc_s, Roo
 bool HybridNew::runTestStatistics(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) {
     bool isProfile = (testStat_ == "LHC" || testStat_ == "LHCFC"  || testStat_ == "Profile");
     if (readHybridResults_ && expectedFromGrid_) {
-        std::auto_ptr<RooStats::HypoTestResult> result(readToysFromFile(rValues_));
+        std::unique_ptr<RooStats::HypoTestResult> result(readToysFromFile(rValues_));
         applyExpectedQuantile(*result);
         limit = -2 * result->GetTestStatisticData();
     } else {    
         HybridNew::Setup setup;
-        std::auto_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rValues_, setup));
+        std::unique_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rValues_, setup));
         RooArgSet nullPOI(*mc_s->GetParametersOfInterest());
         if (isProfile) { 
             /// Probably useless, but should double-check before deleting this.
@@ -673,7 +673,7 @@ std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig
 std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, const RooAbsCollection & rVals, bool adaptive, double clsTarget) {
     if (readHybridResults_) {
         bool isProfile = (testStat_ == "LHC" || testStat_ == "LHCFC"  || testStat_ == "Profile");
-        std::auto_ptr<RooStats::HypoTestResult> result(readToysFromFile(rVals));
+        std::unique_ptr<RooStats::HypoTestResult> result(readToysFromFile(rVals));
         std::pair<double, double> ret(-1,-1);
         assert(result.get() != 0 && "Null result in HybridNew::eval(Workspace,...) after readToysFromFile");
         if (expectedFromGrid_) {
@@ -681,7 +681,7 @@ std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig
             result->SetTestStatisticData(result->GetTestStatisticData() + (isProfile ? -EPS : EPS));
         } else if (!noUpdateGrid_) {
             Setup setup;
-            std::auto_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, rVals, setup);
+            std::unique_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, rVals, setup);
             RooArgSet nullPOI(*setup.modelConfig_bonly.GetSnapshot());
             if (isProfile) nullPOI.assignValueOnly(rVals);
             double testStat = setup.qvar->Evaluate(data, nullPOI);
@@ -698,7 +698,7 @@ std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig
         r->setVal(rIn->getVal());
         if (verbose) std::cout << "  " << r->GetName() << " = " << rIn->getVal() << " +/- " << r->getError() << std::endl;
     } 
-    std::auto_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rVals, setup));
+    std::unique_ptr<RooStats::HybridCalculator> hc(create(w, mc_s, mc_b, data, rVals, setup));
     std::pair<double, double> ret = eval(*hc, rVals, adaptive, clsTarget);
 
     // add to plot 
@@ -713,7 +713,7 @@ std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig
 
 
 
-std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double rVal, HybridNew::Setup &setup) {
+std::unique_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double rVal, HybridNew::Setup &setup) {
     RooArgSet rValues;
     mc_s->GetParametersOfInterest()->snapshot(rValues);
     RooRealVar *r = dynamic_cast<RooRealVar*>(rValues.first());
@@ -722,7 +722,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
     return create(w,mc_s,mc_b,data,rValues,setup);
 }
 
-std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, const RooAbsCollection & rVals, HybridNew::Setup &setup) {
+std::unique_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, const RooAbsCollection & rVals, HybridNew::Setup &setup) {
   using namespace RooStats;
   
   w->loadSnapshot("clean");
@@ -775,7 +775,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
   }
 
   utils::CheapValueSnapshot fitMu, fitZero;
-  std::auto_ptr<RooArgSet> paramsToFit;
+  std::unique_ptr<RooArgSet> paramsToFit;
 
   // Count the number of floating, non POI parameters, if there are more than 0, then we would need to fit to estimate their values for the generation ...
   RooArgSet floatParsModel(*(mc_s->GetPdf()->getParameters(data)));
@@ -793,7 +793,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
         r->setVal(0); pdfB = mc_s->GetPdf();
     }
     timer.Start();
-    std::auto_ptr<RooAbsReal> nll(pdfB->createNLL(data, RooFit::Extended(isExt), RooFit::Constrain(*mc_s->GetNuisanceParameters())));
+    std::unique_ptr<RooAbsReal> nll(pdfB->createNLL(data, RooFit::Extended(isExt), RooFit::Constrain(*mc_s->GetNuisanceParameters())));
     {
         CloseCoutSentry sentry(verbose < 3);
         CascadeMinimizer minim(*nll, CascadeMinimizer::Constrained, r);
@@ -807,7 +807,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
     // print the values of the parameters used to generate the toy
     if (verbose > 2) {
       Logger::instance().log(std::string(Form("HybridNew.cc: %d -- Using the following (post-fit) parameters for No signal hypothesis ",__LINE__)),Logger::kLogLevelInfo,__func__);
-      std::auto_ptr<TIterator> iter(paramsToFit->createIterator());
+      std::unique_ptr<TIterator> iter(paramsToFit->createIterator());
       for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
   	TString varstring = utils::printRooArgAsString(a);
   	Logger::instance().log(std::string(Form("HybridNew.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -835,7 +835,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
       Logger::instance().log(std::string(Form("HybridNew.cc: %d -- Using the following (post-fit) parameters for S+B hypothesis ",__LINE__)),Logger::kLogLevelInfo,__func__);
       RooArgSet reportParams; 
       reportParams.add(*paramsToFit); reportParams.add(poi);
-      std::auto_ptr<TIterator> iter(reportParams.createIterator());
+      std::unique_ptr<TIterator> iter(reportParams.createIterator());
       for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
   	TString varstring = utils::printRooArgAsString(a);
   	Logger::instance().log(std::string(Form("HybridNew.cc: %d -- %s",__LINE__,varstring.Data())),Logger::kLogLevelInfo,__func__);
@@ -1003,7 +1003,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
     setup.toymcsampler->SetProofConfig(setup.pc.get());
   }   
 
-  std::auto_ptr<HybridCalculator> hc(new HybridCalculator(data, setup.modelConfig, setup.modelConfig_bonly, setup.toymcsampler.get()));
+  std::unique_ptr<HybridCalculator> hc(new HybridCalculator(data, setup.modelConfig, setup.modelConfig_bonly, setup.toymcsampler.get()));
   if (genNuisances_ || !genGlobalObs_) {
       if (withSystematics) {
           setup.toymcsampler->SetGlobalObservables(*setup.modelConfig.GetNuisanceParameters());
@@ -1078,7 +1078,7 @@ std::auto_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, Roo
 
 std::pair<double,double> 
 HybridNew::eval(RooStats::HybridCalculator &hc, const RooAbsCollection & rVals, bool adaptive, double clsTarget) {
-    std::auto_ptr<HypoTestResult> hcResult(evalGeneric(hc));
+    std::unique_ptr<HypoTestResult> hcResult(evalGeneric(hc));
     if (expectedFromGrid_) applyExpectedQuantile(*hcResult);
     if (hcResult.get() == 0) {
         std::cerr << "Hypotest failed" << std::endl;
@@ -1105,7 +1105,7 @@ HybridNew::eval(RooStats::HybridCalculator &hc, const RooAbsCollection & rVals, 
           hc.SetToys(nToys_, nToys_);
         }
         while (cls.second >= clsAccuracy_ && (clsTarget == -1 || fabs(cls.first-clsTarget) < 3*cls.second) ) {
-            std::auto_ptr<HypoTestResult> more(evalGeneric(hc));
+            std::unique_ptr<HypoTestResult> more(evalGeneric(hc));
             more->SetBackgroundAsAlt(false);
             if (testStat_ == "LHC" || testStat_ == "LHCFC"  || testStat_ == "Profile") more->SetPValueIsRightTail(!more->GetPValueIsRightTail());
             hcResult->Append(more.get());
@@ -1115,7 +1115,7 @@ HybridNew::eval(RooStats::HybridCalculator &hc, const RooAbsCollection & rVals, 
         }
     } else if (iterations_ > 1) {
         for (unsigned int i = 1; i < iterations_; ++i) {
-            std::auto_ptr<HypoTestResult> more(evalGeneric(hc));
+            std::unique_ptr<HypoTestResult> more(evalGeneric(hc));
             more->SetBackgroundAsAlt(false);
             if (testStat_ == "LHC" || testStat_ == "LHCFC"  || testStat_ == "Profile") more->SetPValueIsRightTail(!more->GetPValueIsRightTail());
             hcResult->Append(more.get());
@@ -1332,7 +1332,7 @@ RooStats::HypoTestResult * HybridNew::evalGeneric(RooStats::HybridCalculator &hc
 
 RooStats::HypoTestResult * HybridNew::evalWithFork(RooStats::HybridCalculator &hc) {
     TStopwatch timer;
-    std::auto_ptr<RooStats::HypoTestResult> result(0);
+    std::unique_ptr<RooStats::HypoTestResult> result{nullptr};
     char tmpfile[999]; snprintf(tmpfile, 998, "%s/rstats-XXXXXX", P_tmpdir);
     
     int fd = mkstemp(tmpfile); close(fd);
@@ -1394,14 +1394,14 @@ RooStats::HypoTestResult * HybridNew::evalFrequentist(RooStats::HybridCalculator
     RooArgSet nuis(*hc.GetAlternateModel()->GetNuisanceParameters());
     RooArgSet gobs(*hc.GetAlternateModel()->GetGlobalObservables());
     RooArgSet nullPoi(*hc.GetNullModel()->GetSnapshot());
-    std::auto_ptr<RooAbsCollection> parS(hc.GetAlternateModel()->GetPdf()->getParameters(obs));
-    std::auto_ptr<RooAbsCollection> parB(hc.GetNullModel()->GetPdf()->getParameters(obs));
+    std::unique_ptr<RooAbsCollection> parS(hc.GetAlternateModel()->GetPdf()->getParameters(obs));
+    std::unique_ptr<RooAbsCollection> parB(hc.GetNullModel()->GetPdf()->getParameters(obs));
     RooArgList constraintsS, constraintsB;
     RooAbsPdf *factorS = hc.GetAlternateModel()->GetPdf();
     RooAbsPdf *factorB = hc.GetNullModel()->GetPdf();
-    //std::auto_ptr<RooAbsPdf> factorS(utils::factorizePdf(obs, *hc.GetAlternateModel()->GetPdf(),  constraintsS));
-    //std::auto_ptr<RooAbsPdf> factorB(utils::factorizePdf(obs, *hc.GetNullModel()->GetPdf(), constraintsB));
-    std::auto_ptr<RooAbsPdf> nuisPdf(utils::makeNuisancePdf(const_cast<RooStats::ModelConfig&>(*hc.GetAlternateModel())));
+    //std::unique_ptr<RooAbsPdf> factorS(utils::factorizePdf(obs, *hc.GetAlternateModel()->GetPdf(),  constraintsS));
+    //std::unique_ptr<RooAbsPdf> factorB(utils::factorizePdf(obs, *hc.GetNullModel()->GetPdf(), constraintsB));
+    std::unique_ptr<RooAbsPdf> nuisPdf(utils::makeNuisancePdf(const_cast<RooStats::ModelConfig&>(*hc.GetAlternateModel())));
     std::vector<Double_t> distSB, distB;
     *parS = *snapGlobalObs_;
     Double_t tsData = hc.GetTestStatSampler()->GetTestStatistic()->Evaluate(*realData_, nullPoi);
@@ -1411,12 +1411,12 @@ RooStats::HypoTestResult * HybridNew::evalFrequentist(RooStats::HybridCalculator
        *parS = *hc.GetAlternateModel()->GetSnapshot(); 
        // Throw global observables, and set them
        if (verbose > 2) { std::cout << "Generating global obs starting from " << std::endl; parS->Print("V"); }
-       std::auto_ptr<RooDataSet> gdata(nuisPdf->generate(gobs, 1));
+       std::unique_ptr<RooDataSet> gdata(nuisPdf->generate(gobs, 1));
        *parS = *gdata->get(0);
        if (verbose > 2) { std::cout << "Generated global obs" << std::endl; utils::printRAD(&*gdata); }
        // Throw observables
        if (verbose > 2) { std::cout << "Generating obs starting from " << std::endl; parS->Print("V"); }
-       std::auto_ptr<RooDataSet> data(factorS->generate(obs, RooFit::Extended()));
+       std::unique_ptr<RooDataSet> data(factorS->generate(obs, RooFit::Extended()));
        if (verbose > 2) { std::cout << "Generated obs" << std::endl; utils::printRAD(&*data); }
        // Evaluate T.S.
        distSB.push_back(hc.GetTestStatSampler()->GetTestStatistic()->Evaluate(*data, nullPoi));
@@ -1428,12 +1428,12 @@ RooStats::HypoTestResult * HybridNew::evalFrequentist(RooStats::HybridCalculator
        //*parB = *hc.GetAlternateModel()->GetSnapshot(); 
        // Throw global observables, and set them
        if (verbose > 2) { std::cout << "Generating global obs starting from " << std::endl; parB->Print("V"); }
-       std::auto_ptr<RooDataSet> gdata(nuisPdf->generate(gobs, 1));
+       std::unique_ptr<RooDataSet> gdata(nuisPdf->generate(gobs, 1));
        *parB = *gdata->get(0);
        if (verbose > 2) { std::cout << "Generated global obs" << std::endl; utils::printRAD(&*gdata); }
        // Throw observables
        if (verbose > 2) { std::cout << "Generating obs starting from " << std::endl; parB->Print("V"); }
-       std::auto_ptr<RooDataSet> data(factorB->generate(obs, RooFit::Extended()));
+       std::unique_ptr<RooDataSet> data(factorB->generate(obs, RooFit::Extended()));
        if (verbose > 2) { std::cout << "Generated obs" << std::endl; utils::printRAD(&*data); }
        // Evaluate T.S.
        distB.push_back(hc.GetTestStatSampler()->GetTestStatistic()->Evaluate(*data, nullPoi));
@@ -1462,7 +1462,7 @@ RooStats::HypoTestResult * HybridNew::readToysFromFile(const RooAbsCollection & 
         prefix2 += Form("_%s%g", rIn->GetName(), rIn->getVal());
     }
     if (verbose) std::cout << std::endl;
-    std::auto_ptr<RooStats::HypoTestResult> ret;
+    std::unique_ptr<RooStats::HypoTestResult> ret;
     TIter next(toyDir->GetListOfKeys()); TKey *k;
     while ((k = (TKey *) next()) != 0) {
         if (TString(k->GetName()).Index(prefix1) != 0 && TString(k->GetName()).Index(prefix2) != 0) continue;
@@ -1621,7 +1621,7 @@ void HybridNew::updateGridDataFC(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
     }
     if (verbose > 0) std::cout << "A total of " << rToUpdate.size() << " points will be updated." << std::endl;
     Setup setup;
-    std::auto_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, rToUpdate.back(), setup);
+    std::unique_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, rToUpdate.back(), setup);
     RooArgSet nullPOI(*setup.modelConfig_bonly.GetSnapshot());
     std::vector<Double_t> qVals = ((ProfiledLikelihoodTestStatOpt&)(*setup.qvar)).Evaluate(data, nullPOI, rToUpdate);
     for (int i = 0, n = rToUpdate.size(); i < n; ++i) {
@@ -1641,7 +1641,7 @@ std::pair<double,double> HybridNew::updateGridPoint(RooWorkspace *w, RooStats::M
         point->second->SetTestStatisticData(point->second->GetTestStatisticData() + (isProfile ? EPS : EPS));
     } else {
         Setup setup;
-        std::auto_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, point->first, setup);
+        std::unique_ptr<RooStats::HybridCalculator> hc = create(w, mc_s, mc_b, data, point->first, setup);
         RooArgSet nullPOI(*setup.modelConfig_bonly.GetSnapshot());
         if (isProfile) nullPOI.setRealValue(r->GetName(), point->first);
         double testStat = setup.qvar->Evaluate(data, nullPOI);

--- a/src/MarkovChainMC.cc
+++ b/src/MarkovChainMC.cc
@@ -200,7 +200,7 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
   }
   
   w->loadSnapshot("clean");
-  std::auto_ptr<RooFitResult> fit(0);
+  std::unique_ptr<RooFitResult> fit{nullptr};
   if (proposalType_ == FitP || (cropNSigmas_ > 0)) {
       CloseCoutSentry coutSentry(verbose <= 1); // close standard output and error, so that we don't flood them with minuit messages
       fit.reset(mc_s->GetPdf()->fitTo(data, RooFit::Save(), RooFit::Minos(runMinos_)));
@@ -231,7 +231,7 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
       }
   }
 
-  std::auto_ptr<ProposalFunction> ownedPdfProp; 
+  std::unique_ptr<ProposalFunction> ownedPdfProp; 
   ProposalFunction* pdfProp = 0;
   ProposalHelper ph;
   switch (proposalType_) {
@@ -278,7 +278,7 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
       if (proposalHelperUniformFraction_ > 0) ph.SetUniformFraction(proposalHelperUniformFraction_);
   }
 
-  std::auto_ptr<DebugProposal> pdfDebugProp(debugProposal_ > 0 ? new DebugProposal(pdfProp, mc_s->GetPdf(), &data, debugProposal_) : 0);
+  std::unique_ptr<DebugProposal> pdfDebugProp(debugProposal_ > 0 ? new DebugProposal(pdfProp, mc_s->GetPdf(), &data, debugProposal_) : 0);
   
   MCMCCalculator mc(data, *mc_s);
   mc.SetNumIters(iterations_); 
@@ -291,7 +291,7 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
     mc.SetPriorPdf(*((RooAbsPdf *)0));
   }
 
-  std::auto_ptr<MCMCInterval> mcInt;
+  std::unique_ptr<MCMCInterval> mcInt;
   try {  
       mcInt.reset((MCMCInterval*)mc.GetInterval()); 
   } catch (std::length_error &ex) {

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -172,7 +172,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
  
     // start with a best fit
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();
-    std::auto_ptr<RooFitResult> res;
+    std::unique_ptr<RooFitResult> res;
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
     bool doHesse = (algo_ == Singles || algo_ == Impact) || (saveFitResult_) ;
     if ( !skipInitialFit_){
@@ -485,7 +485,7 @@ void MultiDimFit::doImpact(RooFitResult &res, RooAbsReal &nll) {
   std::cout << "Parameter impacts: " << std::endl;
 
   // Save the initial parameters here to reset between NPs
-  std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
+  std::unique_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
   RooArgSet init_snap;
   params->snapshot(init_snap);
 
@@ -594,7 +594,7 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
     if (!autoBoundsPOIs_.empty()) minim.setAutoBounds(&autoBoundsPOISet_); 
     if (!autoMaxPOIs_.empty()) minim.setAutoMax(&autoMaxPOISet_); 
     //minim.setStrategy(minimizerStrategy_);
-    std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
+    std::unique_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
     RooArgSet snap; params->snapshot(snap);
     //snap.Print("V");
     if (n == 1) {

--- a/src/RooRealFlooredSumPdf.cc
+++ b/src/RooRealFlooredSumPdf.cc
@@ -324,9 +324,9 @@ Double_t RooRealFlooredSumPdf::analyticalIntegralWN(Int_t code, const RooArgSet*
 	CacheElem* cache = (CacheElem*)_normIntMgr.getObjByIndex(code - 1);
 	if (cache == 0) { // revive the (sterilized) cache
 		//cout << "RooRealFlooredSumPdf("<<this<<")::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>") << ": reviving cache "<< endl;
-		std::auto_ptr<RooArgSet> vars(getParameters(RooArgSet()));
-		std::auto_ptr<RooArgSet> iset(_normIntMgr.nameSet2ByIndex(code - 1)->select(*vars));
-		std::auto_ptr<RooArgSet> nset(_normIntMgr.nameSet1ByIndex(code - 1)->select(*vars));
+		std::unique_ptr<RooArgSet> vars(getParameters(RooArgSet()));
+		std::unique_ptr<RooArgSet> iset(_normIntMgr.nameSet2ByIndex(code - 1)->select(*vars));
+		std::unique_ptr<RooArgSet> nset(_normIntMgr.nameSet1ByIndex(code - 1)->select(*vars));
 		RooArgSet dummy;
 		Int_t code2 = getAnalyticalIntegralWN(*iset, dummy, nset.get(), rangeName);
 		assert(code == code2); // must have revived the right (sterilized) slot...

--- a/src/Significance.cc
+++ b/src/Significance.cc
@@ -115,7 +115,7 @@ bool Significance::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::M
   RooRealVar *r = dynamic_cast<RooRealVar *>(mc_s->GetParametersOfInterest()->first());
   bool success = false;
   std::vector<double> limits; double rMax = r->getMax();  
-  std::auto_ptr<RooAbsPdf> nuisancePdf(0);
+  std::unique_ptr<RooAbsPdf> nuisancePdf{nullptr};
   for (int i = 0; i < maxTries_; ++i) {
       w->loadSnapshot("clean");
       if (i > 0) { // randomize starting point
@@ -195,7 +195,7 @@ bool Significance::runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooAbs
 
   while (!success) {
     ProfileLikelihoodCalculator plcB(data, *mc_s, 1.0-cl);
-    std::auto_ptr<LikelihoodInterval> plInterval;
+    std::unique_ptr<LikelihoodInterval> plInterval;
     if (useMinos_ || bruteForce_) {
         // try first with Minos, unless brute force requested
         if (!bruteForce_) { 
@@ -272,7 +272,7 @@ bool Significance::runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s,
       Double_t q0 = testStat.Evaluate(data, nullParamValues);
       limit = (q0 > 0 ? sqrt(2*q0) : (uncapped_ ? -sqrt(-2*q0) : 0));
   } else {
-      std::auto_ptr<HypoTestResult> result(plcS.GetHypoTest());
+      std::unique_ptr<HypoTestResult> result(plcS.GetHypoTest());
       if (result.get() == 0) return false;
       limit = result->Significance();
       if (uncapped_ && r->getVal() < signalForSignificance_) limit = -limit;
@@ -298,7 +298,7 @@ bool Significance::runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s,
 
 
 double Significance::upperLimitWithMinos(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance, double cl) const {
-    std::auto_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
+    std::unique_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
     RooMinimizer minim(*nll);
     minim.setStrategy(0);
     minim.setPrintLevel(verbose-1);
@@ -306,7 +306,7 @@ double Significance::upperLimitWithMinos(RooAbsPdf &pdf, RooAbsData &data, RooRe
     nllutils::robustMinimize(*nll, minim, verbose-1);
     int minosStat = minim.minos(RooArgSet(poi));
     if (minosStat == -1) return std::numeric_limits<double>::quiet_NaN();
-    std::auto_ptr<RooFitResult> res(minim.save());
+    std::unique_ptr<RooFitResult> res(minim.save());
     double muhat = poi.getVal(), limit = poi.getVal() + (lowerLimit_ ? poi.getAsymErrorLo() : poi.getAsymErrorHi());
     double nll0 = nll->getVal();
     poi.setVal(limit);
@@ -322,7 +322,7 @@ double Significance::upperLimitWithMinos(RooAbsPdf &pdf, RooAbsData &data, RooRe
 
 std::pair<double,double> Significance::upperLimitBruteForce(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance, double cl) const {
     poi.setConstant(false);
-    std::auto_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
+    std::unique_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
     RooMinimizer minim0(*nll);
     minim0.setStrategy(0);
     minim0.setPrintLevel(-1);
@@ -334,7 +334,7 @@ std::pair<double,double> Significance::upperLimitBruteForce(RooAbsPdf &pdf, RooA
         std::cerr << "Initial minimization failed. Aborting." << std::endl;
         return std::pair<double,double>(0, -1);
     }
-    std::auto_ptr<RooFitResult> start(minim.save());
+    std::unique_ptr<RooFitResult> start(minim.save());
     double minnll = nll->getVal();
     double rval = poi.getVal() + (lowerLimit_ ? -3 : +3)*poi.getError(), rlow = poi.getVal(), rhigh = lowerLimit_ ? poi.getMin() : poi.getMax();
     if (rval >= rhigh || rval <= rlow) rval = 0.5*(rlow + rhigh);
@@ -370,7 +370,7 @@ std::pair<double,double> Significance::upperLimitBruteForce(RooAbsPdf &pdf, RooA
     } while (fabs(rhigh - rlow) > tolerance);
     if (fail) {
         // try do do it in small steps instead
-        std::auto_ptr<RooArgSet> pars(nll->getParameters((const RooArgSet *)0));
+        std::unique_ptr<RooArgSet> pars(nll->getParameters((const RooArgSet *)0));
         double dx = (lowerLimit_ ? -0.05 : +0.05)*poi.getError();
         *pars = start->floatParsFinal();
         rval = poi.getVal() + dx;
@@ -404,7 +404,7 @@ double Significance::significanceBruteForce(RooAbsPdf &pdf, RooAbsData &data, Ro
     poi.setConstant(false);
     //poi.setMin(0); 
     poi.setVal(0.05*poi.getMax());
-    std::auto_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
+    std::unique_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
     CascadeMinimizer minim0(*nll, CascadeMinimizer::Unconstrained, &poi);
     minim0.setStrategy(0);
     minim0.minimize(verbose-2);
@@ -421,7 +421,7 @@ double Significance::significanceBruteForce(RooAbsPdf &pdf, RooAbsData &data, Ro
         printf("Minimum found at %s = %8.5f\n", poi.GetName(), poi.getVal());
     }
     MinimizerSentry minimizerConfig(minimizerAlgoForBF_, minimizerToleranceForBF_);
-    std::auto_ptr<RooFitResult> start(minim.save());
+    std::unique_ptr<RooFitResult> start(minim.save());
     double minnll = nll->getVal(), thisnll = minnll, lastnll = thisnll;
     double rbest = poi.getVal(), rval = rbest;
     TGraph *points = 0;
@@ -479,7 +479,7 @@ double Significance::significanceBruteForce(RooAbsPdf &pdf, RooAbsData &data, Ro
 }
 
 double Significance::significanceFromScan(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance, int steps) const {
-    std::auto_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
+    std::unique_ptr<RooAbsReal> nll(pdf.createNLL(data, RooFit::Constrain(*nuisances)));
     double maxScan = poi.getMax()*0.7;
     bool stepDown = (bfAlgo_.find("stepDown") != std::string::npos);
     bool twice    = (bfAlgo_.find("Twice")    != std::string::npos);
@@ -506,7 +506,7 @@ double Significance::significanceFromScan(RooAbsPdf &pdf, RooAbsData &data, RooR
         printf("Minimum found at %s = %8.5f\n", poi.GetName(), poi.getVal());
     }
     MinimizerSentry minimizerConfig(minimizerAlgoForBF_, minimizerToleranceForBF_);
-    std::auto_ptr<RooFitResult> start(minim.save());
+    std::unique_ptr<RooFitResult> start(minim.save());
     double minnll = nll->getVal(), thisnll = minnll, refnll = thisnll, maxnll = thisnll;
     double rbest = poi.getVal(), rval = rbest;
     TGraph *points = new TGraph(steps+1); points->SetName(Form("nll_scan_%g", mass_));

--- a/src/SimplerLikelihoodRatioTestStatExt.cc
+++ b/src/SimplerLikelihoodRatioTestStatExt.cc
@@ -56,7 +56,7 @@ SimplerLikelihoodRatioTestStatOpt::Evaluate(RooAbsData& data, RooArgSet& nullPOI
     if (paramsAlt_.get() == 0)  paramsAlt_.reset(pdfAlt_->getParameters(data));
 
     // if the dataset is not empty, redirect pdf nodes to the dataset
-    std::auto_ptr<TIterator> iterDepObs(pdfDepObs_.createIterator());
+    std::unique_ptr<TIterator> iterDepObs(pdfDepObs_.createIterator());
     bool nonEmpty = data.numEntries() > 0;
     if (nonEmpty) {
         const RooArgSet *entry = data.get(0);
@@ -87,7 +87,7 @@ SimplerLikelihoodRatioTestStatOpt::Evaluate(RooAbsData& data, RooArgSet& nullPOI
 
 void SimplerLikelihoodRatioTestStatOpt::unrollSimPdf(RooSimultaneous *simpdf, std::vector<RooAbsPdf *> &out) {
     // get a clone of the pdf category, so that I can use it to enumerate the pdf states
-    std::auto_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) simpdf->indexCat().Clone());
+    std::unique_ptr<RooAbsCategoryLValue> catClone((RooAbsCategoryLValue*) simpdf->indexCat().Clone());
     out.resize(catClone->numBins(NULL), 0);
     //std::cout << "Pdf " << pdf->GetName() <<" is a SimPdf over category " << catClone->GetName() << ", with " << out.size() << " bins" << std::endl;
 
@@ -175,8 +175,8 @@ SimplerLikelihoodRatioTestStatExt::~SimplerLikelihoodRatioTestStatExt()
 Double_t
 SimplerLikelihoodRatioTestStatExt::Evaluate(RooAbsData& data, RooArgSet& nullPOI) 
 {
-    std::auto_ptr<RooAbsReal> nllNull_(pdfNull_->createNLL(data));
-    std::auto_ptr<RooAbsReal> nllAlt_(pdfAlt_->createNLL(data));
+    std::unique_ptr<RooAbsReal> nllNull_(pdfNull_->createNLL(data));
+    std::unique_ptr<RooAbsReal> nllAlt_(pdfAlt_->createNLL(data));
 
     *paramsNull_ = snapNull_;
     *paramsNull_ = nullPOI;

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -167,7 +167,7 @@ toymcoptutils::SinglePdfGenInfo::generatePseudoAsimov(RooRealVar *&weightVar, in
         if ( verbose > 2 ) printf("  ToyMCSamplerOpt -- Generating PseudoAsimov dataset for pdf %s: with %d weighted events\n", pdf_->GetName(), nPoints);
         if ( verbose > 0 ) Logger::instance().log(std::string(Form("ToyMCSamplerOpt.cc: %d -- Generating PseudoAsimov dataset for pdf %s: with %d weighted events",__LINE__,pdf_->GetName(),nPoints)),Logger::kLogLevelInfo,__func__);
         double expEvents = pdf_->expectedEvents(observables_);
-        std::auto_ptr<RooDataSet> data(pdf_->generate(observables_, nPoints));
+        std::unique_ptr<RooDataSet> data(pdf_->generate(observables_, nPoints));
         if (weightVar == 0) weightVar = new RooRealVar("_weight_","",1.0);
         RooArgSet obsPlusW(observables_); obsPlusW.add(*weightVar);
         RooDataSet *rds = new RooDataSet(data->GetName(), "", obsPlusW, weightVar->GetName());
@@ -282,7 +282,7 @@ toymcoptutils::SinglePdfGenInfo::generateCountingAsimov()
 void
 toymcoptutils::SinglePdfGenInfo::setToExpected(RooProdPdf &prod, RooArgSet &obs) 
 {
-    std::auto_ptr<TIterator> iter(prod.pdfList().createIterator());
+    std::unique_ptr<TIterator> iter(prod.pdfList().createIterator());
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         if (!a->dependsOn(obs)) continue;
         RooPoisson *pois = 0;
@@ -301,7 +301,7 @@ toymcoptutils::SinglePdfGenInfo::setToExpected(RooPoisson &pois, RooArgSet &obs)
 {
     RooRealVar *myobs = 0;
     RooAbsReal *myexp = 0;
-    std::auto_ptr<TIterator> iter(pois.serverIterator());
+    std::unique_ptr<TIterator> iter(pois.serverIterator());
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         if (obs.contains(*a)) {
             assert(myobs == 0 && "SinglePdfGenInfo::setToExpected(RooPoisson): Two observables??");

--- a/src/VectorizedHistFactoryPdfs.cc
+++ b/src/VectorizedHistFactoryPdfs.cc
@@ -11,7 +11,7 @@ void
 cacheutils::VectorizedHistFunc::fill() 
 {
     RooArgSet obs(*data_->get());
-    std::auto_ptr<RooArgSet> params(pdf_->getObservables(obs));
+    std::unique_ptr<RooArgSet> params(pdf_->getObservables(obs));
 
     yvals_.reserve(data_->numEntries());
     for (unsigned int i = 0, n = data_->numEntries(); i < n; ++i) {
@@ -37,7 +37,7 @@ cacheutils::VectorizedHistFunc::VectorizedHistFunc(const RooHistFunc &pdf, const
     
 {
     RooArgSet obs(*data.get());
-    std::auto_ptr<RooArgSet> params(pdf.getParameters(data));
+    std::unique_ptr<RooArgSet> params(pdf.getParameters(data));
     if (params->getSize() != 0) throw std::invalid_argument("HistFunc with parameters !?");
 
     //const RooRealVar * x_ = dynamic_cast<const RooRealVar*>(obs.first());

--- a/src/VectorizedSimplePdfs.cc
+++ b/src/VectorizedSimplePdfs.cc
@@ -8,7 +8,7 @@
 VectorizedExponential::VectorizedExponential(const RooExponential &pdf, const RooAbsData &data, bool includeZeroWeights)
 {
     RooArgSet obs(*data.get());
-    std::auto_ptr<RooArgSet> params(pdf.getParameters(data));
+    std::unique_ptr<RooArgSet> params(pdf.getParameters(data));
     if (params->getSize() != 1) throw std::invalid_argument("Can't resolve which is the parameter of the exponential");
 
     x_ = dynamic_cast<const RooRealVar*>(obs.first());

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -94,20 +94,20 @@ void utils::printRAD(const RooAbsData *d) {
 
 void utils::printPdf(const RooAbsReal *pdf) {
   std::cout << "Pdf " << pdf->GetName() << " parameters." << std::endl;
-  std::auto_ptr<RooArgSet> params(pdf->getVariables());
+  std::unique_ptr<RooArgSet> params(pdf->getVariables());
   params->Print("V");
 }
 
 
 void utils::printPdf(RooStats::ModelConfig &mc) {
   std::cout << "ModelConfig " << mc.GetName() << " (" << mc.GetTitle() << "): pdf parameters." << std::endl;
-  std::auto_ptr<RooArgSet> params(mc.GetPdf()->getVariables());
+  std::unique_ptr<RooArgSet> params(mc.GetPdf()->getVariables());
   params->Print("V");
 }
 
 void utils::printPdf(RooWorkspace *w, const char *pdfName) {
   std::cout << "PDF " << pdfName << " parameters." << std::endl;
-  std::auto_ptr<RooArgSet> params(w->pdf(pdfName)->getVariables());
+  std::unique_ptr<RooArgSet> params(w->pdf(pdfName)->getVariables());
   params->Print("V");
 }
 
@@ -238,7 +238,7 @@ void utils::factorizeFunc(const RooArgSet &observables, RooAbsReal &func, RooArg
         RooProduct *prod = dynamic_cast<RooProduct *>(&func);
         RooArgList components(utils::factors(*prod));
         //std::cout << "Function " << func.GetName() << " is a RooProduct with " << components.getSize() << " components." << std::endl;
-        std::auto_ptr<TIterator> iter(components.createIterator());
+        std::unique_ptr<TIterator> iter(components.createIterator());
         for (RooAbsReal *funci = (RooAbsReal *) iter->Next(); funci != 0; funci = (RooAbsReal *) iter->Next()) {
             //std::cout << "  component " << funci->GetName() << " of type " << funci->ClassName() << "(dep obs? " << funci->dependsOn(observables) << ")" << std::endl;
             factorizeFunc(observables, *funci, obsTerms, constraints, true);
@@ -306,11 +306,11 @@ RooAbsReal *utils::fullCloneFunc(const RooAbsReal *pdf, const RooArgSet &obs, Ro
 
 
 void utils::getClients(const RooAbsCollection &values, const RooAbsCollection &allObjects, RooAbsCollection &clients) {
-    std::auto_ptr<TIterator> iterAll(allObjects.createIterator());
-    std::auto_ptr<TIterator> iterVal(values.createIterator());
+    std::unique_ptr<TIterator> iterAll(allObjects.createIterator());
+    std::unique_ptr<TIterator> iterVal(values.createIterator());
     for (RooAbsArg *v = (RooAbsArg *) iterVal->Next(); v != 0; v = (RooAbsArg *) iterVal->Next()) {
         if (typeid(*v) != typeid(RooRealVar) && typeid(*v) != typeid(RooCategory)) continue;
-        std::auto_ptr<TIterator> clientIter(v->clientIterator());
+        std::unique_ptr<TIterator> clientIter(v->clientIterator());
         for (RooAbsArg *a = (RooAbsArg *) clientIter->Next(); a != 0; a = (RooAbsArg *) clientIter->Next()) {
             if (allObjects.containsInstance(*a) && !clients.containsInstance(*a)) clients.add(*a);
         }
@@ -319,7 +319,7 @@ void utils::getClients(const RooAbsCollection &values, const RooAbsCollection &a
 
 bool utils::setAllConstant(const RooAbsCollection &coll, bool constant) {
     bool changed = false;
-    std::auto_ptr<TIterator> iter(coll.createIterator());
+    std::unique_ptr<TIterator> iter(coll.createIterator());
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         RooRealVar *v = dynamic_cast<RooRealVar *>(a);
         RooCategory *cv = dynamic_cast<RooCategory *>(a);
@@ -350,7 +350,7 @@ TString utils::printRooArgAsString(RooAbsArg *a){
 
 bool utils::checkModel(const RooStats::ModelConfig &model, bool throwOnFail) {
     bool ok = true; std::ostringstream errors; 
-    std::auto_ptr<TIterator> iter;
+    std::unique_ptr<TIterator> iter;
     RooAbsPdf *pdf = model.GetPdf(); if (pdf == 0) throw std::invalid_argument("Model without Pdf");
     RooArgSet allowedToFloat; 
     if (model.GetObservables() == 0) { 
@@ -391,7 +391,7 @@ bool utils::checkModel(const RooStats::ModelConfig &model, bool throwOnFail) {
             if (!pdf->dependsOn(*v)) { errors << "WARNING: pdf does not depend on global observable " << a->GetName() << "\n"; continue; }
         }
     }
-    std::auto_ptr<RooArgSet> params(pdf->getParameters(*model.GetObservables()));
+    std::unique_ptr<RooArgSet> params(pdf->getParameters(*model.GetObservables()));
     iter.reset(params->createIterator());
     for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
         if (a->getAttribute("flatParam") && a->isConstant()) {
@@ -416,12 +416,12 @@ bool utils::checkModel(const RooStats::ModelConfig &model, bool throwOnFail) {
 
     if (model.GetNuisanceParameters() != 0) {
         RooArgList constraints;
-        std::auto_ptr<RooAbsPdf> factorizedPdf(utils::factorizePdf(*model.GetObservables(), *model.GetPdf(), constraints));
+        std::unique_ptr<RooAbsPdf> factorizedPdf(utils::factorizePdf(*model.GetObservables(), *model.GetPdf(), constraints));
         if (factorizedPdf.get() == 0 || factorizedPdf.get() == model.GetPdf()) {
             factorizedPdf.release();
             ok = false; errors << "ERROR: have nuisance parameters, but can't factorize the pdf\n";
         }
-        std::auto_ptr<RooArgSet> obsParams(factorizedPdf->getParameters(*model.GetObservables()));
+        std::unique_ptr<RooArgSet> obsParams(factorizedPdf->getParameters(*model.GetObservables()));
         iter.reset(model.GetNuisanceParameters()->createIterator());
         for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
             if (!obsParams->contains(*a))  {
@@ -596,7 +596,7 @@ utils::makePlots(const RooAbsPdf &pdf, const RooAbsData &data, const char *signa
         TIter next(datasets);
         for (RooAbsData *ds = (RooAbsData *) next(); ds != 0; ds = (RooAbsData *) next()) {
             RooAbsPdf *pdfi  = sim->getPdf(ds->GetName());
-            std::auto_ptr<RooArgSet> obs(pdfi->getObservables(ds));
+            std::unique_ptr<RooArgSet> obs(pdfi->getObservables(ds));
             if (obs->getSize() == 0) break;
 	    TIterator *obs_iter = obs->createIterator();
 	    std::cout << " PDF CHECKING " << std::endl; 
@@ -625,7 +625,7 @@ utils::makePlots(const RooAbsPdf &pdf, const RooAbsData &data, const char *signa
         }
         delete datasets;
     } else if (pdf.canBeExtended()) {
-        std::auto_ptr<RooArgSet> obs(pdf.getObservables(&data));
+        std::unique_ptr<RooArgSet> obs(pdf.getObservables(&data));
 
 	//for (int iobs=0;iobs<obs->getSize();iobs++){
 	TIterator *obs_iter = obs->createIterator();
@@ -725,7 +725,7 @@ void utils::setModelParameters( const std::string & setPhysicsModelParameterExpr
         std::cout<<"interpreting "<<reg_esp<<" as regex "<<std::endl;
         std::regex rgx( reg_esp, std::regex::ECMAScript);
 
-        std::auto_ptr<TIterator> iter(params.createIterator());
+        std::unique_ptr<TIterator> iter(params.createIterator());
         for (RooAbsArg *tmp = (RooAbsArg*) iter->Next(); tmp != 0; tmp = (RooAbsArg*) iter->Next()) {
 
             bool isrvar = tmp->IsA()->InheritsFrom(RooRealVar::Class());  // check its type    
@@ -816,7 +816,7 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
           std::cout<<"interpreting "<<reg_esp<<" as regex "<<std::endl;
           std::regex rgx( reg_esp, std::regex::ECMAScript);
 
-          std::auto_ptr<TIterator> iter(params.createIterator());
+          std::unique_ptr<TIterator> iter(params.createIterator());
           for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
               RooRealVar *tmpParameter = dynamic_cast<RooRealVar *>(a);
               const std::string &target = tmpParameter->GetName();
@@ -1018,7 +1018,7 @@ bool utils::freezeAllDisassociatedRooMultiPdfParameters(RooArgSet multiPdfs, Roo
 	// For each multiPdf, get the active pdf and remove its parameters 
 	// from this list of params and then freeze the remaining ones 
 	
-        std::auto_ptr<TIterator> iter_p(multiPdfs.createIterator());
+        std::unique_ptr<TIterator> iter_p(multiPdfs.createIterator());
         for (RooAbsArg *P = (RooAbsArg *) iter_p->Next(); P != 0; P = (RooAbsArg *) iter_p->Next()) {
 	  RooMultiPdf *mpdf = dynamic_cast<RooMultiPdf *>(P);
 	  RooAbsPdf *pdf = (RooAbsPdf*)mpdf->getCurrentPdf();


### PR DESCRIPTION
Hello,

as discussed 2 weeks ago on my presentation about the standalone compilation, I'm suggesting some changes to theoretically alow for unproblematic standalone compilation outside the CERN environment, i.e. on your laptop.

At the beginning would be a very unintrusive change which allows to compile this package with any recent C++ compiler without any resistance: replacing the `auto_ptr` removed in C++17 with the new `unique_ptr`. This also entails replacing `0` with `nullptr` at some places, since the `unique_ptr` can't be initialized with an integer.

I hope `102x` is the correct branch for new developments? That's what you said in the meeting, right? When this PR is through, I could next integrate my CMake files to compile the package on any platform without either relying on CMSSW or `cvmfs`, like the current standalone compilation does. My requirements on the C++ side of combine would then be met :-)

Cheers,
Jonas