### PR TITLE
Memory optimization for binned analyses (for combination)

### DIFF
--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -146,6 +146,7 @@ class CMSHistFunc : public RooAbsReal {
 
   static void EnableFastVertical();
   friend class CMSHistV<CMSHistFunc>;
+  friend class CMSHistSum;
 
   /*
 

--- a/interface/CMSHistSum.h
+++ b/interface/CMSHistSum.h
@@ -1,0 +1,117 @@
+#ifndef CMSHistSum_h
+#define CMSHistSum_h
+#include <ostream>
+#include <vector>
+#include <memory>
+#include "RooAbsReal.h"
+#include "RooArgSet.h"
+#include "RooListProxy.h"
+#include "RooRealProxy.h"
+#include "Rtypes.h"
+#include "TH1F.h"
+#include "HiggsAnalysis/CombinedLimit/interface/FastTemplate_Old.h"
+#include "HiggsAnalysis/CombinedLimit/interface/SimpleCacheSentry.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistV.h"
+
+class CMSHistSum : public RooAbsReal {
+private:
+  struct BarlowBeeston {
+    bool init = false;
+    std::vector<unsigned> use;
+    std::vector<double> dat;
+    std::vector<double> valsum;
+    std::vector<double> toterr;
+    std::vector<double> err;
+    std::vector<double> b;
+    std::vector<double> c;
+    std::vector<double> tmp;
+    std::vector<double> x1;
+    std::vector<double> x2;
+    std::vector<double> res;
+    std::vector<double> gobs;
+    std::set<RooAbsArg*> dirty_prop;
+    std::vector<RooRealVar*> push_res;
+  };
+public:
+  CMSHistSum();
+
+  CMSHistSum(const char* name, const char* title, RooRealVar& x,
+                         RooArgList const& funcs, RooArgList const& coeffs);
+
+  CMSHistSum(CMSHistSum const& other, const char* name = 0);
+
+  virtual TObject* clone(const char* newname) const {
+    return new CMSHistSum(*this, newname);
+  }
+
+  virtual ~CMSHistSum() {;}
+
+  void applyErrorShifts(unsigned idx, FastHisto const& nominal, FastHisto & result);
+
+  Double_t evaluate() const;
+
+  RooArgList * setupBinPars(double poissonThreshold);
+
+  std::unique_ptr<RooArgSet> getSentryArgs() const;
+
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
+                      TString indent) const;
+
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
+                              const char* rangeName = 0) const;
+
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+
+  void setData(RooAbsData const& data) const;
+
+  void setAnalyticBarlowBeeston(bool flag) const;
+
+  inline FastHisto const& cache() const { return cache_; }
+
+  RooArgList wrapperList() const;
+  RooArgList const& coefList() const { return coeffs_; }
+  RooArgList const& funcList() const { return funcs_; }
+
+  friend class CMSHistV<CMSHistSum>;
+
+ protected:
+  RooRealProxy x_;
+  RooListProxy funcs_;
+  RooListProxy coeffs_;
+  RooListProxy binpars_;
+  mutable std::vector<CMSHistFunc const*> vfuncs_; //!
+  mutable std::vector<RooAbsReal const*> vcoeffs_; //!
+  mutable std::vector<std::vector<RooAbsReal *>> vbinpars_; //!
+  std::vector<std::vector<unsigned>> bintypes_;
+
+  mutable std::vector<double> coeffvals_; //!
+  mutable FastHisto valsum_; //!
+  mutable FastHisto cache_; //!
+  mutable std::vector<double> err2sum_; //!
+  mutable std::vector<double> toterr_; //!
+  mutable std::vector<std::vector<double>> binmods_; //!
+  mutable std::vector<std::vector<double>> scaledbinmods_; //!
+  mutable SimpleCacheSentry sentry_; //!
+  mutable SimpleCacheSentry binsentry_; //!
+  mutable std::vector<double> data_; //!
+
+  mutable BarlowBeeston bb_; //!
+
+  mutable bool initialized_; //! not to be serialized
+
+  mutable int last_eval_; //! not to be serialized
+
+  mutable bool analytic_bb_; //! not to be serialized
+
+  void initialize() const;
+  void updateCache(int eval = 1) const;
+
+  void runBarlowBeeston() const;
+
+
+ private:
+  ClassDef(CMSHistSum,1)
+};
+
+#endif

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -19,6 +19,7 @@ def addDatacardParserOptions(parser):
     parser.add_option("--default-morphing",  dest="defMorph", type="string", default="shape", help="Default template morphing algorithm (to be used when the datacard has just 'shape')")
     parser.add_option("--no-b-only","--for-fits",    dest="noBOnly", default=False, action="store_true", help="Do not save the background-only pdf (saves time)")
     parser.add_option("--no-wrappers", dest="noHistFuncWrappers", default=False, action="store_true", help="Do not create and save the CMSHistFuncWrapper objects for autoMCStats-based models (saves time)")
+    parser.add_option("--use-histsum", dest="useCMSHistSum", default=False, action="store_true", help="Use memory-optimized CMSHistSum instead of CMSHistErrorPropagator")
     parser.add_option("--no-optimize-pdfs",    dest="noOptimizePdf", default=False, action="store_true", help="Do not save the RooSimultaneous as RooSimultaneousOpt and Gaussian constraints as SimpleGaussianConstraint")
     parser.add_option("--no-data",    dest="noData", default=False, action="store_true", help="Do not save the RooDataSet in the ouput workspace")
     parser.add_option("--optimize-simpdf-constraints",    dest="moreOptimizeSimPdf", default="none", type="string", help="Handling of constraints in simultaneous pdf: 'none' = add all constraints on all channels (default); 'lhchcg' = add constraints on only the first channel; 'cms' = add constraints to the RooSimultaneousOpt.")

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -142,8 +142,12 @@ class ShapeBuilder(ModelBuilder):
                 else:
                     sigcoeffs.append(coeff)
             if self.options.verbose > 1: print "Creating RooAddPdf %s with %s elements" % ("pdf_bin"+b, coeffs.getSize())
-            if channelBinParFlag: 
-                prop = self.addObj(ROOT.CMSHistErrorPropagator, "prop_bin%s" % b, "", pdfs.at(0).getXVar(), pdfs, coeffs)
+            if channelBinParFlag:
+                if self.options.useCMSHistSum:
+                    prop = self.addObj(ROOT.CMSHistSum, "prop_bin%s" % b, "", pdfs.at(0).getXVar(), pdfs, coeffs)
+                    prop.setAttribute('CachingPdf_NoClone', True)
+                else:
+                    prop = self.addObj(ROOT.CMSHistErrorPropagator, "prop_bin%s" % b, "", pdfs.at(0).getXVar(), pdfs, coeffs)
                 prop.setAttribute('CachingPdf_Direct', True)
                 if self.DC.binParFlags[b][0] >= 0.:
                     bbb_args = prop.setupBinPars(self.DC.binParFlags[b][0])

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -505,6 +505,7 @@ RooArgList * CMSHistSum::setupBinPars(double poissonThreshold) {
   std::set<unsigned> skip_idx;
   std::vector<std::string> skipped_procs;
   for (unsigned i = 0; i < vfuncstmp_.size(); ++i) {
+    vfuncstmp_[i]->updateCache();
     if (vfuncstmp_[i]->attributes().count("skipForErrorSum")) {
       skipped_procs.push_back(vfuncstmp_[i]->getStringAttribute("combine.process"));
       skip_idx.insert(i);

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -1,0 +1,552 @@
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistSum.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
+#include <stdexcept>
+#include <vector>
+#include <ostream>
+#include <memory>
+#include "Math/ProbFuncMathCore.h"
+#include "Math/QuantFuncMathCore.h"
+#include "RooRealProxy.h"
+#include "RooArgSet.h"
+#include "RooAbsReal.h"
+#include "RooAbsData.h"
+#include "RooConstVar.h"
+#include "RooGaussian.h"
+#include "RooProduct.h"
+#include "vectorized.h"
+
+#define HFVERBOSE 0
+
+CMSHistSum::CMSHistSum() : initialized_(false) {}
+
+CMSHistSum::CMSHistSum(const char* name,
+                                               const char* title,
+                                               RooRealVar& x,
+                                               RooArgList const& funcs,
+                                               RooArgList const& coeffs)
+    : RooAbsReal(name, title),
+      x_("x", "", this, x),
+      funcs_("funcs", "", this),
+      coeffs_("coeffs", "", this),
+      binpars_("binpars", "", this),
+      sentry_(TString(name) + "_sentry", ""),
+      binsentry_(TString(name) + "_binsentry", ""),
+      initialized_(false),
+      last_eval_(-1) {
+  funcs_.add(funcs);
+  coeffs_.add(coeffs);
+}
+
+CMSHistSum::CMSHistSum(
+    CMSHistSum const& other, const char* name)
+    : RooAbsReal(other, name),
+      x_("x", this, other.x_),
+      funcs_("funcs", this, other.funcs_),
+      coeffs_("coeffs", this, other.coeffs_),
+      binpars_("binpars", this, other.binpars_),
+      bintypes_(other.bintypes_),
+      sentry_(name ? TString(name) + "_sentry" : TString(other.sentry_.GetName()), ""),
+      binsentry_(name ? TString(name) + "_binsentry" : TString(other.binsentry_.GetName()), ""),
+      initialized_(false),
+      last_eval_(-1) {
+}
+
+void CMSHistSum::initialize() const {
+  if (initialized_) return;
+  sentry_.SetName(TString(this->GetName()) + "_sentry");
+  binsentry_.SetName(TString(this->GetName()) + "_binsentry");
+#if HFVERBOSE > 0
+  std::cout << "Initialising vectors\n";
+#endif
+  unsigned nf = funcs_.getSize();
+  vfuncs_.resize(nf);
+  vcoeffs_.resize(nf);
+  for (unsigned i = 0; i < nf; ++i) {
+    vfuncs_[i] = dynamic_cast<CMSHistFunc const*>(funcs_.at(i));
+    vcoeffs_[i] = dynamic_cast<RooAbsReal const*>(coeffs_.at(i));
+    auto sargs = vfuncs_[i]->getSentryArgs();
+    sentry_.addVars(*sargs);
+  }
+  unsigned nb = vfuncs_[0]->cache().size();
+  vbinpars_.resize(nb);
+  if (bintypes_.size()) {
+    for (unsigned j = 0, r = 0; j < nb; ++j) {
+      vbinpars_[j].resize(bintypes_[j].size(), nullptr);
+      for (unsigned i = 0; i < bintypes_[j].size(); ++i) {
+        if (bintypes_[j][i] >= 1 && bintypes_[j][i] < 4) {
+          vbinpars_[j][i] = dynamic_cast<RooAbsReal *>(binpars_.at(r));
+          ++r;
+        }
+      }
+    }
+  }
+  valsum_ = vfuncs_[0]->cache();
+  valsum_.Clear();
+  cache_ = vfuncs_[0]->cache();
+  cache_.Clear();
+  err2sum_.resize(nb, 0.);
+  toterr_.resize(nb, 0.);
+  binmods_.resize(nf, std::vector<double>(nb, 0.));
+  scaledbinmods_.resize(nf, std::vector<double>(nb, 0.));
+  coeffvals_.resize(nf, 0.);
+
+  sentry_.addVars(coeffs_);
+  binsentry_.addVars(binpars_);
+
+  sentry_.setValueDirty();
+  binsentry_.setValueDirty();
+
+  initialized_ = true;
+}
+
+
+void CMSHistSum::updateCache(int eval) const {
+  initialize();
+
+#if HFVERBOSE > 0
+  std::cout << "Sentry: " << sentry_.good() << "\n";
+#endif
+  if (!sentry_.good() || eval != last_eval_) {
+    for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+      vfuncs_[i]->updateCache();
+      coeffvals_[i] = vcoeffs_[i]->getVal();
+    }
+
+    valsum_.Clear();
+    std::fill(err2sum_.begin(), err2sum_.end(), 0.);
+    for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+      vectorized::mul_add(valsum_.size(), coeffvals_[i], &(vfuncs_[i]->cache()[0]), &valsum_[0]);
+      vectorized::mul_add_sqr(valsum_.size(), coeffvals_[i], &(vfuncs_[i]->errors()[0]), &err2sum_[0]);
+    }
+    vectorized::sqrt(valsum_.size(), &err2sum_[0], &toterr_[0]);
+    cache_ = valsum_;
+
+    if (eval == 0 && bintypes_.size()) {
+      for (unsigned j = 0; j < valsum_.size(); ++j) {
+        if (bintypes_[j][0] == 1) {
+#if HFVERBOSE > 1
+          std::cout << "Bin " << j << "\n";
+          printf(" | %.6f/%.6f/%.6f\n", valsum_[j], err2sum_[j], toterr_[j]);
+#endif
+          for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+            if (err2sum_[j] > 0. && coeffvals_[i] > 0.) {
+              double e =  vfuncs_[i]->errors()[j] * coeffvals_[i];
+              binmods_[i][j] = (toterr_[j] *  e * e) / (err2sum_[j] * coeffvals_[i]);
+            } else {
+              binmods_[i][j] = 0.;
+            }
+#if HFVERBOSE > 1
+            printf("%.6f   ", binmods_[i][j]);
+#endif
+          }
+#if HFVERBOSE > 1
+          printf("\n");
+#endif
+        }
+      }
+    }
+
+
+    sentry_.reset();
+    binsentry_.setValueDirty();
+  }
+
+
+  if (!binsentry_.good() || eval != last_eval_) {
+    runBarlowBeeston();
+    // bintypes might have size == 0 if we never ran setupBinPars()
+    for (unsigned j = 0; j < bintypes_.size(); ++j) {
+      cache_[j] = valsum_[j];
+      if (bintypes_[j][0] == 0) {
+        continue;
+      } else if (bintypes_[j][0] == 1) {
+        double x = vbinpars_[j][0]->getVal();
+        cache_[j] += toterr_[j] * x;
+        // Only fill the scaledbinmods if we're in eval == 0 mode (i.e. need to
+        // propagate to wrappers)
+        if (eval == 0) {
+          for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+            scaledbinmods_[i][j] = binmods_[i][j] * x;
+          }
+        }
+      } else {
+        for (unsigned i = 0; i < bintypes_[j].size(); ++i) {
+          if (bintypes_[j][i] == 2) {
+            // Poisson: this is a multiplier on the process yield
+            scaledbinmods_[i][j] = ((vbinpars_[j][i]->getVal() - 1.) *
+                 vfuncs_[i]->cache()[j]);
+            cache_[j] += (scaledbinmods_[i][j] * coeffvals_[i]);
+          } else if (bintypes_[j][i] == 3) {
+            // Gaussian This is the addition of the scaled error
+            scaledbinmods_[i][j] = vbinpars_[j][i]->getVal() * vfuncs_[i]->errors()[j];
+            cache_[j] += (scaledbinmods_[i][j] * coeffvals_[i]);
+          }
+        }
+      }
+    }
+    cache_.CropUnderflows();
+    binsentry_.reset();
+  }
+
+  last_eval_ = eval;
+}
+
+void CMSHistSum::runBarlowBeeston() const {
+  if (!bb_.init) return;
+  RooAbsArg::setDirtyInhibit(true);
+
+  const unsigned n = bb_.use.size();
+  for (unsigned j = 0; j < n; ++j) {
+    bb_.dat[j] = data_[bb_.use[j]];
+    bb_.valsum[j] = valsum_[bb_.use[j]] * cache_.GetWidth(bb_.use[j]);
+    bb_.toterr[j] = toterr_[bb_.use[j]] * cache_.GetWidth(bb_.use[j]);
+  }
+  // This pragma statement tells (modern) gcc that loop can be safely
+  // vectorized
+  #pragma GCC ivdep
+  for (unsigned j = 0; j < n; ++j) {
+    bb_.b[j] = bb_.toterr[j] + (bb_.valsum[j] / bb_.toterr[j]) - bb_.gobs[j];
+    bb_.c[j] = bb_.valsum[j] - bb_.dat[j] - (bb_.valsum[j] / bb_.toterr[j]) * bb_.gobs[j];
+    bb_.tmp[j] = -0.5 * (bb_.b[j] + copysign(1.0, bb_.b[j]) * std::sqrt(bb_.b[j] * bb_.b[j] - 4. * bb_.c[j]));
+    bb_.x1[j] = bb_.tmp[j];
+    bb_.x2[j] = bb_.c[j] / bb_.tmp[j];
+    bb_.res[j] = std::max(bb_.x1[j], bb_.x2[j]);
+  }
+  for (unsigned j = 0; j < n; ++j) {
+    if (toterr_[bb_.use[j]] > 0.) bb_.push_res[j]->setVal(bb_.res[j]);
+  }
+  RooAbsArg::setDirtyInhibit(false);
+  for (RooAbsArg *arg : bb_.dirty_prop) {
+    arg->setValueDirty();
+  }
+}
+
+void CMSHistSum::setAnalyticBarlowBeeston(bool flag) const {
+  // Clear it if it's already initialised
+  if (bb_.init && flag) return;
+  if (bb_.init && !flag) {
+    for (unsigned i = 0; i < bb_.push_res.size(); ++i) {
+      bb_.push_res[i]->setConstant(false);
+    }
+    bb_.use.clear();
+    bb_.dat.clear();
+    bb_.valsum.clear();
+    bb_.toterr.clear();
+    bb_.err.clear();
+    bb_.b.clear();
+    bb_.c.clear();
+    bb_.tmp.clear();
+    bb_.x1.clear();
+    bb_.x2.clear();
+    bb_.res.clear();
+    bb_.gobs.clear();
+    bb_.dirty_prop.clear();
+    bb_.push_res.clear();
+    bb_.init = false;
+  }
+  if (flag && data_.size()) {
+    for (unsigned j = 0; j < bintypes_.size(); ++j) {
+      if (bintypes_[j][0] == 1 && !vbinpars_[j][0]->isConstant()) {
+        bb_.use.push_back(j);
+        double gobs_val = 0.;
+        RooFIter iter = vbinpars_[j][0]->valueClientMIterator();
+        RooAbsArg *arg = nullptr;
+        while((arg = iter.next())) {
+          if (arg == this || arg == &binsentry_) {
+            // std::cout << "Skipping " << this << " " << this->GetName() << "\n";
+          } else {
+            // std::cout << "Adding " << arg << " " << arg->GetName() << "\n";
+            bb_.dirty_prop.insert(arg);
+            auto as_gauss = dynamic_cast<RooGaussian*>(arg);
+            if (as_gauss) {
+              auto gobs = dynamic_cast<RooAbsReal*>(as_gauss->findServer(TString(vbinpars_[j][0]->GetName())+"_In"));
+              if (gobs) gobs_val = gobs->getVal();
+            }
+          }
+        }
+        bb_.gobs.push_back(gobs_val);
+        bb_.push_res.push_back((RooRealVar*)vbinpars_[j][0]);
+        bb_.push_res.back()->setConstant(true);
+      }
+    }
+    unsigned n = bb_.use.size();
+    bb_.dat.resize(n);
+    bb_.valsum.resize(n);
+    bb_.toterr.resize(n);
+    bb_.err.resize(n);
+    bb_.b.resize(n);
+    bb_.c.resize(n);
+    bb_.tmp.resize(n);
+    bb_.x1.resize(n);
+    bb_.x2.resize(n);
+    bb_.res.resize(n);
+    bb_.init = true;
+  }
+}
+
+
+RooArgList * CMSHistSum::setupBinPars(double poissonThreshold) {
+  RooArgList * res = new RooArgList();
+  if (bintypes_.size()) {
+    std::cout << "setupBinPars() already called for " << this->GetName() << "\n";
+    return res;
+  }
+
+  // First initialize all the storage
+  initialize();
+  // Now fill the bin contents and errors
+  updateCache(1); // the arg (1) forces updateCache to fill the caches for all bins
+
+  bintypes_.resize(valsum_.size(), std::vector<unsigned>(1, 0));
+
+
+  std::cout << std::string(60, '=') << "\n";
+  std::cout << "Analysing bin errors for: " << this->GetName() << "\n";
+  std::cout << "Poisson cut-off: " << poissonThreshold << "\n";
+  std::set<unsigned> skip_idx;
+  std::vector<std::string> skipped_procs;
+  for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+    if (vfuncs_[i]->attributes().count("skipForErrorSum")) {
+      skipped_procs.push_back(vfuncs_[i]->getStringAttribute("combine.process"));
+      skip_idx.insert(i);
+    }
+  }
+  if (skipped_procs.size()) {
+    std::cout << "Processes excluded for sums:";
+    for (auto &s: skipped_procs) std::cout << " " << s;
+    std::cout << "\n";
+  }
+  std::cout << std::string(60, '=') << "\n";
+  std::cout << TString::Format("%-10s %-15s %-15s %-30s\n", "Bin", "Contents", "Error", "Notes");
+
+  for (unsigned j = 0; j < valsum_.size(); ++j) {
+    std::cout << TString::Format("%-10i %-15f %-15f %-30s\n", j, valsum_[j], toterr_[j], "total sum");
+    double sub_sum = 0.;
+    double sub_err = 0.;
+    // Check using a possible sub-set of bins
+    for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+      if (skip_idx.count(i)) {
+        continue;
+      }
+      sub_sum += vfuncs_[i]->cache()[j] * coeffvals_[i];
+      sub_err += std::pow(vfuncs_[i]->errors()[j] * coeffvals_[i], 2.);;
+    }
+    sub_err = std::sqrt(sub_err);
+    if (skipped_procs.size()) {
+      std::cout << TString::Format("%-10i %-15f %-15f %-30s\n", j, sub_sum, sub_err, "excluding marked processes");
+    }
+
+    if (sub_err <= 0.) {
+      std::cout << TString::Format("  %-30s\n", "=> Error is zero, ignore");
+      std::cout << std::string(60, '-') << "\n";
+      continue;
+    }
+
+    // Now check if we are below the poisson threshold
+    double n = int(0.5 + ((sub_sum * sub_sum) / (sub_err * sub_err)));
+    double alpha = valsum_[j] / n;
+    std::cout << TString::Format(
+        "%-10i %-15f %-15f %-30s\n", j, n, std::sqrt(n),
+        TString::Format("Unweighted events, alpha=%f", alpha).Data());
+
+    if (n <= poissonThreshold) {
+      std::cout << TString::Format("  %-30s\n", "=> Number of weighted events is below poisson threshold");
+
+      bintypes_[j].resize(vfuncs_.size(), 4);
+
+      for (unsigned i = 0; i < vfuncs_.size(); ++i) {
+        std::string proc =
+            vfuncs_[i]->stringAttributes().count("combine.process")
+                ? vfuncs_[i]->getStringAttribute("combine.process")
+                : vfuncs_[i]->GetName();
+        double v_p = vfuncs_[i]->cache()[j];
+        double e_p = vfuncs_[i]->errors()[j];
+        std::cout << TString::Format("    %-20s %-15f %-15f %-30s\n", proc.c_str(), v_p, e_p, "");
+        // relax the condition of v_p >= e_p slightly due to numerical rounding...
+        // Possibilities:
+        //    v_p = any   e_p <= 0       : skip
+        //    v_p < 0     e_p > 0        : for now, skip but technically we should be able to handle this in the future
+        //    v_p >= 0    e_p > v_p      : Create an additive gaussian constraint for this bin
+        //    v_p > 0     0 < e_p <= v_p : do the poisson
+        if (e_p <= 0.) {
+          std::cout << TString::Format("      %-30s\n", "=> Error is zero, ignore");
+          bintypes_[j][i] = 4;
+        } else if (v_p < 0. && e_p > 0.) {
+          std::cout << TString::Format("      %-30s\n", "=> Cannot handle negative content, ignore");
+          bintypes_[j][i] = 4;
+        } else if (v_p > 0. && e_p > 0. && v_p >= (e_p*0.999)) {
+          double n_p_r = int(0.5 + ((v_p * v_p) / (e_p * e_p)));
+          double alpha_p_r = v_p / n_p_r;
+          std::cout << TString::Format(
+              "    %-20s %-15f %-15f %-30s\n", "", n_p_r, std::sqrt(n_p_r),
+              TString::Format("Unweighted events, alpha=%f", alpha_p_r).Data());
+          if (n_p_r <= poissonThreshold) {
+            double sigma = 7.;
+            double rmin = 0.5*ROOT::Math::chisquared_quantile(ROOT::Math::normal_cdf_c(sigma), n_p_r * 2.);
+            double rmax = 0.5*ROOT::Math::chisquared_quantile(1. - ROOT::Math::normal_cdf_c(sigma), n_p_r * 2. + 2.);
+            RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i_%s", this->GetName(), j, proc.c_str()), "", n_p_r, rmin, rmax);
+            RooConstVar *cvar = new RooConstVar(TString::Format("%g", 1. / n_p_r), "", 1. / n_p_r);
+            RooProduct *prod = new RooProduct(TString::Format("%s_prod", var->GetName()), "", RooArgList(*var, *cvar));
+            var->addOwnedComponents(RooArgSet(*prod, *cvar));
+            var->setAttribute("createPoissonConstraint");
+            res->addOwned(*var);
+            binpars_.add(*prod);
+
+            std::cout << TString::Format(
+                "      => Product of %s[%.2f,%.2f,%.2f] and const [%.4f] to be poisson constrained\n",
+                var->GetName(), var->getVal(), var->getMin(), var->getMax(), cvar->getVal());
+            bintypes_[j][i] = 2;
+          } else {
+            RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i_%s", this->GetName(), j, proc.c_str()), "", 0, -7, 7);
+            std::cout << TString::Format(
+                "      => Parameter %s[%.2f,%.2f,%.2f] to be gaussian constrained\n",
+                var->GetName(), var->getVal(), var->getMin(), var->getMax());
+            var->setAttribute("createGaussianConstraint");
+            res->addOwned(*var);
+            binpars_.add(*var);
+            bintypes_[j][i] = 3;
+          }
+        } else if (v_p >= 0 && e_p > v_p) {
+          RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i_%s", this->GetName(), j, proc.c_str()), "", 0, -7, 7);
+          std::cout << TString::Format(
+              "      => Poisson not viable, %s[%.2f,%.2f,%.2f] to be gaussian constrained\n",
+              var->GetName(), var->getVal(), var->getMin(), var->getMax());
+          var->setAttribute("createGaussianConstraint");
+          res->addOwned(*var);
+          binpars_.add(*var);
+          bintypes_[j][i] = 3;
+        } else{
+          std::cout << "      => ERROR: shouldn't be here\n";
+        }
+        std::cout << "  " << std::string(58, '-') << "\n";
+
+      }
+    } else if (toterr_[j] > 0.) {
+      bintypes_[j][0] = 1;
+      RooRealVar *var = new RooRealVar(TString::Format("%s_bin%i", this->GetName(), j), "", 0, -7, 7);
+      std::cout << TString::Format(
+          "  => Total parameter %s[%.2f,%.2f,%.2f] to be gaussian constrained\n",
+          var->GetName(), var->getVal(), var->getMin(), var->getMax());
+      var->setAttribute("createGaussianConstraint");
+      var->setAttribute("forBarlowBeeston");
+      res->addOwned(*var);
+      binpars_.add(*var);
+    }
+    std::cout << std::string(60, '-') << "\n";
+  }
+
+  // binpars_.add(*res);
+  binsentry_.addVars(binpars_);
+  binsentry_.setValueDirty();
+
+  for (unsigned j = 0, r = 0; j < valsum_.size(); ++j) {
+    vbinpars_[j].resize(bintypes_[j].size());
+    for (unsigned i = 0; i < bintypes_[j].size(); ++i) {
+      if (bintypes_[j][i] >= 1 && bintypes_[j][i] < 4) {
+        vbinpars_[j][i] = dynamic_cast<RooAbsReal *>(binpars_.at(r));
+        ++r;
+      }
+    }
+  }
+  return res;
+}
+
+
+void CMSHistSum::applyErrorShifts(unsigned idx,
+                                              FastHisto const& nominal,
+                                              FastHisto& result) {
+  // We can skip the whole evaluation if there's nothing to evaluate
+  // if (bintypes_.size() == 0) return;
+  // std::cout << "Start of function\n";
+  updateCache(0);
+  for (unsigned i = 0; i < result.size(); ++i) {
+    result[i] = nominal[i] + scaledbinmods_[idx][i];
+  }
+}
+
+std::unique_ptr<RooArgSet> CMSHistSum::getSentryArgs() const {
+  // We can do this without initialising because we're going to hand over
+  // the sentry directly
+  sentry_.SetName(TString(this->GetName()) + "_sentry");
+  binsentry_.SetName(TString(this->GetName()) + "_binsentry");
+  std::unique_ptr<RooArgSet> args(new RooArgSet(sentry_, binsentry_));
+  return args;
+}
+
+Double_t CMSHistSum::evaluate() const {
+  updateCache(1);
+  return cache().GetAt(x_);
+}
+
+
+void CMSHistSum::printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
+                    TString indent) const {
+  RooAbsReal::printMultiline(os, contents, verbose, indent);
+  updateCache();
+  if (bintypes_.size()) {
+    std::cout << ">> Bin types are:\n";
+    for (unsigned j = 0; j < bintypes_.size(); ++j) {
+      std::cout << ">> " << j << ":";
+      for (unsigned i = 0; i < bintypes_[j].size(); ++i) {
+        std::cout << " " << bintypes_[j][i];
+      }
+      std::cout << "\n";
+    }
+  }
+  std::cout << ">> Current cache:\n";
+  valsum_.Dump();
+  std::cout << ">> Current cache (bin scaled):\n";
+  cache_.Dump();
+  std::cout << ">> Sentry: " << sentry_.good() << "\n";
+  sentry_.Print("v");
+
+}
+
+Int_t CMSHistSum::getAnalyticalIntegral(RooArgSet& allVars,
+                                         RooArgSet& analVars,
+                                         const char* /*rangeName*/) const {
+  if (matchArgs(allVars, analVars, x_)) return 1;
+  return 0;
+}
+
+Double_t CMSHistSum::analyticalIntegral(Int_t code,
+                                         const char* rangeName) const {
+  // TODO: check how RooHistFunc handles ranges that splice bins
+  switch (code) {
+    case 1: {
+      updateCache(1);
+      return cache().IntegralWidth();
+    }
+  }
+
+  assert(0);
+  return 0;
+}
+
+void CMSHistSum::setData(RooAbsData const& data) const {
+  updateCache(1);
+  data_.clear();
+  data_.resize(cache_.fullsize(), 0.); // fullsize is important here is we've used activeBins
+  RooArgSet obs(x_.arg());
+  const RooRealVar& x = static_cast<const RooRealVar&>(*obs.first());
+  for (int i = 0, n = data.numEntries(); i < n; ++i) {
+    obs = *data.get(i);
+    int idx = cache_.FindBin(x.getVal());
+    data_[idx] = data.weight();
+  }
+}
+
+RooArgList CMSHistSum::wrapperList() const {
+  RooArgList result;
+  for (int i = 0; i < funcs_.getSize(); ++i) {
+    CMSHistFunc const* hf = dynamic_cast<CMSHistFunc const*>(funcs_.at(i));
+    if (hf) {
+      CMSHistFuncWrapper const* wrapper = hf->wrapper();
+      if (wrapper) result.add(*wrapper);
+    }
+  }
+  return result;
+}
+
+#undef HFVERBOSE
+

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -13,6 +13,7 @@
 #include <HiggsAnalysis/CombinedLimit/interface/CMSHistV.h>
 #include <HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h>
 #include <HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h>
