### PR TITLE
Fix naming in CMSHistSum copy constructor

### DIFF
--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -185,8 +185,8 @@ CMSHistSum::CMSHistSum(
       vsmooth_par_(other.vsmooth_par_),
       bintypes_(other.bintypes_),
       cache_(other.cache_),
-      sentry_(name ? TString(name) + "_sentry" : TString(other.sentry_.GetName()), ""),
-      binsentry_(name ? TString(name) + "_binsentry" : TString(other.binsentry_.GetName()), ""),
+      sentry_(name ? TString(name) + "_sentry" : TString(other.GetName())+"_sentry", ""),
+      binsentry_(name ? TString(name) + "_binsentry" : TString(other.GetName())+"_binsentry", ""),
       initialized_(false),
       fast_mode_(0) {
       initialize();


### PR DESCRIPTION
Needed to avoid `Caught exception Each RooFit object needs a name. Objects representing the same entity (e.g. an observable 'x') are identified using their name.` error when cloning CMSHistSum