### PR TITLE
Fix typo in histogram title

### DIFF
--- a/test/diffNuisances.py
+++ b/test/diffNuisances.py
@@ -378,7 +378,7 @@ if options.plotfile:
     gr_fit_b.SetLineWidth(2)
     gr_fit_s.SetLineWidth(2)
     hist_prefit.SetLineWidth(2)
-    hist_prefit.SetTitle("Nuisance Paramaeters")
+    hist_prefit.SetTitle("Nuisance Parameters")
     hist_prefit.SetLineColor(ROOT.kBlack)
     hist_prefit.SetFillColor(ROOT.kGray)
     hist_prefit.SetMaximum(3)


### PR DESCRIPTION
This is a trivial PR to fix a typo in the title of one of the histograms produced by `diffNuisances.py`.