### PR TITLE
Speed up datacard parsing

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -282,6 +282,14 @@ def addDatacardParserOptions(parser):
     )
 
 
+def strip(l):
+    """Strip comments and whitespace from end of line"""
+    idx = l.find("#")
+    if idx > 0:
+        return l[:idx].rstrip()
+    return l.rstrip()
+
+
 def isVetoed(name, vetoList):
     for pattern in vetoList:
         if not pattern:
@@ -453,10 +461,10 @@ def parseCard(file, options):
                 break  # rate is the last line before nuisances
         # parse nuisances
         for lineNumber2, l in enumerate(file):
-            if l.startswith("--"):
+            if l.startswith("--") or l.startswith("#"):
                 continue
-            l = re.sub("\\s*#.*", "", l)
-            l = re.sub("(?<=\\s)-+(\\s|$)", " 0\\1", l)
+
+            l = strip(l)
             f = l.split()
             if len(f) <= 1:
                 continue
@@ -623,6 +631,8 @@ def parseCard(file, options):
                         if v <= 0.00:
                             raise ValueError('Found "%s" in the nuisances affecting %s for %s. This would lead to NANs later on, so please fix it.' % (r, p, b))
                 else:
+                    if r == "-" * len(r):
+                        r = 0.0
                     errline[b][p] = float(r)
                     # values of 0.0 are treated as 1.0; scrap negative values.
                     if pdf not in ["trG", "dFD", "dFD2"] and errline[b][p] < 0:


### PR DESCRIPTION
Two regular expressions were applied to all lines in card, both of which
were *10x* slower than doing the equivalent transformation by hand in python.

 - `\\s*#.*` removes comments and whitespace at the end of the line
 - `(?<=\\s)-+(\\s|$)` converts any ` -` entries to ` 0`

The latter was applied universally, whereas now it is only checked for
parameter effect size arguments. This means that the interpretation of
arguments for certain nuisances is now more restricted, e.g.:
```
unc1 unif - 1  ...
unc2 gmN -  ...
```
used to be equivalent to
```
unc1 unif 0 1  ...
unc2 gmN 0  ...
```
but now would raise an error on converting `-` to int or float. (of course for `gmN` you wouldn't really want 0 anyway)
Using `---` to indicate no effect on the process column still works the same as before.