### PR TITLE
[WIP] Make parameters of null-hypothesis configurable in Significance method.

### DIFF
--- a/interface/Significance.h
+++ b/interface/Significance.h
@@ -63,6 +63,8 @@ protected:
   static float signalForSignificance_;
   static float mass_;
 
+  static std::string setNullParametersExpression_;
+
   static std::string plot_;
 
   bool runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc, RooAbsData &data, double &limit, double &limitErr);
@@ -72,6 +74,7 @@ protected:
   std::pair<double,double> upperLimitBruteForce(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance, double cl) const ;
   double significanceBruteForce(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance) const ;
   double significanceFromScan(RooAbsPdf &pdf, RooAbsData &data, RooRealVar &poi, const RooArgSet *nuisances, double tolerance, int npoints) const ;
+  void setNullParameters(RooWorkspace *w, RooArgSet &nullParamValues) const;
 };
 
 #endif

--- a/src/ProfiledLikelihoodRatioTestStatExt.cc
+++ b/src/ProfiledLikelihoodRatioTestStatExt.cc
@@ -145,7 +145,7 @@ ProfiledLikelihoodTestStatOpt::ProfiledLikelihoodTestStatOpt(
     DBG(DBG_PLTestStat_main, (std::cout << "Created for " << pdf.GetName() << "." << std::endl))
 
     params.snapshot(snap_,false);
-    ((RooRealVar*)snap_.find(params.first()->GetName()))->setConstant(false);
+
     if (nuisances) { nuisances_.add(*nuisances); snap_.addClone(*nuisances, /*silent=*/true); }
     params_.reset(pdf_->getParameters(observables));
     DBG(DBG_PLTestStat_ctor, (std::cout << "Observables: " << std::endl)) DBG(DBG_PLTestStat_ctor, (observables.Print("V")))
@@ -161,6 +161,9 @@ ProfiledLikelihoodTestStatOpt::ProfiledLikelihoodTestStatOpt(
         if (ps == 0) { std::cerr << "WARNING: no snapshot for POI " << a->GetName() << ", cannot profile"  << std::endl; continue; }
         poi_.add(*ps);
         poiParams_.add(*pp);
+
+        // make the POI non-constant in the snapshot
+        ((RooRealVar*)ps)->setConstant(false);
     }
 }
 

--- a/src/Significance.cc
+++ b/src/Significance.cc
@@ -71,7 +71,7 @@ Significance::Significance() :
         ("scanPoints", boost::program_options::value<int>(&points_)->default_value(points_), "Points for the scan")
         ("setBruteForceTypeAndAlgo",      boost::program_options::value<std::string>(&minimizerAlgoForBF_)->default_value(minimizerAlgoForBF_), "Choice of minimizer for brute-force search (default is Minuit2,simplex)")
         ("setBruteForceTolerance", boost::program_options::value<float>(&minimizerToleranceForBF_)->default_value(minimizerToleranceForBF_),  "Tolerance for minimizer when doing brute-force search")
-        ("setNullParameters", boost::program_options::value<string>(&setNullParametersExpression_)->default_value(setNullParametersExpression_), "Set the values of model parameters of the null hypothesis. Give a comma separated list of parameter value assignments. Example: CV=1.0,CF=1.0. Not supported when --bruteForce is enabled.")
+        ("setNullParameters", boost::program_options::value<string>(&setNullParametersExpression_)->default_value(setNullParametersExpression_), "Set the values of model parameters of the null hypothesis to frozen values. Give a comma separated list of parameter value assignments. Example: CV=1.0,CF=1.0. Not supported when --bruteForce is enabled.")
     ;
 }
 


### PR DESCRIPTION
Dear combine experts,

in the context of our HH analysis, we are investigating different null-hypothesis definitions for the calculation of significances. In general, we would like to be able to control our model parameters separately and independently in the (simulated) dataset and in the tested null-hypothesis.

At the moment, there is an option to toggle the (first) POI using `--signalForSignificance`, effectively allowing to switch between background-only and signal+background null-hypotheses when the POI is `r`. Therefore, parts of the mechanism we were looking for already exist. I created a draft implementation to configure parameters other than a POI.

## Changes

I added a new parameter `--setNullParameters` to the `-m Significance` method that expects a string value in the same format as (e.g.) `--setParameters`. To avoid ambiguity with the `--signalForSignificance` parameter in case the (first) POI is also set via `--setNullParameters`, the value is taken from the latter and a warning is printed. The values are saved in the (already existing) `nullParamValues` set and used in case Minos or the PLC method are selected (I couldn't find a way to use them in the bruteForce method). Also, I did some minor adjustments in the `ProfiledLikelihoodRatioTestStatOpt` ctor to ensure that non-POIs are frozen, while POIs aren't (as before).

So far, the implementation looks rather straight forward, and the results of some tests seem reasonable. Do you think that I missed anything crucial?

Thanks in advance!

@adavidzh 