### PR TITLE
Add CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+# CMakeLists.txt file for cms-analysis/HiggsAnalysis-CombinedLimit
+# Authors: Jonas Rembser, CERN 2022
+
+cmake_minimum_required(VERSION 3.12)
+project(HiggsAnalysis-CombinedLimit CXX)
+
+##########################################
+# Define configuration and build targets #
+##########################################
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -m64 -O2 -rdynamic -g -Wall")
+
+find_package(ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory)
+include(${ROOT_USE_FILE}) # inherit ROOT's compile options, including C++ standard
+
+find_package(Boost 1.45.0 COMPONENTS program_options filesystem system)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
+
+find_package(Eigen3 3.0 REQUIRED)
+
+# To get the Python library install directory into Python_SITELIB
+find_package(Python COMPONENTS Interpreter Development)
+
+set(LIBNAME HiggsAnalysisCombinedLimit)
+
+include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(interface)
+
+file(GLOB SOURCE_FILES src/*.c*)
+file(GLOB HEADER_FILES interface/*.h*)
+
+ROOT_GENERATE_DICTIONARY(G__${LIBNAME} ../src/classes.h LINKDEF src/classes_def.xml
+                         MODULE ${LIBNAME}
+                         OPTIONS --deep)
+
+add_library(${LIBNAME} SHARED ${SOURCE_FILES} G__${LIBNAME}.cxx)
+set_target_properties(${LIBNAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
+
+target_link_libraries(${LIBNAME} PUBLIC ${ROOT_LIBRARIES})
+target_link_libraries(${LIBNAME} PUBLIC ${Boost_LIBRARIES})
+
+add_executable(combine bin/combine.cpp)
+target_link_libraries(combine PUBLIC ${LIBNAME})
+
+# Create empty __init__.py file in the build directory that will be installed
+# in the Python library directories.
+set(empty_init_py "${CMAKE_CURRENT_BINARY_DIR}/__init__.py")
+
+
+#####################
+# Installation part #
+#####################
+
+
+# Install the dictionaries.
+install(FILES ${PROJECT_BINARY_DIR}/lib${LIBNAME}_rdict.pcm
+              ${PROJECT_BINARY_DIR}/lib${LIBNAME}.rootmap
+        DESTINATION lib)
+
+# Install the libraries and header files.
+install(TARGETS ${LIBNAME}
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/HiggsAnalysis/CombinedLimit/interface
+)
+
+# Install the "combine" executable in the bin directory.
+install(TARGETS combine DESTINATION bin)
+
+# Install the scripts like "text2workspace" to the bin directory.
+install(DIRECTORY scripts/ DESTINATION bin)
+
+# Check if the Python library installation directory is outside the install
+# prefix. If it is, we error out because CMake should not install files outside
+# the prefix. In the future, one can imagine to let the user choose where the
+# Python libraries get installed in the prefix with a CMake configuration flag.
+cmake_path(IS_PREFIX CMAKE_INSTALL_PREFIX "${Python_SITELIB}" sitelib_in_prefix)
+if(NOT ${sitelib_in_prefix})
+    message( FATAL_ERROR "Your Python library installation directory ${Python_SITELIB} "
+                         "is outside the install prefix ${CMAKE_INSTALL_PREFIX}! "
+                         "This is not supported for now. Consider changing the install prefix "
+                         "with the -DCMAKE_INSTALL_PREFIX:PATH=<path> cmake configuration option.")
+endif()
+
+# The the Python library installation directory relative to the install prefix.
+file(RELATIVE_PATH Python_SITELIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX} ${Python_SITELIB})
+
+# The python package will be installed in such a way that the original
+# CMSSW-style directory structure is kept, for maximal compatibility.
+install(DIRECTORY python/ DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit)
+
+# Create empty __init__.py files in the Python package subdirectories such that
+# the Python imports work.
+file(TOUCH ${empty_init_py})
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/__init__.py)
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit/__init__.py)


### PR DESCRIPTION
## Description:

This PR adds the relevant files to build combine with CMake. I had this around privately for a long time, and I think it would be good to expose this also to other users and developers that want to build combine with CMake.

It is a draft PR for now because there is still something I want to improve: right now, the python libraries are always installed in the system Python package directory, but it would be good to have a configuration option maybe called `PYTHON_LOCAL` to install to the local library directory for the user (like `--local` for pip). I will implement this when I have time, but I still wanted to open the PR already to get feedback from interested people that want to give it a shot.

You can try it out with:
```bash
git clone git@github.com:guitargeek/HiggsAnalysis-CombinedLimit.git -b 112x_cmake HiggsAnalysis/CombinedLimit
cd HiggsAnalysis/CombinedLimit
mkdir build
cd build
cmake3 -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
cmake3 --build . -j8
make install
```

Unlike the standalone `Makefile` that is already in the repo, this should work not only on lxplus because of the smart CMake macros that try to find the dependencies at the right place.

## Tested on:

I'll try to make it work for the "vanilla" versions of the operating systems, so no `cmsenv` allowed for example. A yellow sign means it doesn't work immediately out of the box, but after only small adaptations to the environment like sourcing a newer ROOT version.

* **CentOS 7 (`lxplus7`)** :x:
  * compiler is too old
* **CentOS 8 (`lxplus8`)** :heavy_plus_sign:
  * requires [ROOT 6.26.06 sourced from cvmfs](https://root.cern/releases/release-62606/)
* **Arch Linux** :heavy_check_mark:
  * package can be generated with [this PKGBUILD file](https://github.com/guitargeek/PKGBUILDs/blob/master/cms-higgs-combine/PKGBUILD)

## Still todo:

* add `PYTHON_LOCAL` option described before
* automatically detect correct C++ standard matching the ROOT installation
* ~~remove restriction that source code directory must be named `HiggsAnalysis/CombinedLimit`~~ **DONE**
* try to get rid of using [cmake_path](https://cmake.org/cmake/help/latest/command/cmake_path.html) because it's only available in cmake 3.20 which is quite new