### PR TITLE
text2workspace: create discrete parameter set when no other systematics are present

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -281,11 +281,12 @@ class ModelBuilder(ModelBuilderBase):
         """create pdf_bin<X> and pdf_bin<X>_bonly for each bin"""
         raise RuntimeError, "Not implemented in ModelBuilder"
     def doNuisances(self):
+        for cpar in self.DC.discretes: self.addDiscrete(cpar)
+
         if len(self.DC.systs) == 0: return
         self.doComment(" ----- nuisances -----")
         globalobs = []
 
-        for cpar in self.DC.discretes: self.addDiscrete(cpar)
         for (n,nofloat,pdf,args,errline) in self.DC.systs:
             is_func_scaled = False
             func_scaler = None


### PR DESCRIPTION
Fixes the problem described here: https://hypernews.cern.ch/HyperNews/CMS/get/higgs-combination/1685/1/2/1/1/1/3.html

Unusual edge case with a discrete parameter but no other lnN/shape systematics. Code skips adding the discrete param. in this case, fixed by the PR.