### PR TITLE
No longer need to reset Minimizer if changing parametrs of NLL

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1030,7 +1030,7 @@ bool utils::freezeAllDisassociatedRooMultiPdfParameters(RooArgSet multiPdfs, Roo
 	} 
 	
 	if (multiPdfParams->getSize()>0 ) {
-	 std::cout << " Going to freeze these disacociated params" << std::endl; 
+	 std::cout << " Going to " << (freeze ? " freeze " : " float ") << " these disacociated params" << std::endl; 
 	 multiPdfParams->Print();
 	 setAllConstant(*multiPdfParams,freeze);
 	 return true;


### PR DESCRIPTION
Removing recreation of RooMinimizer between freezing/floating long lists of parameters as new interface allows this. 