### PR TITLE
112x: fix rateParameters ranges

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -321,7 +321,7 @@ class ModelBuilder(ModelBuilderBase):
                     ## check range. The parameter needs to be created in range. Then we will remove it
                     param_range = "%g,%g" % (-2.0 * abs(v), 2.0 * abs(v))
                 # additional check for range requested
-                lo_r, hi_r = map( float, param_range.split(','))
+                lo_r, hi_r = map(float, param_range.split(','))
                 if v < lo_r or v > hi_r:
                     raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -254,7 +254,7 @@ class ModelBuilder(ModelBuilderBase):
                 setConst = param_range == "const"
                 if param_range in ["", "const"]:
                     v = float(param_val)
-                    param_range = "%g,%g" % (-2. * abs(v), 2. * abs(v))
+                    param_range = "%g,%g" % (-2.0 * abs(v), 2.0 * abs(v))
                     removeRange = True
 
                 self.doVar("%s[%s,%s]" % (rp, float(param_val), param_range))
@@ -319,9 +319,12 @@ class ModelBuilder(ModelBuilderBase):
                 removeRange = len(param_range) == 0
                 if param_range == "":
                     ## check range. The parameter needs to be created in range. Then we will remove it
-                    param_range = "%g,%g" % (-2. * abs(v), 2. * abs(v))
-                #additional check for range requested
-                lo_r, hi_r = (float(param_range.split(',')[0]), float(param_range.split(',')[1]), )
+                    param_range = "%g,%g" % (-2.0 * abs(v), 2.0 * abs(v))
+                # additional check for range requested
+                lo_r, hi_r = (
+                    float(param_range.split(",")[0]),
+                    float(param_range.split(",")[1]),
+                )
                 if v < lo_r or v > hi_r:
                     raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -253,7 +253,8 @@ class ModelBuilder(ModelBuilderBase):
                 removeRange = False
                 setConst = param_range == "const"
                 if param_range in ["", "const"]:
-                    param_range = "0,1"
+                    v = float(param_val)
+                    param_range="%g,%g"%(-2*abs(v),2*abs(v))
                     removeRange = True
 
                 self.doVar("%s[%s,%s]" % (rp, float(param_val), param_range))
@@ -314,9 +315,15 @@ class ModelBuilder(ModelBuilderBase):
                 if self.out.arg(argu):
                     continue
 
+                v = float(argv)
                 removeRange = len(param_range) == 0
                 if param_range == "":
-                    param_range = "0,1"
+                    ## check range. The parameter needs to be created in range. Then we will remove it
+                    param_range="%g,%g"%(-2*abs(v),2*abs(v))
+                #additional check for range requested
+                lo_r,hi_r=(float(param_range.split(',')[0]),float(param_range.split(',')[1]),)
+                if v<lo_r or v >hi_r: raise ValueError("Parameter: "+argu+"asked to be created out-of-range (it will lead to an error): "+argv+":"+param_range)
+
                 self.doVar("%s[%s,%s]" % (argu, argv, param_range))
                 if removeRange:
                     self.out.var(argu).removeRange()

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -321,7 +321,7 @@ class ModelBuilder(ModelBuilderBase):
                     ## check range. The parameter needs to be created in range. Then we will remove it
                     param_range = "%g,%g" % (-2.0 * abs(v), 2.0 * abs(v))
                 # additional check for range requested
-                lo_r, hi_r = map(float, param_range.split(','))
+                lo_r, hi_r = map(float, param_range.split(","))
                 if v < lo_r or v > hi_r:
                     raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -254,7 +254,7 @@ class ModelBuilder(ModelBuilderBase):
                 setConst = param_range == "const"
                 if param_range in ["", "const"]:
                     v = float(param_val)
-                    param_range = "%g,%g" % (-2*abs(v), 2*abs(v))
+                    param_range = "%g,%g" % (-2. * abs(v), 2. * abs(v))
                     removeRange = True
 
                 self.doVar("%s[%s,%s]" % (rp, float(param_val), param_range))
@@ -319,10 +319,10 @@ class ModelBuilder(ModelBuilderBase):
                 removeRange = len(param_range) == 0
                 if param_range == "":
                     ## check range. The parameter needs to be created in range. Then we will remove it
-                    param_range = "%g,%g" % (-2*abs(v), 2*abs(v))
+                    param_range = "%g,%g" % (-2. * abs(v), 2. * abs(v))
                 #additional check for range requested
                 lo_r, hi_r = (float(param_range.split(',')[0]), float(param_range.split(',')[1]), )
-                if v < lo_r or v > hi_r: 
+                if v < lo_r or v > hi_r:
                     raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 
                 self.doVar("%s[%s,%s]" % (argu, argv, param_range))

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -321,10 +321,7 @@ class ModelBuilder(ModelBuilderBase):
                     ## check range. The parameter needs to be created in range. Then we will remove it
                     param_range = "%g,%g" % (-2.0 * abs(v), 2.0 * abs(v))
                 # additional check for range requested
-                lo_r, hi_r = (
-                    float(param_range.split(",")[0]),
-                    float(param_range.split(",")[1]),
-                )
+                lo_r, hi_r = map( float, param_range.split(','))
                 if v < lo_r or v > hi_r:
                     raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -254,7 +254,7 @@ class ModelBuilder(ModelBuilderBase):
                 setConst = param_range == "const"
                 if param_range in ["", "const"]:
                     v = float(param_val)
-                    param_range="%g,%g"%(-2*abs(v),2*abs(v))
+                    param_range = "%g,%g" % (-2*abs(v), 2*abs(v))
                     removeRange = True
 
                 self.doVar("%s[%s,%s]" % (rp, float(param_val), param_range))
@@ -319,10 +319,11 @@ class ModelBuilder(ModelBuilderBase):
                 removeRange = len(param_range) == 0
                 if param_range == "":
                     ## check range. The parameter needs to be created in range. Then we will remove it
-                    param_range="%g,%g"%(-2*abs(v),2*abs(v))
+                    param_range = "%g,%g" % (-2*abs(v), 2*abs(v))
                 #additional check for range requested
-                lo_r,hi_r=(float(param_range.split(',')[0]),float(param_range.split(',')[1]),)
-                if v<lo_r or v >hi_r: raise ValueError("Parameter: "+argu+"asked to be created out-of-range (it will lead to an error): "+argv+":"+param_range)
+                lo_r, hi_r = (float(param_range.split(',')[0]), float(param_range.split(',')[1]), )
+                if v < lo_r or v > hi_r: 
+                    raise ValueError("Parameter: " + argu + " asked to be created out-of-range (it will lead to an error): " + argv + ":" + param_range)
 
                 self.doVar("%s[%s,%s]" % (argu, argv, param_range))
                 if removeRange:


### PR DESCRIPTION
This is a bug appearing from the 112x series. 
Likely something has been enforced in the roofit factory expression creation.

factory expressions now needs to be in range to be created correctly. I assign as default +/- twice the value for such parameters. this should fix it for both rateParams and extArgs.
Notice that this range is going to be removed after.

For the rateParameters, I put an additional check for those ranges that are input in the datacard, raising eventually an exception.

This has been tested on comb_2021_tth_multilepton.root

It should affect all the 112x series; namely 112x, 112x-comb2021, 112x-comb2022, and root626