### PR TITLE
T2W changes for making ATLAS-compatible workspaces

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -20,6 +20,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("--no-b-only","--for-fits",    dest="noBOnly", default=False, action="store_true", help="Do not save the background-only pdf (saves time)")
     parser.add_option("--no-wrappers", dest="noHistFuncWrappers", default=False, action="store_true", help="Do not create and save the CMSHistFuncWrapper objects for autoMCStats-based models (saves time)")
     parser.add_option("--no-optimize-pdfs",    dest="noOptimizePdf", default=False, action="store_true", help="Do not save the RooSimultaneous as RooSimultaneousOpt and Gaussian constraints as SimpleGaussianConstraint")
+    parser.add_option("--no-data",    dest="noData", default=False, action="store_true", help="Do not save the RooDataSet in the ouput workspace")
     parser.add_option("--optimize-simpdf-constraints",    dest="moreOptimizeSimPdf", default="none", type="string", help="Handling of constraints in simultaneous pdf: 'none' = add all constraints on all channels (default); 'lhchcg' = add constraints on only the first channel; 'cms' = add constraints to the RooSimultaneousOpt.")
     #parser.add_option("--use-HistPdf",  dest="useHistPdf", type="string", default="always", help="Use RooHistPdf for TH1s: 'always' (default), 'never', 'when-constant' (i.e. not when doing template morphing)")
     parser.add_option("--channel-masks",  dest="doMasks", default=False, action="store_true", help="Create channel-masking RooRealVars")


### PR DESCRIPTION
 - Adds option "--no-data" that skips writing the dataset into the
   output file (useful when we want to avoid sharing real data)
 - Use plain RooGaussian constraints for autoMCStats when
   "--no-optimize-pdfs" is used (instead of SimpleGaussianConstraint)
 - Adjust the behaviour of "--optimize-simpdf-constraints=lhchcg". In
   principle, we only add the full nuisance constraint pdf product on the
   first channel pdf. Since the autoMCStats constraints are not in full pdf
   we do have to make sure these are always added channel-by-channel.
   It's not ideal but should work ok.