+#include <HiggsAnalysis/CombinedLimit/interface/CMSHistSum.h>
 #include <HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h>
 #include <HiggsAnalysis/CombinedLimit/interface/VectorizedGaussian.h>
 #include <HiggsAnalysis/CombinedLimit/interface/VectorizedCB.h>
@@ -30,6 +31,7 @@ namespace cacheutils {
     typedef OptimizedCachingPdfT<CMSHistFunc, CMSHistV<CMSHistFunc>> CachingCMSHistFunc;
     typedef OptimizedCachingPdfT<CMSHistFuncWrapper, CMSHistV<CMSHistFuncWrapper>> CachingCMSHistFuncWrapper;
     typedef OptimizedCachingPdfT<CMSHistErrorPropagator, CMSHistV<CMSHistErrorPropagator>> CachingCMSHistErrorPropagator;
+    typedef OptimizedCachingPdfT<CMSHistSum, CMSHistV<CMSHistSum>> CachingCMSHistSum;
     typedef OptimizedCachingPdfT<RooGaussian,VectorizedGaussian> CachingGaussPdf;
     typedef OptimizedCachingPdfT<RooCBShape,VectorizedCBShape> CachingCBPdf;
     typedef OptimizedCachingPdfT<RooExponential,VectorizedExponential> CachingExpoPdf;
@@ -248,33 +250,41 @@ std::pair<std::vector<Double_t> *, bool> cacheutils::ValuesCache::get()
     return std::pair<std::vector<Double_t> *, bool>(&items[found]->values, good);
 }
 
