### PR TITLE
Seems like order of map is incorrect

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -137,7 +137,21 @@ class ModelBuilder(ModelBuilderBase):
                 self.out.pdf("model_s").graphVizTree(self.options.out+".dot", "\\n")
                 print "Wrote GraphVizTree of model_s to ",self.options.out+".dot"
 
+    
+    def getRenamingParameters(self):
 
+        toFreeze = []
+	renameParamString = [] 
+	paramString       = []
+      	for n in self.DC.systematicsParamMap.keys():
+	  paramString.append(n)
+	  renameParamString.append(self.DC.systematicsParamMap[n])
+	  if n!=self.DC.systematicsParamMap[n]: toFreeze.append(n)
+	if len(renameParamString): 
+	  renameParamString=",".join(renameParamString)
+	  paramString=",".join(paramString)
+
+       
     def runPostProcesses(self):
       for n in self.DC.frozenNuisances:
          self.out.arg(n).setConstant(True)
@@ -641,7 +655,11 @@ class ModelBuilder(ModelBuilderBase):
 		    	elif self.out.var(factorName): procNorm.addOtherFactor(self.out.var(factorName))
 		    	elif self.out.arg(factorName): raise RuntimeError("Factor %s for process %s, bin %s is a %s (not supported)" % (factorName, p, b, self.out.arg(factorName).ClassName()))
 		    	else: raise RuntimeError("Cannot add non-existant factor %s for process %s, bin %s" % (factorName, p, b))
-                    self.out._import(procNorm)
+	
+		    # take care of any variables which were renamed (eg for "param")
+		    paramString,renameParamString,toFreeze = getRenamingParameters()
+		    if len(renameParamString): self.out._import(procNorm, ROOT.RooFit.RecycleConflictNodes(),ROOT.RooFit.RenameVariable(paramString,renameParamString))
+                    else: self.out._import(procNorm)
     def doIndividualModels(self):
         """create pdf_bin<X> and pdf_bin<X>_bonly for each bin"""
         raise RuntimeError, "Not implemented in ModelBuilder"

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -125,6 +125,8 @@ def doRenameNuisance(datacard, args):
         i+=1
         if lsyst == oldname : # found the nuisance
 	  nuisanceID = i
+	  if pdf0 == "flatParam" :
+            raise RuntimeError, "Error: Cannot use nuisance edit rename with flatParam type nuisances currently - you should rename the parameter in your input workspace."	  
 	  if pdf0 != "param": 
             raise RuntimeError, "Missing arguments: the syntax is: nuisance edit rename process channel oldname newname"	  
           for lsyst2,nofloat2,pdf02,args02,errline02 in (datacard.systs[:]):
@@ -134,10 +136,10 @@ def doRenameNuisance(datacard, args):
              else: 
 	      if (args0[0])!=(args02[0])  or float(args0[1])!=float(args02[1]) : raise RuntimeError, "Can't rename nuisance %s with Gaussian pdf G(%s,%s) to name %s which already exists with Gaussian pdf G(%s,%s) constraint!" % (lsyst,args0[0],args0[1],lsyst2,args02[0],args02[1])
 	  break
-      if nuisanceID: 
+      if nuisanceID >-1 : 
       	datacard.systs[nuisanceID][0]=newname 
 	datacard.systematicsParamMap[oldname]=newname
-      else: raise RuntimeError, "No nuisance parameter found with name %s"%oldname 
+      else: raise RuntimeError, "No nuisance parameter found with name %s in the datacard"%oldname 
       return
 
     if len(args) < 4:

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -136,7 +136,7 @@ def doRenameNuisance(datacard, args):
 	  break
       if nuisanceID: 
       	datacard.systs[nuisanceID][0]=newname 
-	datacard.systematicsParamMap[newname]=oldname
+	datacard.systematicsParamMap[oldname]=newname
       else: raise RuntimeError, "No nuisance parameter found with name %s"%oldname 
       return
 

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -283,8 +283,8 @@ class ShapeBuilder(ModelBuilder):
 		renameParamString = [] 
 		paramString       = []
       		for n in self.DC.systematicsParamMap.keys():
-		  paramString.append(self.DC.systematicsParamMap[n])
-		  renameParamString.append(n)
+		  paramString.append(n)
+		  renameParamString.append(self.DC.systematicsParamMap[n])
 		if len(renameParamString): 
 		  renameParamString=",".join(renameParamString)
 		  paramString=",".join(paramString)


### PR DESCRIPTION
Specifically, if several nuisances of type `param` are mapped to *one new name* "Z" - this PR will
allow it (eg correlating across different years) - eg Y -> Z and X -> Z

Previously, the behaviour would be to take only the last nuisance mapped to Z would be renamed.