### PR TITLE
Discrete minim./RooMultiPdf improvements from HIG-19-014

### DIFF
--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -411,7 +411,7 @@ double FitterAlgoBase::findCrossing(CascadeMinimizer &minim, RooAbsReal &nll, Ro
     bool ok = false;
     {
         CloseCoutSentry sentry(verbose < 3);    
-        ok = minim.improve(verbose-1);
+        ok = minim.minimize(verbose-1);
         checkpoint.reset(minim.save());
     }
     if (!ok && !keepFailures_) { 
@@ -437,7 +437,7 @@ double FitterAlgoBase::findCrossing(CascadeMinimizer &minim, RooAbsReal &nll, Ro
             ok = false;
         } else {
             CloseCoutSentry sentry(verbose < 3);    
-            ok = minim.improve(verbose-1);
+            ok = minim.minimize(verbose-1);
         }
         if (!ok && !keepFailures_) { 
             nfail++;

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -32,8 +32,10 @@ RooMultiPdf::RooMultiPdf(const char *name, const char *title, RooCategory& _x, c
 	c.add(*fPdf);
 	// This is done by the user BUT is there a way to do it at construction?
 	_x.defineType(Form("_pdf%d",count),count);//(fPdf->getParameters())->getSize());
+  std::unique_ptr<RooArgSet> variables(fPdf->getVariables());
+  std::unique_ptr<RooAbsCollection> nonConstVariables(variables->selectByAttrib("Constant", false));
 	// Isn't there a better wat to hold on to these values?
-	RooConstVar *tmp = new RooConstVar(Form("const%s",fPdf->GetName()),"",fPdf->getVariables()->getSize());
+	RooConstVar *tmp = new RooConstVar(Form("const%s",fPdf->GetName()),"",nonConstVariables->getSize());
 	corr.add(*tmp);
 	count++;
   }

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -59,8 +59,11 @@ RooMultiPdf::RooMultiPdf(const RooMultiPdf& other, const char* name) :
  RooAbsPdf *fPdf;
  while ( (fPdf = (RooAbsPdf*) pdfIter->Next()) ){
 	c.add(*fPdf);
+  std::unique_ptr<RooArgSet> variables(fPdf->getVariables());
+  std::unique_ptr<RooAbsCollection> nonConstVariables(variables->selectByAttrib("Constant", false));
+
 	RooConstVar *tmp = new RooConstVar(Form("const%s",fPdf->GetName())
-		,"",fPdf->getVariables()->getSize());
+		,"",nonConstVariables->getSize());
 	corr.add(*tmp);
  }
 


### PR DESCRIPTION
This PR introduces two changes:

 - In FitterAlgoBase, call `minimize` instead of `improve` in findCrossing (robustFit) so that the resulting interval includes the discrete minimisation
 - RooMultiPdf will only count non-const parameters for the penalty term