### PR TITLE
Do not print verbose in MultiDimFit::saveResult

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -1148,7 +1148,7 @@ void MultiDimFit::doBox(RooAbsReal &nll, double cl, const char *name, bool commi
 }
 
 void MultiDimFit::saveResult(RooFitResult &res) {
-    if (verbose>2) res.Print("V");
+    if (verbose>2) res.Print();
     fitOut.reset(TFile::Open(("multidimfit"+name_+".root").c_str(), "RECREATE"));
     fitOut->WriteTObject(&res,"fit_mdf");
     fitOut->cd();


### PR DESCRIPTION
res.Print("V") seg faults for some fit results generated by RobustHesse, even if the fit result is fine and can be printed/saved to a file normally. This then means the file with the fit result isn't created. replacing res.Print("V") with res.Print() to avoid this.