### PR TITLE
Fix the printing of err95 in MultiDimFit

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -481,7 +481,7 @@ void MultiDimFit::doSingles(RooFitResult &res)
             //poiVals_[i] = rf->getMin("err95"); Combine::commitPoint(true, /*quantile=*/0.05);
             poiVals_[i] = bestFitVal;
             printf("   %*s :  %+8.3f   %+6.3f/%+6.3f (68%%)    %+6.3f/%+6.3f (95%%) \n", len, poi_[i].c_str(), 
-                    poiVals_[i], -loErr, hiErr, loErr95, -hiErr95);
+                    poiVals_[i], -loErr, hiErr, -loErr95, hiErr95);
         } else {
             poiVals_[i] = bestFitVal;
             printf("   %*s :  %+8.3f   %+6.3f/%+6.3f (68%%)\n", len, poi_[i].c_str(), 


### PR DESCRIPTION
Shouldn't the minus sign be put before `loErr95` instead of `hiErr95` here?

https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/2e2d16c03ea24218da3553775ff39b73c1b1b18c/src/MultiDimFit.cc#L483-L484