### PR TITLE
Options to speed up discrete minimization

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -180,7 +180,7 @@ class CachingSimNLL  : public RooAbsReal {
         void setAnalyticBarlowBeeston(bool flag);
         void setHideRooCategories(bool flag) { hideRooCategories_ = flag; }
         void setHideConstants(bool flag) { hideConstants_ = flag; }
-        void setMaskConstraints(bool flag) { maskConstraints_ = flag; }
+        void setMaskConstraints(bool flag) ;
         void setMaskNonDiscreteChannels(bool mask) ;
         friend class CachingAddNLL;
         // trap this call, since we don't care about propagating it to the sub-components
@@ -212,6 +212,9 @@ class CachingSimNLL  : public RooAbsReal {
         std::vector<RooAbsReal*> channelMasks_;
         std::vector<bool>        internalMasks_;
         bool                     maskConstraints_;
+        RooArgSet                activeParameters_, activeCatParameters_;
+        double                   maskingOffset_;     // offset to ensure that interal or constraint masking doesn't change NLL value
+        double                   maskingOffsetZero_; // and associated zero point
 };
 
 }

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -180,6 +180,8 @@ class CachingSimNLL  : public RooAbsReal {
         void setAnalyticBarlowBeeston(bool flag);
         void setHideRooCategories(bool flag) { hideRooCategories_ = flag; }
         void setHideConstants(bool flag) { hideConstants_ = flag; }
+        void setMaskConstraints(bool flag) { maskConstraints_ = flag; }
+        void setMaskNonDiscreteChannels(bool mask) ;
         friend class CachingAddNLL;
         // trap this call, since we don't care about propagating it to the sub-components
         virtual void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) { }
@@ -208,6 +210,8 @@ class CachingSimNLL  : public RooAbsReal {
         std::vector<double> constrainZeroPointsFast_;
         std::vector<double> constrainZeroPointsFastPoisson_;
         std::vector<RooAbsReal*> channelMasks_;
+        std::vector<bool>        internalMasks_;
+        bool                     maskConstraints_;
 };
 
 }

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -461,7 +461,7 @@ class ModelBuilder(ModelBuilderBase):
                         self.out.var(n).setRange(self.out.function('%s_BoundLo' % n), self.out.function('%s_BoundHi' % n))
                 else:
                     if len(args) == 3: # mean, sigma, range
-		    	sigma = double(args[2])
+		    	sigma = float(args[2])
                         if self.out.var(n):
                           bounds = [float(x) for x in args[2][1:-1].split(",")]
                           self.out.var(n).setConstant(False)

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -839,7 +839,7 @@ cacheutils::CachingSimNLL::CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data,
     nuis_(nuis),
     params_("params","parameters",this),
     catParams_("catParams","Category parameters",this),
-    hideRooCategories_(false), hideConstants_(false)
+    hideRooCategories_(false), hideConstants_(false), maskConstraints_(false)
 {
     setup_();
 }
@@ -851,7 +851,9 @@ cacheutils::CachingSimNLL::CachingSimNLL(const CachingSimNLL &other, const char 
     params_("params","parameters",this),
     catParams_("catParams","Category parameters",this),
     hideRooCategories_(other.hideRooCategories_),
-    hideConstants_(other.hideConstants_)
+    hideConstants_(other.hideConstants_),
+    internalMasks_(other.internalMasks_),
+    maskConstraints_(other.maskConstraints_)
 {
     setup_();
 }
@@ -989,6 +991,7 @@ cacheutils::CachingSimNLL::setup_()
     datasets_.resize(pdfs_.size(), 0);
     splitWithWeights(*dataOriginal_, simpdf->indexCat(), true);
     //std::cout << "Pdf " << simpdf->GetName() <<" is a SimPdf over category " << catClone->GetName() << ", with " << pdfs_.size() << " bins" << std::endl;
+    unsigned int nchannels = 0;
     for (int ib = 0, nb = pdfs_.size(); ib < nb; ++ib) {
         catClone->setBin(ib);
         RooAbsPdf *pdf = simpdf->getPdf(catClone->getLabel());
@@ -1001,12 +1004,19 @@ cacheutils::CachingSimNLL::setup_()
             pdfs_[ib] = new CachingAddNLL(catClone->getLabel(), "", pdf, data, includeZeroWeights);
             params_.add(pdfs_[ib]->params(), /*silent=*/true); 
             catParams_.add(pdfs_[ib]->catParams(), /*silent=*/true); 
+            ++nchannels;
         } else { 
             pdfs_[ib] = 0; 
             //std::cout << "   bin " << ib << " (label " << catClone->getLabel() << ") has no pdf" << std::endl;
         }
     }   
 
