### PR TITLE
autoMCStats: fix for per-process Gaussian/Poisson propagation to CMSHistFuncWrappers

### DIFF
--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -174,12 +174,12 @@ void CMSHistErrorPropagator::updateCache(int eval) const {
           if (bintypes_[j][i] == 2) {
             // Poisson: this is a multiplier on the process yield
             scaledbinmods_[i][j] = ((vbinpars_[j][i]->getVal() - 1.) *
-                 vfuncs_[i]->cache()[j] * coeffvals_[i]);
-            cache_[j] += scaledbinmods_[i][j];
+                 vfuncs_[i]->cache()[j]);
+            cache_[j] += (scaledbinmods_[i][j] * coeffvals_[i]);
           } else if (bintypes_[j][i] == 3) {
             // Gaussian This is the addition of the scaled error
-            scaledbinmods_[i][j] = vbinpars_[j][i]->getVal() * vfuncs_[i]->errors()[j] * coeffvals_[i];
-            cache_[j] += scaledbinmods_[i][j];
+            scaledbinmods_[i][j] = vbinpars_[j][i]->getVal() * vfuncs_[i]->errors()[j];
+            cache_[j] += (scaledbinmods_[i][j] * coeffvals_[i]);
           }
         }
       }


### PR DESCRIPTION

 - Norm scaling terms (lnN's etc) were multiplied with errors propagated to CMSHistWrappers for per-process uncertainties. Means these terms were effectively double counted when evaluating wrappers.
 - This only affects post-fit shape uncertainties with --saveShapes/--saveWithUncertainties when autoMCStats thresh. is > 0. Usually effect would be small, but in rare cases (with huge lnN's) can lead to significantly inflated uncertainty bands.
 - Fit results are unaffected as the NLL evaulation does not use the wrappers.