### PR TITLE
Improve control over grid of points when doing 2D MultiDimFits

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -41,7 +41,8 @@ protected:
   std::auto_ptr<TFile> fitOut;
 
   // options
-  static unsigned int points_, points2_, firstPoint_, lastPoint_;
+  static unsigned int points_, firstPoint_, lastPoint_;
+  static std::string gridPoints_;
   static bool floatOtherPOIs_;
   static bool squareDistPoiStep_;
   static bool skipInitialFit_;
@@ -94,6 +95,8 @@ protected:
   void doBox(RooAbsReal &nll, double cl, const char *name="box", bool commitPoints=true) ;
   /// save a file with the RooFitResult inside
   void saveResult(RooFitResult &res);
+  /// split values passed to --gridPoints option, e.g. "10,20" -> unsigned int vector {10, 20}
+  void splitGridPoints(const std::string& s, std::vector<unsigned int>& points) const;
 };
 
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -86,7 +86,7 @@ MultiDimFit::MultiDimFit() :
         ("squareDistPoiStep","POI step size based on distance from midpoint (max-min)/2 rather than linear")
         ("skipInitialFit","Skip initial fit (save time if snapshot is loaded from previous fit)")
         ("points",  boost::program_options::value<unsigned int>(&points_)->default_value(points_), "Points to use for grid or contour scans")
-        ("points2",  boost::program_options::value<unsigned int>(&points2_)->default_value(points2_), "Same as --points but applies only to the second POI when doing 2D scans, and when set, --points applies only to the first POI")
+        ("secondPOIPoints",  boost::program_options::value<unsigned int>(&points2_)->default_value(points2_), "Same as --points but applies only to the second POI when doing 2D scans, and when set, --points applies only to the first POI")
         ("firstPoint",  boost::program_options::value<unsigned int>(&firstPoint_)->default_value(firstPoint_), "First point to use")
         ("lastPoint",  boost::program_options::value<unsigned int>(&lastPoint_)->default_value(lastPoint_), "Last point to use")
         ("autoRange", boost::program_options::value<float>(&autoRange_)->default_value(autoRange_), "Set to any X >= 0 to do the scan in the +/- X sigma range (where the sigma is from the initial fit, so it may be fairly approximate)")

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -35,9 +35,9 @@ std::vector<float>        MultiDimFit::poiVals_;
 RooArgList                MultiDimFit::poiList_;
 float                     MultiDimFit::deltaNLL_ = 0;
 unsigned int MultiDimFit::points_ = 50;
-unsigned int MultiDimFit::points2_ = 0;
 unsigned int MultiDimFit::firstPoint_ = 0;
 unsigned int MultiDimFit::lastPoint_  = std::numeric_limits<unsigned int>::max();
+std::string MultiDimFit::gridPoints_ = "";
 bool MultiDimFit::floatOtherPOIs_ = false;
 unsigned int MultiDimFit::nOtherFloatingPoi_ = 0;
 bool MultiDimFit::fastScan_ = false;
@@ -86,7 +86,7 @@ MultiDimFit::MultiDimFit() :
         ("squareDistPoiStep","POI step size based on distance from midpoint (max-min)/2 rather than linear")
         ("skipInitialFit","Skip initial fit (save time if snapshot is loaded from previous fit)")
         ("points",  boost::program_options::value<unsigned int>(&points_)->default_value(points_), "Points to use for grid or contour scans")
-        ("secondPOIPoints",  boost::program_options::value<unsigned int>(&points2_)->default_value(points2_), "Same as --points but applies only to the second POI when doing 2D scans, and when set, --points applies only to the first POI")
+        ("gridPoints",  boost::program_options::value<std::string>(&gridPoints_)->default_value(gridPoints_), "Comma separated list of points per POI for multidimensional grid scans. When set, --points is ignored.")
         ("firstPoint",  boost::program_options::value<unsigned int>(&firstPoint_)->default_value(firstPoint_), "First point to use")
         ("lastPoint",  boost::program_options::value<unsigned int>(&lastPoint_)->default_value(lastPoint_), "Last point to use")
         ("autoRange", boost::program_options::value<float>(&autoRange_)->default_value(autoRange_), "Set to any X >= 0 to do the scan in the +/- X sigma range (where the sigma is from the initial fit, so it may be fairly approximate)")
