### PR TITLE
Need to handle constraints lines separately from nuisances

### DIFF
--- a/python/Datacard.py
+++ b/python/Datacard.py
@@ -38,6 +38,8 @@ class Datacard():
         self.rateParamsOrder = set() 
         ## dirct of {name of uncert, boolean to indicate whether this nuisance is floating or not}
         self.frozenNuisances = set()
+        ##
+        self.regularizationTerms = []
 
 	# Allows for nuisance renaming of "shape" systematics
 	self.systematicsShapeMap = {}

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -194,7 +194,7 @@ def parseCard(file, options):
                 args = [float(f[2])];  numbers = f[3:];
 	    elif pdf == "constr":
                 args = f[2:]
-                ret.systs.append([lsyst,nofloat,pdf,args,[]])
+                ret.regularizationTerms.append([lsyst,args])
                 continue
             elif pdf == "param":
                 # for parametric uncertainties, there's no line to account per bin/process effects

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -163,11 +163,13 @@ class ShapeBuilder(ModelBuilder):
                 if not self.options.noBOnly:
                 	self.renameObj("pdf_bin%s_bonly" % b, "pdf_bin%s_bonly_nuis" % b)
                 # now we multiply by all the nuisances, but avoiding nested products
-                # so we first make a list of all nuisances plus the RooAddPdf
+                # so we first make a list of all nuisances, constraints, and the RooAddPdf
                 if len(self.DC.systs):
                     sumPlusNuis_s = ROOT.RooArgList(self.out.nuisPdfs)
                 else:
                     sumPlusNuis_s = ROOT.RooArgList()
+                for n, _ in self.DC.regularizationTerms:
+                    sumPlusNuis_s.add(self.out.pdf('%s_Pdf' % n))
                 sumPlusNuis_s.add(sum_s)
                 pdf_bins = self.addObj(ROOT.RooProdPdf, 'pdfbins_bin%s' % b, "", binconstraints)
                 sumPlusNuis_s.add(pdf_bins)
@@ -178,6 +180,8 @@ class ShapeBuilder(ModelBuilder):
                         sumPlusNuis_b = ROOT.RooArgList(self.out.nuisPdfs)
                     else:
                         sumPlusNuis_b = ROOT.RooArgList()
+                    for n, _ in self.DC.regularizationTerms:
+                        sumPlusNuis_b.add(self.out.pdf('%s_Pdf' % n))
                     sumPlusNuis_b.add(sum_b)
                     sumPlusNuis_b.add(pdf_bins)
                     pdf_b = self.addObj(ROOT.RooProdPdf, "pdf_bin%s_bonly" % b, "", sumPlusNuis_b)
@@ -227,6 +231,8 @@ class ShapeBuilder(ModelBuilder):
                     simPdf.addChannelMasks(maskList)
                 if len(self.DC.systs) and (not self.options.noOptimizePdf) and self.options.moreOptimizeSimPdf == "cms":
                     simPdf.addExtraConstraints(self.out.nuisPdfs)
+                    for n, _ in self.DC.regularizationTerms:
+                        simPdf.addExtraConstraints(self.out.pdf('%s_Pdf' % n))
                 if self.options.verbose:
                     stderr.write("Importing combined pdf %s\n" % simPdf.GetName()); stderr.flush()
 


### PR DESCRIPTION
This PR concerns the recently added constraints feature (by the way do we really want to restrict the constraint shape to gaussian? Wouldn't it be better to give more flexibility by allowing general formula?).

I wanted to write a regularization term that depended on a rateParam defined in the same card, but because the constraints were handled as nuisances, their definitions would come before the rateParams in ModelTools, crashing text2workspace. So I'm proposing to add a "doRegularizations" function that runs after other functions that may introduce new parameters, and migrate the code around "constr" lines from doNuisances to the new function.