### PR TITLE
Minimise usage of iterators in ProcessNormalization::evaluate

### DIFF
--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -40,6 +40,9 @@ class ProcessNormalization : public RooAbsReal {
         std::vector<std::pair<double,double> > logAsymmKappa_; // Logarithm of asymmetric kappas (low, high)
         RooListProxy asymmThetaList_;                           // List of nuisances for asymmetric kappas
         RooListProxy otherFactorList_;     // Other multiplicative terms 
+        std::vector<RooAbsReal *> thetaListVec_; //! Don't serialize me
+        std::vector<RooAbsReal *> asymmThetaListVec_; //! Don't serialize me
+        std::vector<RooAbsReal *> otherFactorListVec_; //! Don't serialize me
 
         // get the kappa for the appropriate x
         Double_t logKappaForX(double x, const std::pair<double,double> &logKappas ) const ;


### PR DESCRIPTION
In ProcessNormalization::evaluate() only iterate through the RooListProxies once at the beginning to fill vectors that are then looped through instead of using the iterator every time.

This saves about 5-10% of the fit runtime (it's a 6% saving on the STXS combination w/o Hww). The fit results are unchanged by this modification.