### PR TITLE
Moving of SingleTop models for 102x comb2021

### DIFF
--- a/python/LHCHCGModels.py
+++ b/python/LHCHCGModels.py
@@ -1057,8 +1057,3 @@ L1 = Lambdas()
 L2 = LambdasReduced()
 L2flipped = LambdasReduced(flipped=True)
 D1 = CommonMatrixModel()
-
-K4 = KappaVKappaT(resolved=True)
-K5 = KappaVKappaT(resolved=False)
-K6 = KappaVKappaT(resolved=False, coupleTopTau=True)
-K7 = KappaVKappaT(resolved=True, coupleTopTau=True)

--- a/python/SingleTopModels.py
+++ b/python/SingleTopModels.py
@@ -149,3 +149,9 @@ class KappaVKappaT(LHCHCGBaseModel):
             print '[LHC-HCG Kappas]', name, production, decay, energy,": ",
             self.modelBuilder.out.function(name).Print("")
         return name
+
+
+K4 = KappaVKappaT(resolved=True)
+K5 = KappaVKappaT(resolved=False)
+K6 = KappaVKappaT(resolved=False, coupleTopTau=True)
+K7 = KappaVKappaT(resolved=True, coupleTopTau=True)


### PR DESCRIPTION
Port of LHC HCG models modifications following the move of the KappaVKappaT model.

Currently, K* models gives an error:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/4516989/123089929-db1f3280-d427-11eb-8ad5-e1c17ee86b61.png">

Ported to 112x-comb2021, as well. #673 
