### PR TITLE
allow freezing all nuisances + others

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -665,7 +665,11 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
           boost::split(nuisToFreeze, freezeNuisances_, boost::is_any_of(","), boost::token_compress_on);
           for (int k=0; k<(int)nuisToFreeze.size(); k++) {
               if (nuisToFreeze[k]=="") continue;
-              if (!w->fundArg(nuisToFreeze[k].c_str())) {
+              else if(nuisToFreeze[k]=="allConstrainedNuisances") {
+                  toFreeze.add(*nuisances);
+                  continue;
+              }
+              else if (!w->fundArg(nuisToFreeze[k].c_str())) {
                   std::cout<<"WARNING: cannot freeze nuisance parameter "<<nuisToFreeze[k].c_str()<<" if it doesn't exist!"<<std::endl;
                   continue;
               }


### PR DESCRIPTION
There may be cases where the user wants to freeze all constrained nuisances and some other parameters (e.g. unconstrained fit parameters).