### PR TITLE
Allow ChannelCompatibilityCheck to skip channels with no signal templates

### DIFF
--- a/src/ChannelCompatibilityCheck.cc
+++ b/src/ChannelCompatibilityCheck.cc
@@ -113,7 +113,9 @@ bool ChannelCompatibilityCheck::runSpecific(RooWorkspace *w, RooStats::ModelConf
   }
   for (std::map<std::string,std::string>::const_iterator it = rs.begin(), ed = rs.end(); it != ed; ++it) {
       RooRealVar *ri = (RooRealVar*) result_freeform->floatParsFinal().find(it->second.c_str());
-      if (runMinos_ && do95_) {
+      if (ri == NULL){
+      printf("Parameter %s not found in channel %s. Does this region contain signal templates?\n", r->GetName(), it->first.c_str());
+      } else if (runMinos_ && do95_) {
 	  printf("Alternate fit: %s = %7.4f  %+6.4f/%+6.4f (68%% CL) in channel %s\n", r->GetName(), ri->getVal(), ri->getAsymErrorLo(), ri->getAsymErrorHi(), it->first.c_str());
 	  printf("               %s = %7.4f  %+6.4f/%+6.4f (95%% CL) in channel %s\n", r->GetName(), ri->getVal(), ri->getMin("err95")-ri->getVal(), ri->getMax("err95")-ri->getVal(), it->first.c_str());
       } else if (runMinos_) {

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -317,6 +317,7 @@ RooFitResult *FitterAlgoBase::doFit(RooAbsPdf &pdf, RooAbsData &data, const RooA
     rfloat = ret->constPars().find(r.GetName());
     if (!rfloat) {
       fprintf(sentry.trueStdOut(), "Skipping %s. Parameter not found in the RooFitResult.\n",r.GetName());
+      continue ;
     }
   }
 	//rfloat->Print("V");


### PR DESCRIPTION
Fixes #801 by skipping channels where the POI was not fitted due to missing signal templates in CRs. Also added a continue statement in FitterAlgoBase.cc to skip parameters which are not present also if the analytic minimiser is not used, to avoid a seg fault at [        RooRealVar &rf = dynamic_cast<RooRealVar &>(*rfloat);](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/102x/src/FitterAlgoBase.cc#L323) (I only encountered this issue with the latest versions of combine due to the switch of the default Minimizer from non-analytic to analytic). I haven't checked if this latter change affects other scripts, as I wasn't sure which tests to do, but can do some if requested.