### PR TITLE
combineCards: Respect absolute workspace paths

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -166,12 +166,14 @@ for ich,fname in enumerate(args):
             p2sMapD = DC.shapeMap['*'] if DC.shapeMap.has_key('*') else {}
             for p, x in p2sMap.items():
                 xrep = [xi.replace("$CHANNEL",b) for xi in x]
-                if xrep[0] != 'FAKE' and dirname != '': xrep[0] = dirname+"/"+xrep[0]
+                if xrep[0] != 'FAKE' and dirname != '' and not xrep[0].startswith("/"):
+                    xrep[0] = dirname+"/"+xrep[0]
                 shapeLines.append((p,bout,xrep))
             for p, x in p2sMapD.items():
                 if p2sMap.has_key(p): continue
                 xrep = [xi.replace("$CHANNEL",b) for xi in x]
-                if xrep[0] != 'FAKE' and dirname != '': xrep[0] = dirname+"/"+xrep[0]
+                if xrep[0] != 'FAKE' and dirname != '' and not xrep[0].startswith("/"):
+                    xrep[0] = dirname+"/"+xrep[0]
                 shapeLines.append((p,bout,xrep))
     elif options.shape:
         for b in DC.bins:


### PR DESCRIPTION
When processing cards, combineCards attempts to update the paths to workspace files. This is done to avoid problems with relative paths in the input cards.
However, if the paths are already absolute paths in the input cards, combineCards can be tricked into also prepending something to these paths, which it should not.
In this PR, I add an additional check to the update condition that prevents an update to paths that already start with a `/`, which indicates that they are absolute paths.