### PR TITLE
Speed up FitDiagnostics for large models by only initialising necessary branches

### DIFF
--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -66,7 +66,7 @@ protected:
   TTree *t_fit_b_, *t_fit_sb_, *t_prefit_;
    
   void getNormalizationsSimple(RooAbsPdf *pdf, const RooArgSet &obs, RooArgSet &out);
-  void createFitResultTrees(const RooStats::ModelConfig &,bool);
+  void createFitResultTrees(const RooStats::ModelConfig &,bool,bool);
   void resetFitResultTrees(bool);
   void setFitResultTrees(const RooArgSet *, double *);
   void setNormsFitResultTrees(const RooArgSet *, double *);


### PR DESCRIPTION
This only creates the branches in the output trees that are needed for --savePredictionsPerToy when that option is enabled - before the branches were getting initialised regardless of whether the option was active. That wasted only seconds for small shape analyses but it doesn't scale very well (e.g. several minutes spent initialising unused branches for moderate-sized models and 3.5 hours for the full run 2 VH(bb) model).