+    std::cout << "SimNLL created with " << nchannels << " channels, " <<
+                 constrainPdfs_.size() << " generic constraints, " << 
+                 constrainPdfsFast_.size() << " fast gaussian constraints, " << 
+                 constrainPdfsFastPoisson_.size() << " fast poisson constraints, " << 
+                 constrainPdfGroups_.size() << " fast group constraints, " << 
+                 std::endl;
     setValueDirty();
 }
 
@@ -1026,10 +1036,13 @@ cacheutils::CachingSimNLL::evaluate() const
     unsigned idx = 0;
     for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it, ++idx) {
         if (*it != 0) {
-            if (channelMasks_.size() > 0 && channelMasks_[idx]->getVal() != 0.) {
+            if (!channelMasks_.empty() && channelMasks_[idx]->getVal() != 0.) {
                 // std::cout << "Channel " << (*it)->GetName() << " will be masked as " 
                 //     << channelMasks_[idx]->GetName() << " evalutes to " 
                 //     << channelMasks_[idx]->getVal() << "\n";
+                continue;
+            }
+            if (!internalMasks_.empty() && !internalMasks_[idx]) {
                 continue;
             }
             double nllval = (*it)->getVal();
@@ -1037,7 +1050,7 @@ cacheutils::CachingSimNLL::evaluate() const
             ret += nllval;
         }
     }
-    if (!constrainPdfs_.empty() || !constrainPdfsFast_.empty()) {
+    if (!maskConstraints_ && (!constrainPdfs_.empty() || !constrainPdfsFast_.empty() || !constrainPdfsFastPoisson_.empty() || !constrainPdfGroups_.empty())) {
         DefaultAccumulator<double> ret2 = 0;
         /// ============= GENERIC CONSTRAINTS  =========
         std::vector<double>::const_iterator itz = constrainZeroPoints_.begin();
@@ -1235,5 +1248,24 @@ cacheutils::CachingSimNLL::getParameters(const RooArgSet* depList, Bool_t stripD
     if (!hideRooCategories_) ret->add(catParams_);
     if (hideConstants_) RooStats::RemoveConstantParameters(ret);
     return ret;
+}
+
+void cacheutils::CachingSimNLL::setMaskNonDiscreteChannels(bool mask) {
+    if (!mask) { internalMasks_.clear(); return; } 
+    internalMasks_.resize(pdfs_.size(), false);
+    unsigned int idx = 0;
+    for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it, ++idx) {
+        if ((*it) == 0) continue;
+        RooLinkedListIter iter = (*it)->catParams().iterator();
+        for (RooAbsArg *P = (RooAbsArg *) iter.Next(); P != 0; P = (RooAbsArg *) iter.Next()) {
+            RooCategory *cat = dynamic_cast<RooCategory *>(P);
+            if (!cat) continue;
+            if (cat && !cat->isConstant()) {
+                internalMasks_[idx] = true; 
+                std::cout << "Enabling channel " << (*it)->GetName() << " that depends on non-const category " << cat->GetName() << std::endl;
+                break;
+            }
+        }
+    }
 }
 

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -839,7 +839,7 @@ cacheutils::CachingSimNLL::CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data,
     nuis_(nuis),
     params_("params","parameters",this),
     catParams_("catParams","Category parameters",this),
-    hideRooCategories_(false), hideConstants_(false), maskConstraints_(false)
+    hideRooCategories_(false), hideConstants_(false), maskConstraints_(false), maskingOffset_(0), maskingOffsetZero_(0)
 {
     setup_();
 }
@@ -853,7 +853,9 @@ cacheutils::CachingSimNLL::CachingSimNLL(const CachingSimNLL &other, const char 
     hideRooCategories_(other.hideRooCategories_),
     hideConstants_(other.hideConstants_),
     internalMasks_(other.internalMasks_),
-    maskConstraints_(other.maskConstraints_)
+    maskConstraints_(other.maskConstraints_),
+    maskingOffset_(other.maskingOffset_),
+    maskingOffsetZero_(other.maskingOffsetZero_)
 {
     setup_();
 }
@@ -1087,6 +1089,7 @@ cacheutils::CachingSimNLL::evaluate() const
         }
         ret -= ret2.sum();
     }
+    ret += (maskingOffset_ - maskingOffsetZero_);
 #ifdef TRACE_NLL_EVALS
     static unsigned long _trace_ = 0; _trace_++;
     if (_trace_ % 10 == 0)  { putchar('.'); fflush(stdout); }
@@ -1187,6 +1190,7 @@ void cacheutils::CachingSimNLL::setZeroPoint() {
     for (SimpleConstraintGroup & g : constrainPdfGroups_) {
         g.setZeroPoint();
     }
+    maskingOffsetZero_ = maskingOffset_;
     setValueDirty();
 }
 
@@ -1198,6 +1202,7 @@ void cacheutils::CachingSimNLL::clearZeroPoint() {
     std::fill(constrainZeroPointsFast_.begin(), constrainZeroPointsFast_.end(), 0.0);
     std::fill(constrainZeroPointsFastPoisson_.begin(), constrainZeroPointsFastPoisson_.end(), 0.0);
     for (SimpleConstraintGroup & g : constrainPdfGroups_) g.clearZeroPoint();
+    maskingOffsetZero_ = 0;
     setValueDirty();
 }
 
@@ -1244,28 +1249,55 @@ cacheutils::CachingSimNLL::getObservables(const RooArgSet* depList, Bool_t value
 RooArgSet* 
 cacheutils::CachingSimNLL::getParameters(const RooArgSet* depList, Bool_t stripDisconnected) const 
 {
-    RooArgSet *ret = new RooArgSet(params_); 
-    if (!hideRooCategories_) ret->add(catParams_);
+    RooArgSet *ret;
+    if (internalMasks_.empty()) {
+        ret = new RooArgSet(params_); 
+        if (!hideRooCategories_) ret->add(catParams_);
+    } else {
+        ret = new RooArgSet(activeParameters_); 
+        if (!hideRooCategories_) ret->add(activeCatParameters_);
+    }
     if (hideConstants_) RooStats::RemoveConstantParameters(ret);
     return ret;
 }
 
+void cacheutils::CachingSimNLL::setMaskConstraints(bool flag) {
+    double nllBefore = evaluate();
+    maskConstraints_ = flag;
+    double nllAfter = evaluate();
+    maskingOffset_ += (nllBefore - nllAfter);
+    //printf("CachingSimNLL: setMaskConstraints(%d): nll before %.12g, nll after %.12g (diff %.12g), new maskingOffset %.12g, check = %.12g\n",
+    //            int(flag), nllBefore, nllAfter, (nllBefore-nllAfter), maskingOffset_, evaluate() - nllBefore);
+}
+
 void cacheutils::CachingSimNLL::setMaskNonDiscreteChannels(bool mask) {
-    if (!mask) { internalMasks_.clear(); return; } 
-    internalMasks_.resize(pdfs_.size(), false);
-    unsigned int idx = 0;
-    for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it, ++idx) {
-        if ((*it) == 0) continue;
-        RooLinkedListIter iter = (*it)->catParams().iterator();
-        for (RooAbsArg *P = (RooAbsArg *) iter.Next(); P != 0; P = (RooAbsArg *) iter.Next()) {
-            RooCategory *cat = dynamic_cast<RooCategory *>(P);
-            if (!cat) continue;
-            if (cat && !cat->isConstant()) {
-                internalMasks_[idx] = true; 
-                std::cout << "Enabling channel " << (*it)->GetName() << " that depends on non-const category " << cat->GetName() << std::endl;
-                break;
+    double nllBefore = evaluate();
+    internalMasks_.clear(); // reset
+    activeParameters_.removeAll(); 
+    activeCatParameters_.removeAll();
+    if (mask) {
+        internalMasks_.resize(pdfs_.size(), false);
+        unsigned int idx = 0;
+        for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it, ++idx) {
+            if ((*it) == 0) continue;
+            RooLinkedListIter iter = (*it)->catParams().iterator();
+            for (RooAbsArg *P = (RooAbsArg *) iter.Next(); P != 0; P = (RooAbsArg *) iter.Next()) {
+                RooCategory *cat = dynamic_cast<RooCategory *>(P);
+                if (!cat) continue;
+                if (cat && !cat->isConstant()) {
+                    internalMasks_[idx] = true; 
+                    activeParameters_.add((*it)->params(), /*silent=*/true); 
+                    activeCatParameters_.add((*it)->catParams(), /*silent=*/true); 
+                    std::cout << "Enabling channel " << (*it)->GetName() << " that depends on non-const category " << cat->GetName() << std::endl;
+                    break;
+                }
             }
         }
     }
+    double nllAfter = evaluate();
+    maskingOffset_ += (nllBefore - nllAfter);
+    //printf("CachingSimNLL: setMaskNonDiscreteChannels(%d): nll before %.12g, nll after %.12g (diff %.12g), new maskingOffset %.12g, check = %.12g\n",
+    //            int(mask), nllBefore, nllAfter, (nllBefore-nllAfter), maskingOffset_, evaluate() - nllBefore);
+    
 }
 

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -355,7 +355,7 @@ bool CascadeMinimizer::iterativeMinimize(double &minimumNLL,int verbose, bool ca
    // unfreeze from *
    freezeDiscParams(false);
 
-   tw.Stop(); std::cout << "Done the full fit in " << tw.RealTime() << std::endl;
+   tw.Stop(); if (verbose > 2) std::cout << "Done the full fit in " << tw.RealTime() << std::endl;
 
    return ret;
 }
@@ -621,11 +621,15 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
       }
       freezeDiscParams(false);
 
+
       fitCounter++;
       double thisNllValue = nll_.getVal();
       
       if ( thisNllValue < minimumNLL ){
 		// Now we insert the correction ! 
+                if (verbose>2) {
+                    std::cout << " .... Found a better fit: new NLL = " << thisNllValue << " (improvement: " << (thisNllValue-minimumNLL) << std::endl;
+                }
 	        minimumNLL = thisNllValue;	
                 //std::cout << " .... Found a better fit! hoorah! " << minimumNLL << std::endl; 
     		snap.assignValueOnly(*params);
@@ -634,6 +638,11 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
 			if (bestIndeces[id] != ((RooCategory*)(pdfCategoryIndeces.at(id)))->getIndex() ) newDiscreteMinimum = true;
 			bestIndeces[id]=((RooCategory*)(pdfCategoryIndeces.at(id)))->getIndex();	
 		}
+                if (verbose>2 && newDiscreteMinimum) {
+                    std::cout << " .... Better fit corresponds to a new set of indices :=" ; 
+                    for (int id=0;id<numIndeces;id++) { std::cout << " " << bestIndeces[id]; }
+                    std::cout << std::endl;
+                }
       }
 
       // FIXME this should be made configurable!
@@ -676,8 +685,7 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
     runtimedef::set("MINIMIZER_analytic", currentBarlowBeeston);
     ROOT::Math::MinimizerOptions::SetDefaultStrategy(backupStrategy);
 
-    tw.Stop(); std::cout << "Done " << myCombos.size() << " combinations in " << tw.RealTime() << std::endl;
-    tw.Start();
+    tw.Stop(); if (verbose > 2) std::cout << "Done " << myCombos.size() << " combinations in " << tw.RealTime() << " s. New discrete minimum? " << newDiscreteMinimum << std::endl;
 
     if (maskChannels && simnll) {
         simnll->setMaskNonDiscreteChannels(false);
@@ -688,7 +696,6 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
         minimizer_.reset(); // will be recreated when needed by whoever needs it
     }
 
-    tw.Stop(); std::cout << "Done minimizer reset in " << tw.RealTime() << std::endl;
 
     return newDiscreteMinimum;
 }


### PR DESCRIPTION
Options to speed up discrete minimization.
* `--X-rtd MINIMIZER_multiMin_hideConstants`: hide the constant terms in the likelihood when recreating the minimizer 
* `--X-rtd MINIMIZER_multiMin_maskConstraints`: hide the constraint terms during the discrete minimization process
* `--X-rtd MINIMIZER_multiMin_maskChannels=<choice>`  mask in the NLL the channels that are not needed:
    * `<choice> 1`: keeps unmasked all channels that are participating in the discrete minimization
    * `<choice> 2`: keeps unmasked only the channel whose index is being scanned at the moment (works only in multipleMinimize mode 0, makes discrete minimization faster)

All the options work only if `--X-rtd MINIMIZER_freezeDisassociatedParams` is enabled.

It is possible that already setting maskChannels=2 and SIMNLL_GROUPCONSTRAINTS=N make the gain from hideConstant and maskConstraints redundant in practice but I haven't tested since I developed them in the order they're listed here.

@nucleosynthesis 
