### PR TITLE
MultiDimFit: evaluate NLL if there are no floating parameters

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -654,7 +654,7 @@ void MultiDimFit::doGrid(RooWorkspace *w, RooAbsReal &nll)
                 Combine::commitPoint(true, /*quantile=*/0);
                 continue;
             }
-            bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) ? 
+            bool ok = fastScan_ || (hasMaxDeltaNLLForProf_ && (nll.getVal() - nll0) > maxDeltaNLLForProf_) || utils::countFloating(*params)==0 ? 
                         true : 
                         minim.minimize(verbose-1);
             if (ok) {


### PR DESCRIPTION
When running MultiDimFit with `--algo grid` and all constrained nuisance parameters frozen there are no floating parameters in some models, meaning no minimization can take place.  Unless running in fastScan mode this would lead to the dNLL not being stored, although it is a valid configuration (e.g. for doing uncertainty breakdowns). This fixes the issue and also evaluates/stores the dNLL when no floating parameters are detected.