### PR TITLE
Likelihood scans from files containing multiple toys

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -1032,6 +1032,12 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     algo->setNToys(nToys);
 
     for (iToy = 1; iToy <= nToys; ++iToy) {
+
+      // Reset ranges --> for likelihood scans
+      if (setPhysicsModelParameterRangeExpression_ != "") {
+	utils::setModelParameterRanges( setPhysicsModelParameterRangeExpression_, w->allVars());
+      }
+
       algo->setToyNumber(iToy-1);
       RooAbsData *absdata_toy = 0;
       if (readToysFromHere == 0) {
@@ -1209,8 +1215,6 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
       	      if (verbose) Logger::instance().log(std::string(Form("Combine.cc: %d -- Adding discrete %s ",__LINE__,cat->GetName())),Logger::kLogLevelInfo,__func__);
 	    }
             (CascadeMinimizerGlobalConfigs::O().pdfCategories).add(*arg);
-
-	    
           }
         }
     } 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -154,6 +154,7 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
 
     // Process POI not in list
     nOtherFloatingPoi_ = 0;
+    deltaNLL_ = 0;
     int nConstPoi=0;
     RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();
     std::string setConstPOI;


### PR DESCRIPTION
Dear Experts,

I noticed a couple of small fixes that could be interesting for combine.. in case not feel free to skip and close this PR (I had also a quick discussion by email with @nucleosynthesis). 

In the context of bias studies for Hmm analysis, I am performing fits on a set of generated toys. In particular, since we are studying the possible usage of a discrete likelihood profile, for each toy we are performing a "quick" likelihood scan to have the best estimation of the post-fit uncertainty (crossing at 2*deltaNLL = 1). To better clarify my observations, I am gonna use one of the datacards committed in combine to make an example:

1) Toy generation: 

combine -M GenerateOnly simple-shapes-TH1.txt -t 10 --toysFrequentist --expectSignal 1 -n _toys --saveToys -s 0

2) Fit + likelihood scan: 

combine -M MultiDimFit simple-shapes-TH1.txt -t 10 --toysFile higgsCombine_toys.GenerateOnly.mH120.0.root --algo grid --points 50 --autoRange 3 -n _scan --forceRecreateNLL --setParameterRanges r=-10,10

If you open the output file you can see the following:
limit->Scan("2*deltaNLL:r","iToy==1","L")
*        0 *         0 * 1.0140694 *
....
*       50 * 6.0868215 * 3.0260498 *

limit->Scan("2*deltaNLL:r","iToy==2","L")
*       51 * 6.0868215 * 0.8925997 *
*       52 * 8.5949173 * -0.720857 *

I think this is because deltaNLL is not reset to 0 when runSpecific method is called, so it stores in the tree the value of the last point of the previous scan.

In addition, if autoRange is used to center the likelihood scan around the best-fit, the range of POI are not correctly reset in each toy. For example, the range determined by the fit/scan of the first toy is used as minimum/maximum bound for the POI in the second toy, etc. For example, in the file produced by MultiDimFit you can plot the scan for iToy==4 and you will get [0] which does not corresponds to 3-sigma belt around the best-fit. In this PR, I fixed it by re-setting the parameter range inside the toy loop but there could be better ways to obtain the same effect.

Hope this helps, Best Regards,

Raffaele 

[0] https://www.dropbox.com/s/bld4f67apai1q5d/Screenshot%202019-05-28%2011.40.39.png?dl=0


