### PR TITLE
src/CMSHistFunc.cc: fixing boundary issues for morphing & improving debug output

### DIFF
--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -1120,7 +1120,7 @@ FastTemplate CMSHistFunc::cdfMorph(unsigned idx, double par1, double par2,
   }
 #if HFVERBOSE > 2
   std::cout << "CDF mapped into the histogram binning:" << std::endl;
-  for (int ind = ixf-1; ind < ixl+1; ind++) {
+  for (int ind = std::max(0, ixf - 1); ind < ixl+1; ind++) {
     std::cout << "\t(bin,x,y) = (" << ind << "," << cache_.GetEdge(ind) << "," << sigdisf[ind] << ")" << std::endl;
   }
 #endif

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -459,10 +459,18 @@ void CMSHistFunc::updateCache() const {
             double x2 = hpoints_[0][global_.p2];
             double y1 = mcache_[idx1].integral;
             double y2 = mcache_[idx2].integral;
-            mcache_[idx1].step1 = cdfMorph(idx1, x1, x2, val);
-            mcache_[idx1].step1.CropUnderflows();
-            double ym = y1 + ((y2 - y1) / (x2 - x1)) * (val - x1);
-            mcache_[idx1].step1.Scale(ym / integrateTemplate(mcache_[idx1].step1));
+            if(y1 <= 0.0 || y2 <= 0.0)
+            {
+              FastTemplate emptyhist(cache_.size());
+              mcache_[idx1].step1 = emptyhist;
+            }
+            else
+            {
+              mcache_[idx1].step1 = cdfMorph(idx1, x1, x2, val);
+              mcache_[idx1].step1.CropUnderflows();
+              double ym = y1 + ((y2 - y1) / (x2 - x1)) * (val - x1);
+              mcache_[idx1].step1.Scale(ym / integrateTemplate(mcache_[idx1].step1));
+            }
           }
         }
 

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -1093,8 +1093,8 @@ FastTemplate CMSHistFunc::cdfMorph(unsigned idx, double par1, double par2,
       if (xdisn[ix3 + 1] - x >= 1.0 * dx2) {  // Empty bin treatment
 #if HFVERBOSE > 2
         std::cout << "Warning - th1fmorph: encountered empty bin." << std::endl;
-        y = c1.y[ix3];
 #endif
+        y = c1.y[ix3];
       } else if (xdisn[ix3 + 1] > xdisn[ix3]) {  // Normal bins
         y = c1.y[ix3] + (c1.y[ix3 + 1] - c1.y[ix3]) *
                                (x - xdisn[ix3]) / (xdisn[ix3 + 1] - xdisn[ix3]);

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -14,7 +14,7 @@
 #include "vectorized.h"
 #include "TMath.h"
 
-#define HFVERBOSE 4
+#define HFVERBOSE 0
 
 bool CMSHistFunc::enable_fast_vertical_ = false;
 


### PR DESCRIPTION
 Might happen for 0-yield histograms.

Encountered this in my use-case for morphed MSSM Higgs signals with different masses (90 GeV to 3.2 TeV). At a certain mass point the integral for the signal is 0 and this leads to segmentation fault within the function in this fix.

After that fix, my fit is successfull, however, I'm not sure, whether CMSHistFunc behaves properly after that while loop is escaped.