### PR TITLE
Allow reading of remote files

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -261,8 +261,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
 
   bool isTextDatacard = false, isBinary = false;
-  TString fileToLoad = (hlfFile[0] == '/' ? hlfFile : pwd+"/"+hlfFile);
-  if (!boost::filesystem::exists(fileToLoad.Data())) throw std::invalid_argument(("File "+fileToLoad+" does not exist").Data());
+  TString fileToLoad = ((hlfFile[0] == '/' || hlfFile.Contains("://")) ? hlfFile : pwd+"/"+hlfFile);
+  if (!fileToLoad.Contains("://") && !boost::filesystem::exists(fileToLoad.Data())) throw std::invalid_argument(("File "+fileToLoad+" does not exist").Data());
   if (hlfFile.EndsWith(".hlf") ) {
     // nothing to do
   } else if (hlfFile.EndsWith(".root")) {
@@ -304,6 +304,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 
   if (isBinary) {
     TFile *fIn = TFile::Open(fileToLoad); 
+    if (!fIn) throw std::runtime_error(("Could not open file "+fileToLoad).Data());
     garbageCollect.tfile = fIn; // request that we close this file when done
 
     w = dynamic_cast<RooWorkspace *>(fIn->Get(workspaceName_.c_str()));

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -260,13 +260,11 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       unlink(tmpFile); // this is to be deleted, since we'll use tmpFile+".root"
   }
 
-  bool isTextDatacard = false, isBinary = false;
+  bool isTextDatacard = false, isBinary = hlfFile.EndsWith(".root");
   TString fileToLoad = ((hlfFile[0] == '/' || hlfFile.Contains("://")) ? hlfFile : pwd+"/"+hlfFile);
-  if (!fileToLoad.Contains("://") && !boost::filesystem::exists(fileToLoad.Data())) throw std::invalid_argument(("File "+fileToLoad+" does not exist").Data());
-  if (hlfFile.EndsWith(".hlf") ) {
+  if (!(fileToLoad.Contains("://") && isBinary) && !boost::filesystem::exists(fileToLoad.Data())) throw std::invalid_argument(("File "+fileToLoad+" does not exist").Data());
+  if (hlfFile.EndsWith(".hlf") || isBinary) {
     // nothing to do
-  } else if (hlfFile.EndsWith(".root")) {
-    isBinary = true;
   } else {
     TString txtFile = fileToLoad.Data();
     TString options = TString::Format(" -m %f -D %s", mass_, dataset.c_str());


### PR DESCRIPTION
These few lines fix reading of remote files if local copy is not feasible. Something like 'root://[site]/[path_to_store]' for example fails to process with the current status of the implementation, so this commit checks for '://' first before determining whether the file exists or not. One could implement a more sophisticated existence check using calls to gfal-ls through system (I don't think boost would be useful for that case), but I will defer that to another PR if you think that would be desirable.