### PR TITLE
Automatic file cache clearing

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -24,7 +24,7 @@ def addDatacardParserOptions(parser):
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
-    parser.add_option("--no-clear-caches",  dest="noClearCache", default=False, action='store_true', help="File/Workspace caches will be cleared if more than 100 files are open. Add this flag to not clear them.")
+    parser.add_option("--X-no-clear-caches",  dest="noClearCache", default=-1, type=int, help="File/Workspace caches will be cleared if more than X files are open. Set X=-1 (default) to never clear the cache.")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")
     parser.add_option("--X-rescale-nuisance", dest="nuisancesToRescale", type="string", action="append", nargs=2, default=[], help="Rescale by this factor the nuisances that match these regular expressions (the rescaling is applied to the sigma of the gaussian constraint term).")
     parser.add_option("--X-nuisance-function", dest="nuisanceFunctions", type="string", action="append", nargs=2, default=[], help="Set the sigma of the gaussian to be a function for the nuisances that match the regular expression")

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -24,7 +24,7 @@ def addDatacardParserOptions(parser):
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
-    parser.add_option("--X-no-clear-caches",  dest="noClearCache", default=-1, type=int, help="File/Workspace caches will be cleared if more than X files are open. Set X=-1 (default) to never clear the cache.")
+    parser.add_option("--X-clear-caches",  dest="noClearCache", default=-1, type=int, help="File/Workspace caches will be cleared if more than X (number specified) files are open. Set X=-1 (default) to never clear the cache.")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")
     parser.add_option("--X-rescale-nuisance", dest="nuisancesToRescale", type="string", action="append", nargs=2, default=[], help="Rescale by this factor the nuisances that match these regular expressions (the rescaling is applied to the sigma of the gaussian constraint term).")
     parser.add_option("--X-nuisance-function", dest="nuisanceFunctions", type="string", action="append", nargs=2, default=[], help="Set the sigma of the gaussian to be a function for the nuisances that match the regular expression")

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -24,7 +24,7 @@ def addDatacardParserOptions(parser):
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
-    parser.add_option("--X-clear-caches",  dest="noClearCache", default=-1, type=int, help="File/Workspace caches will be cleared if more than X (number specified) files are open. Set X=-1 (default) to never clear the cache.")
+    parser.add_option("--X-clear-caches",  dest="noClearCache", default=-1, type="int", help="File/Workspace caches will be cleared if more than X (number specified) files are open. Set X=-1 (default) to never clear the cache.")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")
     parser.add_option("--X-rescale-nuisance", dest="nuisancesToRescale", type="string", action="append", nargs=2, default=[], help="Rescale by this factor the nuisances that match these regular expressions (the rescaling is applied to the sigma of the gaussian constraint term).")
     parser.add_option("--X-nuisance-function", dest="nuisanceFunctions", type="string", action="append", nargs=2, default=[], help="Set the sigma of the gaussian to be a function for the nuisances that match the regular expression")

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -24,6 +24,7 @@ def addDatacardParserOptions(parser):
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")
     parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="never", help="Use RooHistPdf for TH1s: 'always', 'never' (default), 'when-constant' (i.e. not when doing template morphing)")
+    parser.add_option("--no-clear-caches",  dest="noClearCache", default=False, action='store_true', help="File/Workspace caches will be cleared if more than 100 files are open. Add this flag to not clear them.")
     parser.add_option("--X-exclude-nuisance", dest="nuisancesToExclude", type="string", action="append", default=[], help="Exclude nuisances that match these regular expressions.")
     parser.add_option("--X-rescale-nuisance", dest="nuisancesToRescale", type="string", action="append", nargs=2, default=[], help="Rescale by this factor the nuisances that match these regular expressions (the rescaling is applied to the sigma of the gaussian constraint term).")
     parser.add_option("--X-nuisance-function", dest="nuisanceFunctions", type="string", action="append", nargs=2, default=[], help="Set the sigma of the gaussian to be a function for the nuisances that match the regular expression")

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -423,7 +423,22 @@ class ShapeBuilder(ModelBuilder):
     ## -------------------------------------
     ## -------- Low level helpers ----------
     ## -------------------------------------
+
+    def clearCachedFiles(self,lcache): 
+	if self.options.verbose: print "Too many files in cache open, clearing cache"
+	for f in lcache.keys(): 
+	 if self.options.verbose: print "... closing/clearing ", f
+	 if lcache[f].InheritsFrom("TFile"): lcache[f].Close()
+	lcache = {}
+	return lcache
+
     def getShape(self,channel,process,syst="",_fileCache={},_cache={},allowNoSyst=False):
+
+        if not self.options.noClearCache:
+	  maxFiles = 100
+	  if len(_fileCache)    > maxFiles : _fileCache = self.clearCachedFiles(_fileCache) 
+	  if len(self.wspnames) > maxFiles : self.wspnames = self.clearCachedFiles(self.wspnames)
+	    
         if _cache.has_key((channel,process,syst)): 
             if self.options.verbose > 2: print "recyling (%s,%s,%s) -> %s\n" % (channel,process,syst,_cache[(channel,process,syst)].GetName())
             return _cache[(channel,process,syst)];

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -434,8 +434,8 @@ class ShapeBuilder(ModelBuilder):
 
     def getShape(self,channel,process,syst="",_fileCache={},_cache={},allowNoSyst=False):
 
-        if not self.options.noClearCache:
-	  maxFiles = 100
+        if self.options.noClearCache>0:
+	  maxFiles = self.options.noClearCache
 	  if len(_fileCache)    > maxFiles : _fileCache = self.clearCachedFiles(_fileCache) 
 	  if len(self.wspnames) > maxFiles : self.wspnames = self.clearCachedFiles(self.wspnames)
 	    


### PR DESCRIPTION
If more than 100 files are open (either in `_fileCache` or workspaces in `wspnames` objects), the caches are cleared to avoid "Too many open files" errors on user accounts