### PR TITLE
Make default POI value warning less confusing

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -927,7 +927,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
 
   // Warn the user that they might be using funky values of POIs 
-  if (!expectSignalSet_ && setPhysicsModelParameterExpression_ == "") { 
+  if (!expectSignalSet_ && setPhysicsModelParameterExpression_ == "" && !(POI->getSize()==1 && POI->find("r"))) {
 	  std::cerr << "Warning! -- You haven't picked default values for the Parameters of Interest (either with --expectSignal or --setParameters) for generating toys. Combine will use the 'B-only' ModelConfig to generate, which may lead to undesired behaviour if not using the default Physics Model" << std::endl;	  
   }	
   // Ok now we're ready to go lets save a "clean snapshot" for the current parameters state


### PR DESCRIPTION
... By not triggering it when the default physics model is used. I note that one might still be confused when running a method that doesn't generate any toys in the first place, but that's not a straightforward extension of this if statement, so probably still best to warn the user. And at least they'll know what a physics model is, since they didn't use the default one ;-)