### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/src/BayesianToyMC.cc
+++ b/src/BayesianToyMC.cc
@@ -194,7 +194,7 @@ std::pair<double,double> BayesianToyMC::priorPredictiveDistribution(RooStats::Mo
         if (verbose > 2) { std::cout << "\n\n==== POINT "<< t << ","<<i<<" ====" << std::endl; params->Print("V"); }
         double nllVal = nll->getVal();
         if (offset) { 
-            if (isnan(*offset)) *offset = nllVal; 
+            if (std::isnan(*offset)) *offset = nllVal; 
             nllVal -= *offset; 
         }
         if (verbose > 1) std::cout << "nll[" << t << ","<<i<<"] = " << nllVal << ", p = " << std::exp(-nllVal) << std::endl;

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -598,7 +598,7 @@ bool CascadeMinimizer::multipleMinimize(const RooArgSet &reallyCleanParameters, 
 	     for (std::vector<int>::iterator it = cit.begin();
 	         it!=cit.end(); it++){
 
-		 isValidCombo *= (contributingIndeces)[pdfIndex][*it];
+		 isValidCombo &= (contributingIndeces)[pdfIndex][*it];
 		 if (!isValidCombo ) /*&& runShortCombinations)*/ continue;
 
 	     	 fPdf = (RooCategory*) pdfCategoryIndeces.at(pdfIndex);

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -1631,7 +1631,6 @@ void HybridNew::updateGridDataFC(RooWorkspace *w, RooStats::ModelConfig *mc_s, R
 }
 
 std::pair<double,double> HybridNew::updateGridPoint(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, std::map<double, RooStats::HypoTestResult *>::iterator point) {
-    typedef std::pair<double,double> CLs_t;
     bool isProfile = (testStat_ == "LHC" || testStat_ == "LHCFC"  || testStat_ == "Profile");
     if (point->first == 0 && CLs_) return std::pair<double,double>(1,0);
     RooArgSet  poi(*mc_s->GetParametersOfInterest());

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -1230,7 +1230,7 @@ void MultiDimFit::splitGridPoints(const std::string& s, std::vector<unsigned int
     boost::split(strPoints, s, boost::is_any_of(","));
 
     // convert to int and add
-    for (const auto strPoint : strPoints) {
+    for (const auto& strPoint : strPoints) {
         points.push_back(std::stoul(strPoint));
     }
 }

--- a/src/th1fmorph.cc
+++ b/src/th1fmorph.cc
@@ -477,8 +477,11 @@ TH1_t *th1fmorph_(const char *chname,
   
   //......Clean up the temporary arrays we allocated.
 
-  delete sigdis1; delete sigdis2; 
-  delete sigdisn; delete xdisn; delete sigdisf;
+  delete[] sigdis1;
+  delete[] sigdis2;
+  delete[] sigdisn;
+  delete[] xdisn;
+  delete[] sigdisf;
 
   //......All done, return the result.
 


### PR DESCRIPTION
Fix various warnings related to unused typedefs, wrong deallocators,
using `*` for booleans, etc.

Also, the change `isnan` to `std::isnan` is required to make the code compile with ROOT master.