### PR TITLE
Workaround for running models with > 100 processes in a RooAddPdf

### DIFF
--- a/interface/utils.h
+++ b/interface/utils.h
@@ -8,6 +8,7 @@
 #include <TString.h>
 #include <RooHistError.h>
 #include <RooFitResult.h>
+#include <RooAddPdf.h>
 #include <TH1.h>
 struct RooDataHist;
 struct RooAbsData;
@@ -119,5 +120,17 @@ namespace utils {
     int countFloating(const RooArgSet &);
     RooArgSet returnAllVars(RooWorkspace *);
     bool freezeAllDisassociatedRooMultiPdfParameters(RooArgSet multiPdfs, RooArgSet allRooMultiPdfParams, bool freeze=true);
+
+    // This is a workaround for a bug (?) in RooAddPdf that limits the number of elements
+    // to 100 when de-serialised from a TFile. We have to access a protected array and reallocate
+    // it with the correct size
+    class RooAddPdfFixer : public RooAddPdf {
+    public:
+      RooAddPdfFixer() : RooAddPdf() {}
+      RooAddPdfFixer(RooAddPdfFixer const& other) : RooAddPdf(other) {}
+
+      void Fix(RooAddPdf & fixme);
+      void FixAll(RooWorkspace & w);
+    };
 }
 #endif

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -374,6 +374,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
         mc_bonly = new RooStats::ModelConfig(*mc);
         mc_bonly->SetPdf(*model_b);
     }
+
+    // Fix for large RooAddPdfs
+    utils::RooAddPdfFixer addpdfFixer;
+    addpdfFixer.FixAll(*w);
     
     // Specific settings should be executed before user specified ranges!
     RooRealVar *r = (RooRealVar*)POI->first();

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1042,3 +1042,21 @@ bool utils::freezeAllDisassociatedRooMultiPdfParameters(RooArgSet multiPdfs, Roo
 	return false;
 }
 
+void utils::RooAddPdfFixer::Fix(RooAddPdf & fixme) {
+  RooAddPdfFixer & fixme_casted = static_cast<RooAddPdfFixer &>(fixme);
+  delete[] fixme_casted.RooAddPdf::_coefCache;
+  fixme_casted.RooAddPdf::_coefCache = new Double_t[fixme_casted.RooAddPdf::_pdfList.getSize()];
+}
+
+void utils::RooAddPdfFixer::FixAll(RooWorkspace & w) {
+  auto pdfs = w.allPdfs();
+  TIterator *iter = pdfs.createIterator();
+  for (RooAbsArg *a = 0; (a = (RooAbsArg *)iter->Next()) != 0; ) {
+    RooAddPdf *addpdf = dynamic_cast<RooAddPdf*>(a);
+    if (addpdf && addpdf->pdfList().getSize() > 100) {
+      // std::cout << "> Fixing RooAddPdf " << addpdf->GetName() << " which has " << addpdf->pdfList().getSize() << " components\n";
+      Fix(*addpdf);
+    }
+  }
+}
+


### PR DESCRIPTION
Fixes the issue reported here: https://hypernews.cern.ch/HyperNews/CMS/get/higgs-combination/1341.html

Combine now scans all RooAddPdfs in the model, and with a bit of a hack expands the incorrectly sized array data members. Some more description of the problem is below:

> Running valgrind on the problematic examples given there reveals that there are invalid memory read/writes in RooAddPdf::updateCoefficients, for example on l697 here: https://root.cern.ch/doc/master/RooAddPdf_8cxx_source.html#l00697. The problem is this _coefCache array. In the normal RooAddPdf constructor, this is allocated with the size of the number of pdfs (l271). But the normal constructors are not used when reading ROOT objects out of a TFile - if I understand it correctly, the default constructor is called to allocate memory, then the data members are filled by the ROOT-created streamer function. Now in the default constructor (l99) this array is given a default size of 100. I suspect this is never updated when the RooAddPdf from disk  is then streamed in. With a very simple test example - with 100 elements in my RooAddPdf there are no problems - with 101 i see these invalid writes with valgrind. This doesn't guarantee a segfault, it depends on the particular memory layout used by the machine in the execution of the program.

Will follow up with the RooFit devs for a longer term fix.