### PR TITLE
fix for RunAllDiscreteCombination and freezeDisassociatedParams

### DIFF
--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -444,7 +444,14 @@ bool CascadeMinimizer::minimize(int verbose, bool cascade)
            multipleMinimize(reallyCleanParameters,ret,minimumNLL,verbose,cascade,1,contIndex);
            multipleMinimize(reallyCleanParameters,ret,minimumNLL,verbose,cascade,2,contIndex);
         }
-
+	
+	// Run one last fully floating fit to maintain RooFitResult in case freezeDisassociatedParams is ON
+	if(runtimedef::get(std::string("MINIMIZER_freezeDisassociatedParams"))){
+	  freezeDiscParams(true);
+	  ret = improve(verbose,cascade,true);
+	  minimumNLL = nll_.getVal();
+	  freezeDiscParams(false);
+	}
       }
     }
 

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -365,6 +365,9 @@ bool CascadeMinimizer::iterativeMinimize(double &minimumNLL,int verbose, bool ca
 
    tw.Stop(); if (verbose > 2) std::cout << "Done the full fit in " << tw.RealTime() << std::endl;
 
+   // unfreeze from *
+   freezeDiscParams(false);
+
    return ret;
 }
 

--- a/src/classes.h
+++ b/src/classes.h
@@ -64,6 +64,8 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooNCSpline_3D_fast.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooFuncPdf.h"
 
+#include "HiggsAnalysis/CombinedLimit/interface/HMuMuRooPdfs.h"
+
 namespace {
     struct dictionary {
 	RooBernsteinFast<1> my_RooBernsteinFast_1;

--- a/src/classes.h
+++ b/src/classes.h
@@ -64,8 +64,6 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooNCSpline_3D_fast.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooFuncPdf.h"
 
-#include "HiggsAnalysis/CombinedLimit/interface/HMuMuRooPdfs.h"
-
 namespace {
     struct dictionary {
 	RooBernsteinFast<1> my_RooBernsteinFast_1;

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -208,4 +208,11 @@
 	<class name="cmsmath::SequentialMinimizer"  transient="true" />
 	<class name="rVrFLikelihood"  transient="true" />
         <class name="TestProposal"  transient="true" />
+
+	<class name="RooModZPdf" />
+        <class name="RooExpPdf" />
+        <class name="RooSumTwoExpPdf" />
+        <class name="RooPowerLawPdf" />
+        <class name="RooSumTwoPowerLawPdf" />
+
 </lcgdict>

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -209,10 +209,5 @@
 	<class name="rVrFLikelihood"  transient="true" />
         <class name="TestProposal"  transient="true" />
 
-	<class name="RooModZPdf" />
-        <class name="RooExpPdf" />
-        <class name="RooSumTwoExpPdf" />
-        <class name="RooPowerLawPdf" />
-        <class name="RooSumTwoPowerLawPdf" />
 
 </lcgdict>


### PR DESCRIPTION
After a discussion today with @nucleosynthesis, @ajgilbert, @adewit, and @amarini, this PR contains two commits:

1) First commit: when RunDiscreteAllCombination is enabled, the RooFitResult object store in CascadeMinimizer points to the last fit performed and not to the best-fit. Best-fit parameters are instead stored in a list (snapshot). When disassociated parameters are frozen and the bes-fit pdf is not the last one tested in the iterative loop, in the RooFitResult object the best-pdf parameters are seen as constant and not floating params. In order to solve this, a final fit is introduced for this special case to save the RooFitResult object corresponding to the best-fit.

2) Second commit: add inside improveOnce, hesse, and minos functions of CascadeMinimizer the call of freezeDiscParamters(true), freezeDiscParamters(false) everytime a fit is performed. In this way, when freeze-diassociated parameters is enabled, all possible fits in CascadeMinimizer done under  the same logic.

In case the second commit has some drawbacks it can be exclude from the PR