### PR TITLE
Options to store toys used to obtain pre/postfit uncertainties in FitDiagnostics

### DIFF
--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -47,6 +47,7 @@ protected:
   static bool        saveShapes_;
   static bool        saveOverallShapes_;
   static bool        saveWithUncertainties_;
+  static bool        saveUncertaintyToys_;
   static bool	     saveWorkspace_;
   static bool        reuseParams_;
   static bool        customStartingPoint_;

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -872,8 +872,9 @@ void FitDiagnostics::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, Roo
                 for (int b = 1, nb = target->GetNbinsX(); b <= nb; ++b) {
                     target->AddBinContent(b, std::pow(h->second->GetBinContent(b) - reference->GetBinContent(b), 2));
                 }
-            }           
-            fOutToys->Close();
+            }       
+            if (fOutToys)
+              fOutToys->Close();
               } // end of the toy loop
         // now take square roots and such
         for (pair = bg, i = 0; pair != ed; ++pair, ++i) {


### PR DESCRIPTION
Here's an option to save the toys that are produced when sampling the covariance matrix and that are used to obtain prefit and postfit uncertainties with FitDiagnostics. Keeping the toys allows to obtain uncertainties for any quantity constructed from those yields. This allows, as an example, to obtain yields grouping different processes or categories in a consistent way. 