### PR TITLE
Don't add autoMCStats NPs for channels that were vetoed

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -36,7 +36,7 @@ obsline = []; obskeyline = [] ;
 keyline = []; expline = []; systlines = {}
 signals = []; backgrounds = []; shapeLines = []
 paramSysts = {}; flatParamNuisances = {}; discreteNuisances = {}; groups = {}; rateParams = {}; rateParamsOrder = set();
-extArgs = {}; binParFlags = {}
+extArgs = {}; binParFlags = {}; bpf_new2old = {}
 nuisanceEdits = [];
 
 def compareParamSystLines(a,b):
@@ -141,6 +141,7 @@ for ich,fname in enumerate(args):
     for K in DC.binParFlags.iterkeys():
         tbin = label if singlebin else label+K
         binParFlags[tbin] = DC.binParFlags[K]
+        bpf_new2old[tbin] = K
     # rate params
     for K in DC.rateParams.iterkeys():
         tbin,tproc = K.split("AND")[0],K.split("AND")[1]
@@ -305,6 +306,7 @@ for groupName,nuisanceNames in groups.iteritems():
     nuisances = ' '.join(nuisanceNames)
     print '%(groupName)s group = %(nuisances)s' % locals()
 for bpf in binParFlags.iterkeys():
+    if isVetoed(bpf_new2old[bpf], options.channelVetos) or not isIncluded(bpf_new2old[bpf],options.channelIncludes): continue
     if len(binParFlags[bpf]) == 1:
       print "%s autoMCStats %g" % (bpf,binParFlags[bpf][0])
     if len(binParFlags[bpf]) == 2:


### PR DESCRIPTION
The combineCards.py option "--xc" allows one to veto specific channels when combining the cards. However, when the using autoMCStats feature, the autoMCStats NP corresponding to this channel is still added to the combined cards. This results in errors downstream, since Combine cannot apply this NP to the channel that was previously removed. This PR suggests a simple fix to only include the autoMCStats NP if the corresponding channel was actually included / not vetoed. 