@@ -600,26 +600,46 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
     std::auto_ptr<RooArgSet> params(nll.getParameters((const RooArgSet *)0));
     RooArgSet snap; params->snapshot(snap);
     //snap.Print("V");
+
+    // check if gridPoints are defined
+    std::vector<unsigned int> pointsPerPoi;
+    if (!gridPoints_.empty()) {
+        splitGridPoints(gridPoints_, pointsPerPoi);
+        if (pointsPerPoi.size() != n) {
+            throw std::logic_error("Number of passed gridPoints "
+                + std::to_string(pointsPerPoi.size()) + " does not match number of POIs "
+                + std::to_string(n));
+        }
+        std::cout << "Parsed number of points per POI: ";
+        for (unsigned int i = 0; i < n; i++) {
+            std::cout << poi_[i] << " -> " << pointsPerPoi[i];
+            if (i < n - 1) std::cout << ", ";
+        }
+        std::cout << std::endl;
+    }
+
     if (n == 1) {
-        double xspacing = (pmax[0]-pmin[0]) / points_;
+        unsigned int points = pointsPerPoi.size() == 0 ? points_ : pointsPerPoi[0];
+
+        double xspacing = (pmax[0]-pmin[0]) / points;
         double xspacingOffset = 0.5;
         if (alignEdges_) {
-          xspacing = (pmax[0]-pmin[0]) / (points_ - 1);
-          if (points_ == 1) xspacing = 0;
+          xspacing = (pmax[0]-pmin[0]) / (points - 1);
+          if (points == 1) xspacing = 0;
           xspacingOffset = 0.0;
         }
         // can do a more intellegent spacing of points
         double xbestpoint = (p0[0] - pmin[0]) / xspacing;
         if (lastPoint_ == std::numeric_limits<unsigned int>::max()) {
-          lastPoint_ = points_ - 1;
+          lastPoint_ = points - 1;
         }
-        for (unsigned int i = 0; i < points_; ++i) {
+        for (unsigned int i = 0; i < points; ++i) {
           if (i < firstPoint_) continue;
           if (i > lastPoint_)  break;
           double x = pmin[0] + (i + xspacingOffset) * xspacing;
           // If we're aligning with the edges and this is the last point,
           // set x to pmax[0] exactly
-          if (alignEdges_ && i == (points_ - 1)) {
+          if (alignEdges_ && i == (points - 1)) {
             x = pmax[0];
           }
           if (xbestpoint > lastPoint_) {
@@ -637,9 +657,9 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
             }
           }
 
-            //if (verbose > 1) std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
-             std::cout << "Point " << i << "/" << points_ << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
-            *params = snap; 
+            //if (verbose > 1) std::cout << "Point " << i << "/" << points << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
+             std::cout << "Point " << i << "/" << points << " " << poiVars_[0]->GetName() << " = " << x << std::endl;
+            *params = snap;
             poiVals_[0] = x;
             poiVars_[0]->setVal(x);
             // now we minimize
@@ -681,14 +701,14 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
 
         // get number of points per axis
         unsigned int nX, nY;
-        if (points2_ == 0) {
+        if (pointsPerPoi.size() == 0) {
             // same number of points per axis ("old" behavior)
             unsigned int sqrn = ceil(sqrt(double(points_)));
             nX = nY = sqrn;
         } else {
             // number of points different per axis
-            nX = points_;
-            nY = points2_;
+            nX = pointsPerPoi[0];
+            nY = pointsPerPoi[1];
         }
         unsigned int nTotal = nX * nY;
 
@@ -832,90 +852,97 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
             }
         }
 
-    } else { // Use utils routine if n > 2 
-
-        unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
-        unsigned int ipoint = 0, nprint = ceil(0.005*TMath::Power((double)rootn,(double)n));
-	
+    } else { // Use utils routine if n > 2
         RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
         CloseCoutSentry sentry(verbose < 2);
-	
-	// Create permutations 
+
+        // get number of points per axis
         std::vector<int> axis_points;
-	
-        for (unsigned int poi_i=0;poi_i<n;poi_i++){
-	  axis_points.push_back((int)rootn);
-    	}
-
-        std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
-	// Step through points
-        std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
-	int npermutations = permutations.size();
-    	for (;perm_it!=permutations.end(); perm_it++){
-
-          if (ipoint < firstPoint_) {ipoint++; continue;}
-          if (ipoint > lastPoint_)  break;
-          *params = snap; 
-
-          if (verbose && (ipoint % nprint == 0)) {
-             fprintf(sentry.trueStdOut(), "Point %d/%d, ",
-                          ipoint,npermutations);
-          }	  
-          for (unsigned int poi_i=0;poi_i<n;poi_i++){
-	    int ip = (*perm_it)[poi_i];
-            double deltaXi = (pmax[poi_i]-pmin[poi_i])/rootn;
-            double spacingOffset = 0.5;
-            if (alignEdges_) {
-                deltaXi = (pmax[poi_i] - pmin[poi_i]) / (rootn - 1);
-                if (rootn == 1) {
-                    deltaXi = 0.;
-                }
-                spacingOffset = 0.0;
+        if (pointsPerPoi.size() == 0) {
+            // same number of points per axis ("old" behavior)
+            unsigned int rootn = ceil(TMath::Power(double(points_),double(1./n)));
+            axis_points.resize(n, (int)rootn);
+        } else {
+            for (auto p : pointsPerPoi) {
+                axis_points.push_back(p);
             }
-	    double xi = pmin[poi_i] + deltaXi * (ip + spacingOffset);
-            poiVals_[poi_i] = xi; poiVars_[poi_i]->setVal(xi);
-	    if (verbose && (ipoint % nprint == 0)){
-             fprintf(sentry.trueStdOut(), " %s = %f ",
-                          poiVars_[poi_i]->GetName(), xi);
-	    }
-	  }
-	  if (verbose && (ipoint % nprint == 0)) fprintf(sentry.trueStdOut(), "\n");
+        }
+        unsigned int nTotal = 1;
+        for (auto p : axis_points) nTotal *= p;
+        unsigned int ipoint = 0, nprint = ceil(0.005*nTotal);
 
-          nll.clearEvalErrorLog(); nll.getVal();
-          if (nll.numEvalErrors() > 0) { 
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		}
-               deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
-               ipoint++;
-	       continue;
-	  }
-          // now we minimize
-          bool skipme = hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_;
-          bool ok = fastScan_ || skipme ? true :  minim.minimize(verbose-1);
-          if (ok) {
-               deltaNLL_ = nll.getVal() - nll0;
-               double qN = 2*(deltaNLL_);
-               double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
-		for(unsigned int j=0; j<specifiedNuis_.size(); j++){
-			specifiedVals_[j]=specifiedVars_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedFuncNames_.size(); j++){
-			specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
-		}
-		for(unsigned int j=0; j<specifiedCatNames_.size(); j++){
-			specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
-		}
-               Combine::commitPoint(true, /*quantile=*/prob);
-          }
-	  ipoint++;	
-	} 
+        // Create permutations
+        std::vector<std::vector<int> > permutations = utils::generateCombinations(axis_points);
+
+        // Step through points
+        std::vector<std::vector<int> >::iterator perm_it = permutations.begin();
+        int npermutations = permutations.size();
+        for (;perm_it!=permutations.end(); perm_it++) {
+            if (ipoint < firstPoint_) {
+                ipoint++;
+                continue;
+            }
+            if (ipoint > lastPoint_) break;
+            *params = snap;
+
+            if (verbose && (ipoint % nprint == 0)) {
+                fprintf(sentry.trueStdOut(), "Point %d/%d, ", ipoint,npermutations);
+            }
+            for (unsigned int poi_i=0;poi_i<n;poi_i++) {
+                int ip = (*perm_it)[poi_i];
+                double deltaXi = (pmax[poi_i]-pmin[poi_i])/axis_points[poi_i];
+                double spacingOffset = 0.5;
+                if (alignEdges_) {
+                    deltaXi = (pmax[poi_i] - pmin[poi_i]) / (axis_points[poi_i] - 1);
+                    if (axis_points[poi_i] == 1) {
+                        deltaXi = 0.;
+                    }
+                    spacingOffset = 0.0;
+                }
+                double xi = pmin[poi_i] + deltaXi * (ip + spacingOffset);
+                poiVals_[poi_i] = xi; poiVars_[poi_i]->setVal(xi);
+                if (verbose && (ipoint % nprint == 0)) {
+                    fprintf(sentry.trueStdOut(), " %s = %f ", poiVars_[poi_i]->GetName(), xi);
+                }
+            }
+            if (verbose && (ipoint % nprint == 0)) fprintf(sentry.trueStdOut(), "\n");
+
+            nll.clearEvalErrorLog(); nll.getVal();
+            if (nll.numEvalErrors() > 0) {
+                for (unsigned int j=0; j<specifiedNuis_.size(); j++) {
+                    specifiedVals_[j]=specifiedVars_[j]->getVal();
+                }
+                for (unsigned int j=0; j<specifiedFuncNames_.size(); j++) {
+                    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+                }
+                for (unsigned int j=0; j<specifiedCatNames_.size(); j++) {
+                    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+                }
+                deltaNLL_ = 9999; Combine::commitPoint(true, /*quantile=*/0);
+                ipoint++;
+                continue;
+            }
+
+            // now we minimize
+            bool skipme = hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_;
+            bool ok = fastScan_ || skipme ? true :  minim.minimize(verbose-1);
+            if (ok) {
+                deltaNLL_ = nll.getVal() - nll0;
+                double qN = 2*(deltaNLL_);
+                double prob = ROOT::Math::chisquared_cdf_c(qN, n+nOtherFloatingPoi_);
+                for (unsigned int j=0; j<specifiedNuis_.size(); j++) {
+                    specifiedVals_[j]=specifiedVars_[j]->getVal();
+                }
+                for (unsigned int j=0; j<specifiedFuncNames_.size(); j++) {
+                    specifiedFuncVals_[j]=specifiedFunc_[j]->getVal();
+                }
+                for (unsigned int j=0; j<specifiedCatNames_.size(); j++) {
+                    specifiedCatVals_[j]=specifiedCat_[j]->getIndex();
+                }
+                Combine::commitPoint(true, /*quantile=*/prob);
+            }
+            ipoint++;
+        }
     }
 }
 
