### PR TITLE
Adding functionality to extract per-process yields from CMSHistSum

### DIFF
--- a/interface/CMSHistSum.h
+++ b/interface/CMSHistSum.h
@@ -50,6 +50,8 @@ public:
 
   Double_t evaluate() const;
 
+  std::map<std::string, Double_t> getProcessNorms() const;
+
   RooArgList * setupBinPars(double poissonThreshold);
 
   std::unique_ptr<RooArgSet> getSentryArgs() const;

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -666,6 +666,32 @@ Double_t CMSHistSum::evaluate() const {
   return cache().GetAt(x_);
 }
 
+std::map<std::string, Double_t> CMSHistSum::getProcessNorms() const {
+  std::map<std::string, Double_t> vals_;
+  initialize();
+  if (!sentry_.good()) {
+    updateMorphs();
+
+    for (unsigned i = 0; i < vcoeffpars_.size(); ++i) {
+      Double_t coeffval = vcoeffpars_[i]->getVal();    
+
+      staging_ = compcache_[i];
+      if (vtype_[i] == CMSHistFunc::VerticalSetting::LogQuadLinear) {
+        staging_.Exp();
+      }
+      staging_.CropUnderflows();
+
+      double const * valarray = &(staging_[0]);
+      Double_t valsum = 0;
+      for(unsigned j=0; j < valsum_.size(); ++j ){
+        valsum += coeffval * valarray[j];
+      }
+
+      vals_[vcoeffpars_[i]->GetName()] = valsum;
+    }
+  }
+  return vals_;
+}
 
 void CMSHistSum::printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
                     TString indent) const {


### PR DESCRIPTION
New function to output dict storing per-process yields from CMSHistSum object

Added catch in printWorkspaceNormalisations.py to deal with these objects correctly

Also can now output json file from printWorkspaceNormalisations.py script