-cacheutils::CachingPdf::CachingPdf(RooAbsReal *pdf, const RooArgSet *obs) :
-    obs_(obs),
-    pdfOriginal_(pdf),
-    pdfPieces_(),
-    pdf_(runtimedef::get("CACHINGPDF_NOCLONE") ? pdfOriginal_ : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE") ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_) : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
-    lastData_(0),
-    cache_(*pdf_,*obs_),
-    includeZeroWeights_(false)
-{
-    if (runtimedef::get("CACHINGPDF_DIRECT") || pdf->getAttribute("CachingPdf_Direct")) {
-        cache_.setDirectMode(true);
-    }
+cacheutils::CachingPdf::CachingPdf(RooAbsReal *pdf, const RooArgSet *obs)
+    : obs_(obs),
+      pdfOriginal_(pdf),
+      pdfPieces_(),
+      pdf_((runtimedef::get("CACHINGPDF_NOCLONE") &&
+            pdfOriginal_->getAttribute("CachingPdf_NoClone"))
+               ? pdfOriginal_
+               : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE")
+                      ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_)
+                      : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
+      lastData_(0),
+      cache_(*pdf_, *obs_),
+      includeZeroWeights_(false) {
+  if (runtimedef::get("CACHINGPDF_DIRECT") || pdf->getAttribute("CachingPdf_Direct")) {
+    cache_.setDirectMode(true);
+  }
 }
 
-cacheutils::CachingPdf::CachingPdf(const CachingPdf &other) :
-    obs_(other.obs_),
-    pdfOriginal_(other.pdfOriginal_),
-    pdfPieces_(),
-    pdf_(runtimedef::get("CACHINGPDF_NOCLONE") ? pdfOriginal_ : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE") ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_) : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
-    lastData_(0),
-    cache_(*pdf_,*obs_),
-    includeZeroWeights_(other.includeZeroWeights_)
-{
-    if (runtimedef::get("CACHINGPDF_DIRECT") || other.pdfOriginal_->getAttribute("CachingPdf_Direct")) {
-        cache_.setDirectMode(true);
-    }
-
+cacheutils::CachingPdf::CachingPdf(const CachingPdf &other)
+    : obs_(other.obs_),
+      pdfOriginal_(other.pdfOriginal_),
+      pdfPieces_(),
+      pdf_((runtimedef::get("CACHINGPDF_NOCLONE") &&
+            other.pdfOriginal_->getAttribute("CachingPdf_NoClone"))
+               ? pdfOriginal_
+               : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE")
+                      ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_)
+                      : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
+      lastData_(0),
+      cache_(*pdf_, *obs_),
+      includeZeroWeights_(other.includeZeroWeights_) {
+  if (runtimedef::get("CACHINGPDF_DIRECT") ||
+      other.pdfOriginal_->getAttribute("CachingPdf_Direct")) {
+    cache_.setDirectMode(true);
+  }
 }
 
 cacheutils::CachingPdf::~CachingPdf() 
@@ -507,6 +517,8 @@ cacheutils::makeCachingPdf(RooAbsReal *pdf, const RooArgSet *obs) {
         return new CachingCMSHistFuncWrapper(pdf, obs);
     } else if (histfuncNll && typeid(*pdf) == typeid(CMSHistErrorPropagator)) {
         return new CachingCMSHistErrorPropagator(pdf, obs);
+    } else if (histfuncNll && typeid(*pdf) == typeid(CMSHistSum)) {
+        return new CachingCMSHistSum(pdf, obs);
     } else {
         if (verb) {
             std::cout << "I don't have an optimized implementation for " << pdf->ClassName() << " (" << pdf->GetName() << ")" << std::endl;
@@ -806,6 +818,10 @@ void cacheutils::CachingAddNLL::propagateData() {
             // printf("Passing data to %s\n", funci.pdf()->GetName());
             (static_cast<CMSHistErrorPropagator const*>(funci.pdf()))->setData(*data_);
         }
+        if (typeid(*(funci.pdf())) == typeid(CMSHistSum)) {
+            // printf("Passing data to %s\n", funci.pdf()->GetName());
+            (static_cast<CMSHistSum const*>(funci.pdf()))->setData(*data_);
+        }
     }
 }
 
@@ -815,6 +831,10 @@ void cacheutils::CachingAddNLL::setAnalyticBarlowBeeston(bool flag) {
         if (typeid(*(funci.pdf())) == typeid(CMSHistErrorPropagator)) {
             (static_cast<CMSHistErrorPropagator const*>(funci.pdf()))->setAnalyticBarlowBeeston(flag);
         }
+        if (typeid(*(funci.pdf())) == typeid(CMSHistSum)) {
+            (static_cast<CMSHistSum const*>(funci.pdf()))->setAnalyticBarlowBeeston(flag);
+        }
+
     }
 }
 

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -63,6 +63,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/ProfilingTools.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooMultiPdf.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistSum.h"
 
 #include "HiggsAnalysis/CombinedLimit/interface/Logger.h"
 
@@ -898,6 +899,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 
   if (runtimedef::get("FAST_VERTICAL_MORPH")) {
     CMSHistFunc::EnableFastVertical();
+    CMSHistSum::EnableFastVertical();
   }
 
   // Warn the user that they might be using funky values of POIs 

--- a/src/classes.h
+++ b/src/classes.h
@@ -52,6 +52,7 @@
 #include "HiggsAnalysis/CombinedLimit/interface/RooDoubleCBFast.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistSum.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooTaylorExpansion.h"
 #include "HiggsAnalysis/CombinedLimit/interface/SimpleTaylorExpansion1D.h"

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -202,6 +202,7 @@
         <function name="function th1fmorph" />
   <class name="CMSHistFunc" />
   <class name="CMSHistErrorPropagator" />
+  <class name="CMSHistSum" />
   <class name="CMSHistFuncWrapper" />
   <class name="SimpleTaylorExpansion1D" />
   <class name="RooTaylorExpansion" />


### PR DESCRIPTION
Adds new CMSHistSum class. Essentially a clone of CMSHistErrorPropagator, but instead of linking to a set of CMSHistFuncs (one per process), encapsulates all processes and performs the vertical template morphing directly. For complex models (e.g. STXS) this dramatically reduces the number of separate RooFit objects that need to go into the workspace. Should be used with `--X-rtd FAST_VERTICAL_MORPH`, as otherwise fitting will be slightly slower than traditional approach, as we now have a single sentry watching all vertical morph params for a given channel.

In testing on the full htautau cards, reduces fit memory usage by over 60%, and fitting time by 40%. Unfortunately not possible to improve t2w memory at this point. We still build full set of CMSHistFuncs, then CMSHistSum constructor extracts all the needed info. A more optimal way would require extensive rewrite of t2w.

Also confirmed that for performing simple fits, there is no need for CMSHistSum to be cloned inside of CachingPdf. text2workspace.py will now add an attribute on CMSHistSum, that in conjunction with `--X-rtd CACHINGPDF_NOCLONE` will prevent the clone.

Recommend validating carefully on all other channels before general use. Results should be highly consistent (at least 3 digits).

**Testing on the full htautau cards: ML_STXS/stage1/125/**

`combineCards.py htt*.txt > combined_all.txt`

OLD
------
`text2workspace.py -o combined_all.root -m 125 --for-fits --no-wrappers --X-pack-asympows --optimize-simpdf-constraints=cms combined_all.txt`
=> 2619.49s / 6.2 GB

`combine -M MultiDimFit --algo none --noMCbonly 1 --cminDefaultMinimizerStrategy 0 --X-rtd NO_INITIAL_SNAP --X-rtd OPTIMIZE_BOUNDS=0 combined_all.root -v 3 --X-rtd FAST_VERTICAL_MORPH`
=> 962.54s / 2.3 GB
```
Minimized in : Real time 0:14:52, CP time 891.940
FINAL NLL - NLL0 VALUE = -1562.217683
 --- MultiDimFit ---
best fit parameter values:
   r :    +0.912
Done in 15.71 min (cpu), 15.71 min (real)
```

NEW
-------
`text2workspace.py -o combined_all_new.root -m 125 --for-fits --no-wrappers --X-pack-asympows --optimize-simpdf-constraints=cms combined_all.txt --use-histsum`
=> 2358.91s / 6.1 GB

`combine -M MultiDimFit --algo none --noMCbonly 1  --cminDefaultMinimizerStrategy 0 --X-rtd NO_INITIAL_SNAP --X-rtd OPTIMIZE_BOUNDS=0 combined_all_new.root -v 3 --X-rtd FAST_VERTICAL_MORPH --X-rtd CACHINGPDF_NOCLONE`
=> 566s / 0.87 GB
```
Minimized in : Real time 0:08:58, CP time 537.780
FINAL NLL - NLL0 VALUE = -1562.217603

 --- MultiDimFit ---
best fit parameter values:
   r :    +0.912
Done in 9.26 min (cpu), 9.27 min (real)
```
