### PR TITLE
Adds SimpleProdPdf class and cleaner VerticalInterpPdf workaround for HZZ

### DIFF
--- a/bin/PerfTest.cpp
+++ b/bin/PerfTest.cpp
@@ -3,14 +3,44 @@
 #include "TROOT.h"
 #include "TEnv.h"
 #include "RooAbsPdf.h"
+#include "RooMsgService.h"
 #include <dlfcn.h>
 #include <RooStats/ModelConfig.h>
 #include "HiggsAnalysis/CombinedLimit/interface/CachingNLL.h"
+#include "HiggsAnalysis/CombinedLimit/interface/ProfilingTools.h"
 
 void (*dump_)(const char *);
 
 
 int main(int argc, char *argv[]) {
+	bool doCombineRuntimes = true;
+	if (doCombineRuntimes) {
+		runtimedef::set("OPTIMIZE_BOUNDS", 1);
+		runtimedef::set("ADDNLL_RECURSIVE", 1);
+		runtimedef::set("ADDNLL_GAUSSNLL", 1);
+		runtimedef::set("ADDNLL_HISTNLL", 1);
+		runtimedef::set("ADDNLL_CBNLL", 1);
+		runtimedef::set("TMCSO_AdaptivePseudoAsimov", 1);
+		// Optimization for bare RooFit likelihoods (--optimizeSimPdf=0)
+		runtimedef::set("MINIMIZER_optimizeConst", 2);
+		runtimedef::set("MINIMIZER_rooFitOffset", 1);
+		// Optimization for ATLAS HistFactory likelihoods
+		runtimedef::set("ADDNLL_ROOREALSUM_FACTOR",1);
+		runtimedef::set("ADDNLL_ROOREALSUM_NONORM",1);
+		runtimedef::set("ADDNLL_ROOREALSUM_BASICINT",1);
+		runtimedef::set("ADDNLL_ROOREALSUM_KEEPZEROS",1);
+		runtimedef::set("ADDNLL_PRODNLL",1);
+		runtimedef::set("ADDNLL_HFNLL",1);
+		runtimedef::set("ADDNLL_HISTFUNCNLL",1);
+		runtimedef::set("ADDNLL_ROOREALSUM_CHEAPPROD",1);
+	}
+	runtimedef::set("ADDNLL_VERBOSE_CACHING", 0);
+	runtimedef::set("fullCloneFunc_VERBOSE", 1);
+	runtimedef::set("CACHINGPDF_NOCLONE", 0); // ! THIS ONE IS NOT SAFE YET
+
+	// Uncomment below for more info
+	// RooMsgService::instance().addStream(RooFit::INFO);
+
 	if (void *sym = dlsym(0, "igprof_dump_now")) {
 	  dump_ = __extension__ (void(*)(const char *)) sym;
 	} else {
@@ -48,7 +78,7 @@ int main(int argc, char *argv[]) {
         const RooCmdArg &constrainCmdArg = RooFit::Constrain(*mc_s->GetNuisanceParameters());
         std::auto_ptr<RooAbsReal> nll;
         nll.reset(pdf.createNLL(*dobs, constrainCmdArg, RooFit::Extended(pdf.canBeExtended()), RooFit::Offset(true))); // make a new nll
-
+        nll->getVal();
 	if(dump_) {
 		dump_("profdump_nll.out.gz");
 	}

--- a/interface/SimpleProdPdf.h
+++ b/interface/SimpleProdPdf.h
@@ -1,0 +1,39 @@
+#ifndef SimpleProdPdf_h
+#define SimpleProdPdf_h
+
+#include <iostream>
+#include <list>
+#include "RooAbsPdf.h"
+#include "RooListProxy.h"
+#include "RooProdPdf.h"
+
+class SimpleProdPdf : public RooAbsPdf {
+ public:
+  SimpleProdPdf();
+  SimpleProdPdf(const char* name, const char* title, RooArgList const& pdfList);
+  SimpleProdPdf(const char* name, const char* title, RooProdPdf const& prodPdf);
+  SimpleProdPdf(const char* name, const char* title, RooArgList& pdfList,
+                std::vector<int> const& pdfSettings);
+  SimpleProdPdf(const SimpleProdPdf& other, const char* name = 0);
+  virtual TObject* clone(const char* newname) const { return new SimpleProdPdf(*this, newname); }
+  inline virtual ~SimpleProdPdf() {}
+
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset,
+                             const RooNumIntConfig* cfg, const char* rangeName) const;
+
+  const RooArgList& pdfList() const { return _pdfList; }
+  void printMetaArgs(std::ostream& os) const;
+
+  // Copied from RooProdPdf - needed to get the correct toy/Asimov binning
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const;
+
+ protected:
+  RooListProxy _pdfList;
+  std::vector<int> _pdfSettings;  // 0 = normal, 1 = conditional
+  virtual Double_t evaluate() const;
+
+ private:
+  ClassDef(SimpleProdPdf, 1)
+};
+
+#endif

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -49,8 +49,10 @@ protected:
 
   Double_t interpolate(Double_t coeff, Double_t central, RooAbsReal *fUp, RooAbsReal *fDown) const ; 
 
-private:
+  bool isConditionalProdPdf(RooAbsReal *pdf) const;
+  RooAbsReal* makeConditionalProdPdfIntegral(RooAbsPdf* pdf, RooArgSet const& analVars) const;
 
+private:
   ClassDef(VerticalInterpPdf,2) // PDF constructed from a sum of (non-pdf) functions
 };
 

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -318,7 +318,7 @@ class ShapeBuilder(ModelBuilder):
         for i in xrange(1, branchNodes.getSize()):
             arg = branchNodes.at(i)
             if arg.GetName() in dupNames and arg not in dupObjs:
-                if self.options.verbose > 1 : stderr.write('Object %s is duplicated, will rename to %s_%s'%(arg.GetName(),arg.GetName(),postFix))
+                if self.options.verbose > 1 : stderr.write('Object %s is duplicated, will rename to %s_%s\n'%(arg.GetName(),arg.GetName(),postFix))
                 arg.SetName(arg.GetName() + '_%s' % postFix)
             # if arg.GetName() in dupNames and arg in dupObjs:
                 # print 'Objected %s is repeated' % arg.GetName()

--- a/src/SimpleProdPdf.cc
+++ b/src/SimpleProdPdf.cc
@@ -1,0 +1,145 @@
+#include "HiggsAnalysis/CombinedLimit/interface/SimpleProdPdf.h"
+#include "HiggsAnalysis/CombinedLimit/interface/RooCheapProduct.h"
+
+#include <string>
+#include <memory>
+#include <stdexcept>
+#include "RooHistPdf.h"
+
+SimpleProdPdf::SimpleProdPdf() : RooAbsPdf() {}
+
+SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooArgList const& pdfList)
+    : RooAbsPdf(name, title), _pdfList("!pdfs", "List of PDFs", this) {
+  RooFIter iter = pdfList.fwdIterator();
+  RooAbsArg* arg;
+  while ((arg = (RooAbsArg*)iter.next())) {
+    RooAbsPdf* pdf = dynamic_cast<RooAbsPdf*>(arg);
+    if (!pdf) {
+      coutW(InputArguments) << "SimpleProdPdf::SimpleProdPdf(" << GetName() << ") list arg "
+                            << arg->GetName() << " is not a PDF, ignored" << std::endl;
+      continue;
+    }
+    _pdfList.add(*pdf);
+    _pdfSettings.push_back(0);
+  }
+}
+
+SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooArgList& pdfList,
+                             std::vector<int> const& pdfSettings)
+    : RooAbsPdf(name, title), _pdfList("!pdfs", "List of PDFs", this) {
+  RooFIter iter = pdfList.fwdIterator();
+  RooAbsArg* arg;
+  int iSetting = -1;
+  while ((arg = (RooAbsArg*)iter.next())) {
+    ++iSetting;
+    RooAbsPdf* pdf = dynamic_cast<RooAbsPdf*>(arg);
+    if (!pdf) {
+      coutW(InputArguments) << "SimpleProdPdf::SimpleProdPdf(" << GetName() << ") list arg "
+                            << arg->GetName() << " is not a PDF, ignored" << std::endl;
+      continue;
+    }
+    _pdfList.add(*pdf);
+    _pdfSettings.push_back(iSetting);
+  }
+}
+
+SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooProdPdf const& prodPdf)
+    : SimpleProdPdf(name, title, prodPdf.pdfList()) {
+  for (int i = 0; i < _pdfList.getSize(); ++i) {
+    RooArgSet* nset = prodPdf.findPdfNSet(*static_cast<RooAbsPdf*>(_pdfList.at(i)));
+    if (nset && TString(nset->GetName()) == "nset" && nset->getSize() > 0) {
+      _pdfSettings.at(i) = 1;
+    }
+  }
+}
+
+SimpleProdPdf::SimpleProdPdf(const SimpleProdPdf& other, const char* name)
+    : RooAbsPdf(other, name),
+      _pdfList("!pdfs", this, other._pdfList),
+      _pdfSettings(other._pdfSettings) {}
+
+Double_t SimpleProdPdf::evaluate() const {
+    Double_t value = 1.0;
+    for (int i = 0; i < _pdfList.getSize(); ++i) {
+        value *= static_cast<RooAbsPdf*>(_pdfList.at(i))->getVal();
+    }
+    return value;
+}
+
+RooAbsReal* SimpleProdPdf::createIntegral(const RooArgSet& iset, const RooArgSet* nset,
+                           const RooNumIntConfig* cfg, const char* rangeName) const {
+    RooArgList terms;
+
+    std::vector<RooAbsPdf*> pdfVec;
+    std::vector<std::unique_ptr<RooArgSet>> iVarsVec;
+    for (int i = 0; i < _pdfList.getSize(); ++i) {
+      RooAbsPdf *iPdf = static_cast<RooAbsPdf*>(_pdfList.at(i));
+      std::unique_ptr<RooArgSet> iVars(iPdf->getVariables());
+      pdfVec.push_back(iPdf);
+      iVarsVec.emplace_back(static_cast<RooArgSet*>(iset.selectCommon(*iVars)));
+    }
+    for (unsigned i = 0; i < pdfVec.size(); ++i) {
+      if (_pdfSettings.at(i) == 1) {
+        for (unsigned j = 0; j < pdfVec.size(); ++j) {
+          if (j == i) continue;
+          iVarsVec.at(i)->remove(*iVarsVec.at(j));
+        }
+      }
+    }
+    for (unsigned i = 0; i < pdfVec.size(); ++i) {
+        TString intName = pdfVec.at(i)->GetName();
+        intName.Append(this->integralNameSuffix(*iVarsVec.at(i),nset,rangeName));
+        RooAbsArg *prexistingInt = nullptr;
+        if (pdfVec.at(i)->ownedComponents() != nullptr) {
+          prexistingInt = pdfVec.at(i)->ownedComponents()->find(intName);
+          if (prexistingInt) {
+            // std::cout << "Found pre-existing integral " << prexistingInt->GetName() << ", recycling...\n";
+            terms.add(*prexistingInt);
+          }
+        }
+        if (prexistingInt == nullptr) {
+          RooAbsReal *iInt = pdfVec.at(i)->createIntegral(*iVarsVec.at(i), nset, cfg, rangeName);
+          iInt->SetName(intName);
+          if (dynamic_cast<RooHistPdf*>(pdfVec.at(i))) {
+            pdfVec.at(i)->addOwnedComponents(RooArgSet(*iInt));
+          }
+          terms.add(*iInt);
+        }
+    }
+    TString name(this->GetName()) ;
+    name.Append(this->integralNameSuffix(iset,nset,rangeName));
+    RooCheapProduct *prod = new RooCheapProduct(name, "", terms, true);
+    return prod;
+}
+
+void SimpleProdPdf::printMetaArgs(std::ostream& os) const
+
+{
+  Bool_t first(kTRUE);
+
+  for (int i = 0; i < _pdfList.getSize(); ++i) {
+    if (!first) {
+      os << " * ";
+    } else {
+      first = kFALSE;
+    }
+    os << _pdfList.at(i)->GetName();
+  }
+  os << " ";
+}
+
+std::list<Double_t>* SimpleProdPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xlo,
+                                                  Double_t xhi) const {
+  RooAbsPdf* pdf;
+  RooFIter pdfIter = _pdfList.fwdIterator();
+  while ((pdf = (RooAbsPdf*)pdfIter.next())) {
+    std::list<Double_t>* hint = pdf->binBoundaries(obs, xlo, xhi);
+    if (hint) {
+      return hint;
+    }
+  }
+
+  return 0;
+}
+
+ClassImp(SimpleProdPdf)

