### PR TITLE
Simple program for performance profiling

### DIFF
--- a/bin/BuildFile.xml
+++ b/bin/BuildFile.xml
@@ -2,3 +2,7 @@
   <use name="HiggsAnalysis/CombinedLimit"/>
   <use   name="boost_program_options"/>
 </bin>
+<bin file="PerfTest.cpp" name="PerfTest">
+  <use name="HiggsAnalysis/CombinedLimit"/>
+  <use   name="boost_program_options"/>
+</bin>

--- a/bin/PerfTest.cpp
+++ b/bin/PerfTest.cpp
@@ -1,0 +1,53 @@
+#include "RooWorkspace.h"
+#include "TFile.h"
+#include "TROOT.h"
+#include "TEnv.h"
+#include "RooAbsPdf.h"
+#include <dlfcn.h>
+
+void (*dump_)(const char *);
+
+
+int main(int argc, char *argv[]) {
+	if (void *sym = dlsym(0, "igprof_dump_now")) {
+	  dump_ = __extension__ (void(*)(const char *)) sym;
+	} else {
+	  dump_=0;
+	  std::cout << "Heap profile requested but application is not"
+	            << " currently being profiled with igprof" << std::endl;
+	}
+
+	gROOT->GetName();
+
+	if (argc < 3) return 1;
+
+	TFile f(argv[1]);
+	if(dump_) {
+		dump_("profdump_file.out.gz");
+	}
+
+	RooWorkspace *w = (RooWorkspace*)gDirectory->Get(argv[2]);
+	// w->Print();
+	auto allfuncs = w->allFunctions();
+	auto it =allfuncs.fwdIterator();
+	for (RooAbsArg *a = it.next(); a != 0; a = it.next()) {
+		auto rrv = dynamic_cast<RooAbsReal*>(a);
+		if (rrv) {
+			std::cout << rrv->GetName() << " " << rrv->getVal() << "\n";
+		}
+	}
+	if(dump_) {
+		dump_("profdump_wsp.out.gz");
+	}
+
+	// Load the workspace a second time, there seems to be some overhead
+	// in the first load that won't appear in the second...
+	// RooWorkspace *w2 = (RooWorkspace*)gDirectory->Get(argv[2]);
+
+
+	// if(dump_) {
+	// 	dump_("profdump_wsp2.out.gz");
+	// }
+
+	return 0;
+}

--- a/bin/PerfTest.cpp
+++ b/bin/PerfTest.cpp
@@ -33,21 +33,12 @@ int main(int argc, char *argv[]) {
 	for (RooAbsArg *a = it.next(); a != 0; a = it.next()) {
 		auto rrv = dynamic_cast<RooAbsReal*>(a);
 		if (rrv) {
-			std::cout << rrv->GetName() << " " << rrv->getVal() << "\n";
+			rrv->getVal();
 		}
 	}
 	if(dump_) {
 		dump_("profdump_wsp.out.gz");
 	}
-
-	// Load the workspace a second time, there seems to be some overhead
-	// in the first load that won't appear in the second...
-	// RooWorkspace *w2 = (RooWorkspace*)gDirectory->Get(argv[2]);
-
-
-	// if(dump_) {
-	// 	dump_("profdump_wsp2.out.gz");
-	// }
 
 	return 0;
 }


### PR DESCRIPTION
Right now can be used for profiling the opening of a workspace. In time can be extended to more things (NLL construction, evaluation, etc).