### PR TITLE
Regularization terms in combineCards.py

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -105,7 +105,15 @@ for ich,fname in enumerate(args):
             if not isIncluded(b_in,options.channelIncludes): continue
             if not systeffect.has_key(bout): systeffect[bout] = {}
             for p in DC.exp[b].keys(): # so that we get only self.DC.processes contributing to this bin
-                r = str(errline[b][p]);
+                try:
+                    r = str(errline[b][p]);
+                except TypeError:
+                    error_message = "You probably have a regularization term in datacard {}.\n".format(fname)\
+                            + "A constraint term is a line that looks like the following:\n\n"\
+                            + "\tconstr0 constr @3*(@0-2*@1+@2) r_0,r_1,r_2,regularize[0.] delta[10.]\n\n"\
+                            + "Remove it and try again"
+                    raise NotImplementedError(error_message)
+
                 if type(errline[b][p]) == list: r = "%s/%s" % (FloatToString(errline[b][p][0]), FloatToString(errline[b][p][1]))
                 elif type in ("lnN",'gmM'): r = "%s" % FloatToString(errline[b][p])
                 if errline[b][p] == 0: r = "-"

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -2,7 +2,6 @@
 import re
 from sys import argv,exit
 import os.path
-from pprint import pprint
 from optparse import OptionParser
 parser = OptionParser(
     usage="%prog [options] [label=datacard.txt | datacard.txt]",


### PR DESCRIPTION
refer to discussion here: https://hypernews.cern.ch/HyperNews/CMS/get/higgs-combination/1661/1.html

When combining one or more datacards, a regularization term that looks like the following

```
constr0 constr @3*(@0-2*@1+@2) r_0,r_1,r_2,regularize[0.] delta[10.]
```
triggers this kind of exception:

```
Traceback (most recent call last):
  File "/work/gallim/CMSSW/CMSSW_11_2_0_pre10/bin/slc7_amd64_gcc900/combineCards.py", line 108, in <module>
    r = str(errline[b][p]);
TypeError: list indices must be integers, not str
```

the reason is that for this kind of line, ```errline``` will be translate to a list instead of a dictionary of dictionaries.

With this commit we catch the TypeError which is raised in these cases and print a menaningful error message:

```
Traceback (most recent call last):
  File "/work/gallim/CMSSW/CMSSW_11_2_0_pre10/bin/slc7_amd64_gcc900/combineCards.py", line 115, in <module>
    raise NotImplementedError(error_message)
NotImplementedError: You probably have a regularization term in datacard Analyses/hig-19-002/ptH/fullmodel.txt.
A constraint term is a line that looks like the following:

        constr0 constr @3*(@0-2*@1+@2) r_0,r_1,r_2,regularize[0.] delta[10.]

Remove it and try again
```

The second commit simply removes an import which is not used.