@@ -1180,4 +1207,15 @@ void MultiDimFit::saveResult(RooFitResult &res) {
     fitOut->WriteTObject(&res,"fit_mdf");
     fitOut->cd();
     fitOut.release()->Close();
+}
+
+void MultiDimFit::splitGridPoints(const std::string& s, std::vector<unsigned int>& points) const {
+    // split by comma
+    std::vector<std::string> strPoints;
+    boost::split(strPoints, s, boost::is_any_of(","));
+
+    // convert to int and add
+    for (const auto strPoint : strPoints) {
+        points.push_back(std::stoul(strPoint));
+    }
 }


### PR DESCRIPTION
Hi!

This PR adds a small feature that allows users performing 2D MultiDimFits to control the number of points separately per POI.

## Motivation

In the current implementation one can only set the total number of points, which is then divided evenly across both scan axes (via `ceil(sqrt(double(points)))`). However, depending on the ranges of the two POIs it can make a lot of sense to control the granularity independently. E.g. given some ranges `poi1=-16,16:poi2=-4,4` I would like to have 32 points for poi1 and 8 points for poi2, rather than setting `--points 256` and getting 16 points per POI.

## Implementation

I added a parameter `--gridPoints`. When not set, the current behavior is preserved. Otherwise, `--gridPoints` accepts a comma-separated list of unsigned integers that control the number of points per POI in the same order. E.g. `--gridPoints 20,30` will result in 20 points for poi1, and 30 points for poi2, respectively. An exception is thrown in case the number of values does not match the number of POIs.