### PR TITLE
Account for discrete index in robust-fit (optional)

### DIFF
--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -38,7 +38,7 @@ protected:
 
   static float preFitValue_;
 
-  static bool robustFit_, do95_, forceRecreateNLL_;
+  static bool robustFit_, do95_, forceRecreateNLL_, floatDiscIndexRobustFit_;
   static float stepSize_;
   static int   maxFailedSteps_;
 


### PR DESCRIPTION
After a discussion with @nucleosynthesis, @ajgilbert, @adewit, and @amarini 
This PR adds the possibility of taking into account discrete index during robust-fit via the option "floatDiscreteIndexInRobustFit" set by default to false. If true, CascadeMinimizer::minimize is called instead of ::improve method.