### PR TITLE
Fixed bug for asymmetric log-normal uncertainties

### DIFF
--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -211,7 +211,8 @@ def doRenameNuisance(datacard,args):
                 for a in errline0.keys():
                     for b in errline0[a].keys():
                         if type(errline0[a][b]) != int and type(errline0[a][b]) != float: allzeroes = allzeroes and False
-                        elif errline0[a][b] != 0.0 and errline0[a][b] != 0: allzeroes = allzeroes and False
+                        #elif errline0[a][b] != 0.0 and errline0[a][b] != 0: allzeroes = allzeroes and False
+                        elif abs(errline0[a][b]) > 1e-6: allzeroes = allzeroes and False
                 #if abs( sum([errline0[a][b] for a in errline0.keys() for b in errline0[a].keys()]) ) < 1e-6 : datacard.systIDMap[oldname].remove(id)
                 if allzeroes: datacard.systIDMap[oldname].remove(id)
             #print " after considering id %d, the map ->"%id, datacard.systIDMap

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -205,7 +205,15 @@ def doRenameNuisance(datacard,args):
                 if not foundChan and "ifexists" not in opts :
                     raise RuntimeError, "Error: no channel found matching nuisance edit rename with args = %s (and option 'ifexists' not specified)\n" % args
                 # if the result was to rename across everything, meaning 0s get put there, remove that id from the map
-                if abs( sum([errline0[a][b] for a in errline0.keys() for b in errline0[a].keys()]) ) < 1e-6 : datacard.systIDMap[oldname].remove(id)
+                # Double check if all elements are actually zeroes (int and float), not something else.
+                # If an element is a list of two floats, it is an asymmetric log-normal uncertainty.
+                allzeroes = True
+                for a in errline0.keys():
+                    for b in errline0[a].keys():
+                        if type(errline0[a][b]) != int and type(errline0[a][b]) != float: allzeroes = allzeroes and False
+                        elif errline0[a][b] != 0.0 and errline0[a][b] != 0: allzeroes = allzeroes and False
+                #if abs( sum([errline0[a][b] for a in errline0.keys() for b in errline0[a].keys()]) ) < 1e-6 : datacard.systIDMap[oldname].remove(id)
+                if allzeroes: datacard.systIDMap[oldname].remove(id)
             #print " after considering id %d, the map ->"%id, datacard.systIDMap
         if len(datacard.systIDMap[oldname]) == 0: datacard.systIDMap.pop(oldname)
 


### PR DESCRIPTION
The original code breaks when an asymmetric log-normal uncertainty, which is a list of two floats, is introduced in a datacard. In this pull request, I introduced a new logic that checks if an element in a list of uncertainties are actually ints or floats. If the element is not either of those, it should be considered as _not_ a zero.

I don't know if there would be another bugs occurring with my new logic. If there is one please let me know.