### PR TITLE
Fixed leaking file descriptor

### DIFF
--- a/src/CloseCoutSentry.cc
+++ b/src/CloseCoutSentry.cc
@@ -62,6 +62,7 @@ void CloseCoutSentry::reallyClear()
         open_   = true;
         owner_ = 0;
     }
+    if (fdTmp_) close(fdTmp_);
 }
 
 void CloseCoutSentry::breakFree() 


### PR DESCRIPTION
Issue reported on hypernews [[0]]

----Observation----
When running multiple toys with the below command

combine -M FitDiagnostics --savePredictionsPerToy -t 1000 --saveToys
--toysFrequentist --expectSignal=0 -s 1 -v 1 datacard.txt

combine crashes with the below message.

*** Break *** segmentation violation
Segmentation fault (core dumped)

This issue seems to be related with #281 and #613.

----Reason----
I think this crash is originating from the below line [[1]].
fdOutDup_ = dup( fdOut_ );

When the crash happens, dup() gives a EMFILE error, which stands for the below
"The per-process limit on the number of open file descriptors has been
reached" [[2]]


It seems that the combine tool is leaking file descriptors.

I believe this leak is because of the below line [[3]].
fdTmp_ = open( "/dev/null", O_RDWR );

File descriptor fdTmp_ is not closed in the CloseCoutSentry class,
so that for each toy that makes an CloseCoutSentry object,
the number of open file descriptors can increase.

Once there are enough toys, one reaches the limit of open file descriptors.

----Possible solution----
To fix this issue, I believe we can close fdTmp_ at the destructor of
the CloseCoutSentry class.
Maybe adding a line after [[4]] as below would do it.
if (fdTmp_) close(fdTmp_);


[0]: https://hypernews.cern.ch/HyperNews/CMS/get/higgs-combination/1593.html
[1]: https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/6b5c25192cb0831096666f18b437f9b6eff6815f/src/CloseCoutSentry.cc#L85
[2]: https://man7.org/linux/man-pages/man2/dup.2.html
[3]: https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/6b5c25192cb0831096666f18b437f9b6eff6815f/src/CloseCoutSentry.cc#L29
[4]: https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/6b5c25192cb0831096666f18b437f9b6eff6815f/src/CloseCoutSentry.cc#L64