### PR TITLE
Filter POIs from specifiedNuis_ in MultiDimFit

### DIFF
--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -372,6 +372,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 		    specifiedNuis_.clear();
 		    RooLinkedListIter iterN = mc_s->GetNuisanceParameters()->iterator();
 		    for (RooAbsArg *a = (RooAbsArg*) iterN.Next(); a != 0; a = (RooAbsArg*) iterN.Next()) {
+			    if (poiList_.contains(*a)) continue;
 			    specifiedNuis_.push_back(a->GetName());
 		    }
 	    }else{
@@ -385,7 +386,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 				    for (RooAbsArg *a = (RooAbsArg*) iterN.Next(); a != 0; a = (RooAbsArg*) iterN.Next()) {
 					    specifiedNuis_.push_back(a->GetName());
 				    }
-			    }else{
+			    }else if (!poiList_.find(token)){
 				    specifiedNuis_.push_back(token);
 			    }
 			    token = strtok(0,",") ; 


### PR DESCRIPTION
Filter POIs from `specifiedNuis_` in `MultiDimFit.cc` to avoid adding duplicate branches in https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/a31a2212266827f1cf0a300725a1cafc06e95470/src/MultiDimFit.cc#L418-L424
Note it's already filtered for `specifiedVals_` few lines lower:
https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/a31a2212266827f1cf0a300725a1cafc06e95470/src/MultiDimFit.cc#L394-L403
causing segmentation faults if the `specifiedNuis_` and `specifiedVals_`do not match.