### PR TITLE
Make floors in vertical pdf interpolator configurable

### DIFF
--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -28,6 +28,8 @@ public:
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
 
+  void setFloorVals(Double_t const& pdf_val, Double_t const& integral_val);
+
 protected:
   
   class CacheElem : public RooAbsCacheElement {
@@ -47,11 +49,14 @@ protected:
   TIterator* _funcIter ;     //! Iterator over FUNC list
   TIterator* _coefIter ;    //! Iterator over coefficient list
 
+  Double_t _pdfFloorVal; // PDF floor should be customizable, default is 1e-15
+  Double_t _integralFloorVal; // PDF integral floor should be customizable, default is 1e-10
+
   Double_t interpolate(Double_t coeff, Double_t central, RooAbsReal *fUp, RooAbsReal *fDown) const ; 
 
 private:
 
-  ClassDef(VerticalInterpPdf,2) // PDF constructed from a sum of (non-pdf) functions
+  ClassDef(VerticalInterpPdf,3) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/src/VerticalInterpPdf.cc
+++ b/src/VerticalInterpPdf.cc
@@ -26,6 +26,8 @@ VerticalInterpPdf::VerticalInterpPdf()
   _funcIter  = _funcList.createIterator() ;
   _coefIter  = _coefList.createIterator() ;
   _quadraticRegion = 0;
+  _pdfFloorVal = 1e-15;
+  _integralFloorVal = 1e-10;
 }
 
 
@@ -36,7 +38,9 @@ VerticalInterpPdf::VerticalInterpPdf(const char *name, const char *title, const 
   _funcList("!funcList","List of functions",this),
   _coefList("!coefList","List of coefficients",this),
   _quadraticRegion(quadraticRegion),
-  _quadraticAlgo(quadraticAlgo)
+  _quadraticAlgo(quadraticAlgo),
+  _pdfFloorVal(1e-15),
+  _integralFloorVal(1e-10)
 { 
 
   if (inFuncList.getSize()!=2*inCoefList.getSize()+1) {
@@ -89,7 +93,9 @@ VerticalInterpPdf::VerticalInterpPdf(const VerticalInterpPdf& other, const char*
   _funcList("!funcList",this,other._funcList),
   _coefList("!coefList",this,other._coefList),
   _quadraticRegion(other._quadraticRegion),
-  _quadraticAlgo(other._quadraticAlgo)
+  _quadraticAlgo(other._quadraticAlgo),
+  _pdfFloorVal(other._pdfFloorVal),
+  _integralFloorVal(other._integralFloorVal)
 {
   // Copy constructor
 
@@ -140,7 +146,7 @@ Double_t VerticalInterpPdf::evaluate() const
       }
   }
    
-  return ( value > 0 ? value : 1E-15 ); // Last IEEE double precision
+  return ( value > 0. ? value : _pdfFloorVal);
 }
 
 
@@ -284,8 +290,8 @@ Double_t VerticalInterpPdf::analyticalIntegralWN(Int_t code, const RooArgSet* no
   }
 
   Double_t result = 0;
-  if(normVal>0) result = value / normVal;
-  return (result > 0 ? result : 1E-10);
+  if(normVal>0.) result = value / normVal;
+  return (result > 0. ? result : _integralFloorVal);
 }
 
 Double_t VerticalInterpPdf::interpolate(Double_t coeff, Double_t central, RooAbsReal *fUp, RooAbsReal *fDn) const  
@@ -364,3 +370,7 @@ Double_t VerticalInterpPdf::interpolate(Double_t coeff, Double_t central, RooAbs
         }
     }
 }
+
+
+//_____________________________________________________________________________
+void VerticalInterpPdf::setFloorVals(Double_t const& pdf_val, Double_t const& integral_val){ _pdfFloorVal = pdf_val; _integralFloorVal = integral_val; }


### PR DESCRIPTION
Noticed that the current floor settings may create artificial negative G2 in some minimization and bias results (especially when one of the up or down variations and nominal have about the same value ~=0). This commit is intended to reduce the impact in a user-configurable manner, especially if workspaces are pre-constructed.