--- a/src/classes.h
+++ b/src/classes.h
@@ -65,6 +65,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooFuncPdf.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooCheapProduct.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHggFormula.h"
+#include "HiggsAnalysis/CombinedLimit/interface/SimpleProdPdf.h"
 
 namespace {
     struct dictionary {

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -219,4 +219,5 @@
   <class name="CMSHggFormulaC1" />
   <class name="CMSHggFormulaD1" />
   <class name="CMSHggFormulaD2" />
+  <class name="SimpleProdPdf" />
 </lcgdict>


### PR DESCRIPTION
 - For ProdPdfs that factorize (i.e. no common integration observables
   between terms) this class will use less memory than RooProdPdf, as
   we do not make so many intermediate RooRealIntegral objects
 - In the full H->ZZ->4l Run 2 analysis, which uses conditional prod
   pdfs heavily, memory is reduced by around 45%
 - Restored VerticalInterpPdf to its previous behaviour, without HZZ
   specfic hacks. The underlying issue was that RooProdPdf performs its
   own normalization, i.e. it does not guarantee that createIntegral
   returns the appropriate value, since internally the normalization is
   calculated in a different way. For the conditional pdfs we use in
   HZZ, the createIntegral output will always be wrong. Now we
   automatically detect any component conditional RooProdPdf, and
   construct the correct integral as the product of integrals of its own
   components (so this only works correctly if pdf factorizes - NB we do
   not currently check this automatically!)