### PR TITLE
Options for saving best-fit values for parameters w/o running Hesse and for loading parameters from a RooArgList

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -30,6 +30,7 @@ extern bool doSignificance_, lowerLimit_;
 extern float cl;
 extern bool bypassFrequentistFit_;
 extern  std::string setPhysicsModelParameterExpression_;
+extern  std::string setParametersFromList_;
 extern  std::string setPhysicsModelParameterRangeExpression_;
 extern  std::string defineBackgroundOnlyModelParameterExpression_;
 

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -57,6 +57,7 @@ protected:
   static bool  startFromPreFit_;
   static bool  alignEdges_;
   static bool  saveFitResult_;
+  static bool  saveFitResultWithoutHesse_;
   static std::string fixedPointPOIs_;
   static float centeredRange_;
   static std::string setParametersForGrid_;

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -108,6 +108,7 @@ namespace utils {
 
     // Set values of physics model parameters
     void setModelParameters( const std::string & setPhysicsModelParameterExpression, const RooArgSet & params);
+    void setParametersFromList( const std::string & setParameterFile, const RooArgSet & params);
     // Set range of physics model parameters
     void setModelParameterRanges( const std::string & setPhysicsModelParameterRangeExpression, const RooArgSet & params);
 

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -53,6 +53,7 @@ bool MultiDimFit::hasMaxDeltaNLLForProf_ = false;
 bool MultiDimFit::squareDistPoiStep_ = false;
 bool MultiDimFit::skipInitialFit_ = false;
 bool MultiDimFit::saveFitResult_ = false;
+bool MultiDimFit::saveFitResultWithoutHesse_ = false;
 float MultiDimFit::maxDeltaNLLForProf_ = 200;
 float MultiDimFit::autoRange_ = -1.0;
 std::string MultiDimFit::fixedPointPOIs_ = "";
@@ -106,6 +107,7 @@ MultiDimFit::MultiDimFit() :
     ("alignEdges",   boost::program_options::value<bool>(&alignEdges_)->default_value(alignEdges_), "Align the grid points such that the endpoints of the ranges are included")
     ("setParametersForGrid", boost::program_options::value<std::string>(&setParametersForGrid_)->default_value(""), "Set the values of relevant physics model parameters. Give a comma separated list of parameter value assignments. Example: CV=1.0,CF=1.0")
 	("saveFitResult",  "Save RooFitResult to multidimfit.root")
+	("saveFitResultWithoutHesse",  "Save RooFitResult to multidimfit.root")
     ("out", boost::program_options::value<std::string>(&out_)->default_value(out_), "Directory to put the diagnostics output file in")
     ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
     ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
@@ -149,6 +151,7 @@ void MultiDimFit::applyOptions(const boost::program_options::variables_map &vm)
     massName_ = vm["massName"].as<std::string>();
     toyName_ = vm["toyName"].as<std::string>();
     saveFitResult_ = (vm.count("saveFitResult") > 0);
+    saveFitResultWithoutHesse_ = (vm.count("saveFitResultWithoutHesse") > 0);
 }
 
 bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) { 
@@ -184,9 +187,9 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     const RooCmdArg &constrainCmdArg = withSystematics  ? RooFit::Constrain(*mc_s->GetNuisanceParameters()) : RooCmdArg();
     std::auto_ptr<RooFitResult> res;
     if (verbose <= 3) RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CountErrors);
-    bool doHesse = (algo_ == Singles || algo_ == Impact) || (saveFitResult_) ;
+    bool doHesse = ((algo_ == Singles || algo_ == Impact) || (saveFitResult_) ) && !(saveFitResultWithoutHesse_);
     if ( !skipInitialFit_){
-        res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, (saveFitResult_ && !robustHesse_), 1, true, false));
+        res.reset(doFit(pdf, data, (doHesse ? poiList_ : RooArgList()), constrainCmdArg, (saveFitResult_ && !robustHesse_ && !saveFitResultWithoutHesse_), 1, true, saveFitResultWithoutHesse_));
         if (!res.get()) {
             std::cout << "\n " <<std::endl;
             std::cout << "\n ---------------------------" <<std::endl;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -15,6 +15,7 @@
 
 #include <TIterator.h>
 #include <TString.h>
+#include <TFile.h>
 
 #include <RooAbsData.h>
 #include <RooAbsPdf.h>
@@ -810,6 +811,38 @@ void utils::setModelParameters( const std::string & setPhysicsModelParameterExpr
   }
 
 }
+
+void utils::setParametersFromList( const std::string & setParameterFile, const RooArgSet & params) {
+
+  TFile* filewithparams = TFile::Open(setParameterFile.c_str());
+  RooArgList* paramlist = (RooArgList*) filewithparams->Get("fitpars");
+  for (Int_t p = 0; p < paramlist->getSize(); ++p) {
+     RooAbsArg  *tmp = (RooAbsArg*)params.find(paramlist->at(p)->GetName());
+     if (tmp){
+         bool isrvar = tmp->IsA()->InheritsFrom(RooRealVar::Class());  // check its type
+         if (isrvar) {
+           RooRealVar *tmpParameter = dynamic_cast<RooRealVar*>(tmp);
+           RooRealVar *parFromList = (RooRealVar*) paramlist->at(p);
+           double PhysicsParameterValue = parFromList->getVal();
+           cout << "Set Default Value of Parameter " << parFromList->GetName()
+               << " To : " << PhysicsParameterValue << "\n";
+          tmpParameter->setVal(PhysicsParameterValue);
+         } else {
+           RooCategory *tmpCategory  = dynamic_cast<RooCategory*>(tmp);
+           RooCategory *catFromList = (RooCategory*) paramlist->at(p);
+           int PhysicsParameterValue = catFromList->getIndex();
+           cout << "Set Default Index of Parameter " << catFromList->GetName()
+                << " To : " << PhysicsParameterValue
+                << " (was: " << tmpCategory->getIndex() << " )\n";
+           tmpCategory->setIndex(PhysicsParameterValue);
+       }
+      }
+        else {
+        std::cout << "Warning: Did not find a parameter with name " << paramlist->at(p)->GetName() << endl;
+      }
+    }
+}
+
 
 void utils::setModelParameterRanges( const std::string & setPhysicsModelParameterRangeExpression, const RooArgSet & params) {
 


### PR DESCRIPTION
This adds an option `--saveFitResultWithoutHesse ` to save the best fit parameter values to fit_mdf without triggering the Hesse run.

After some postprocessing (see PR in summer21 repository) into a RooArgList of fit parameters these can then be loaded to set the initial values of a new fit using `--setParametersFromList <filename.root>` where `filename.root` should contain a RooArgList `fitpars` that will be used to set the parameter values (the creation of this is taken care of by the postprocessing script)

The idea is that you can use the best fit values of a fit with a slightly different configuration as a starting point, e.g. the inclusive mu fit from the STXS fit, or the combined fit with the information from the fits of individual channels. The latter was tested in a combination of hgg, hzz, vhbb, tthbb, tthll (ie main STXS channels except hww, which had some problems), where the initial fit time was reduced by 30% by setting the initial NP values from the fit to those obtained from the individual channel fits.