### PR TITLE
Uniform PDF for flatParam

### DIFF
--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -281,7 +281,7 @@ def addDatacardParserOptions(parser):
         help="Simplify MH dependent objects: 'fixed', 'pol<N>' with N=0..4",
     )
     parser.add_option(
-        "--X-assignflatParamPrior",
+        "--X-assign-flatParam-prior",
         dest="flatParamPrior",
         default=False,
         action="store_true",

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -280,6 +280,14 @@ def addDatacardParserOptions(parser):
         default=None,
         help="Simplify MH dependent objects: 'fixed', 'pol<N>' with N=0..4",
     )
+    parser.add_option(
+        "--X-assignflatParamPrior",
+        dest="flatParamPrior",
+        default=False,
+        action="store_true",
+        help="Assign RooUniform pdf for flatParam NPs",
+    )
+
 
 
 def strip(l):
@@ -522,6 +530,9 @@ def parseCard(file, options):
                 continue
             elif pdf == "flatParam":
                 ret.flatParamNuisances[lsyst] = True
+                if options.flatParamPrior:
+                  ret.systs.append([lsyst, nofloat, pdf, args, []])
+                  ret.add_syst_id(lsyst)
                 # for flat parametric uncertainties, code already does the right thing as long as they are non-constant RooRealVars linked to the model
                 continue
             elif pdf == "extArg":
@@ -669,7 +680,7 @@ def parseCard(file, options):
     syst2 = []
     for lsyst, nofloat, pdf, args, errline in ret.systs:
         nonNullEntries = 0
-        if pdf == "param" or pdf == "constr" or pdf == "discrete" or pdf == "rateParam":  # this doesn't have an errline
+        if pdf == "param" or pdf == "constr" or pdf == "discrete" or pdf == "rateParam" or pdf=="flatParam":  # this doesn't have an errline
             syst2.append((lsyst, nofloat, pdf, args, errline))
             continue
         for b, p, s in ret.keyline:

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -289,7 +289,6 @@ def addDatacardParserOptions(parser):
     )
 
 
-
 def strip(l):
     """Strip comments and whitespace from end of line"""
     idx = l.find("#")
@@ -530,10 +529,10 @@ def parseCard(file, options):
                 continue
             elif pdf == "flatParam":
                 ret.flatParamNuisances[lsyst] = True
-                if options.flatParamPrior:
-                  ret.systs.append([lsyst, nofloat, pdf, args, []])
-                  ret.add_syst_id(lsyst)
                 # for flat parametric uncertainties, code already does the right thing as long as they are non-constant RooRealVars linked to the model
+                if options.flatParamPrior:
+                    ret.systs.append([lsyst, nofloat, pdf, args, []])
+                    ret.add_syst_id(lsyst)
                 continue
             elif pdf == "extArg":
                 # look for additional parameters in workspaces
@@ -680,7 +679,7 @@ def parseCard(file, options):
     syst2 = []
     for lsyst, nofloat, pdf, args, errline in ret.systs:
         nonNullEntries = 0
-        if pdf == "param" or pdf == "constr" or pdf == "discrete" or pdf == "rateParam" or pdf=="flatParam":  # this doesn't have an errline
+        if pdf == "param" or pdf == "constr" or pdf == "discrete" or pdf == "rateParam" or pdf == "flatParam":  # this doesn't have an errline
             syst2.append((lsyst, nofloat, pdf, args, errline))
             continue
         for b, p, s in ret.keyline:

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -137,6 +137,7 @@ class ModelBuilderBase:
             return self.factory_("%s::%s(%s)" % (type, name, X))
         else:
             self.out.write("%s = %s(%s);\n" % (name, type, X))
+
     def addDiscrete(self, var):
         if self.options.removeMultiPdf:
             return
@@ -524,13 +525,13 @@ class ModelBuilder(ModelBuilderBase):
             elif pdf == "flatParam" and self.options.flatParamPrior:
                 self.doExp(
                     "%s_expr" % n,
-                    "%s-%s_In" % (n,n),
-                    "%s[-1,1],%s_In[0,-1,1]" % (n,n))
+                    "%s-%s_In" % (n, n),
+                    "%s[-1,1],%s_In[0,-1,1]" % (n, n))
                 self.doObj(
                     "%s_Pdf" % n,
                     "Uniform",
                     "%s_expr" % n)
-                self.out.var("%s_In" % n).setConstant(True)       
+                self.out.var("%s_In" % n).setConstant(True)
                 globalobs.append("%s_In" % n)
             elif pdf == "dFD" or pdf == "dFD2":
                 dFD_min = -(1 + 8 / args[0])
@@ -888,7 +889,7 @@ class ModelBuilder(ModelBuilderBase):
                         continue
                     if pdf == "constr":
                         continue
-                    if pdf == "rateParam":
+                    if pdf == "rateParam" or pdf == "flatParam":
                         continue
                     if p not in errline[b]:
                         continue
@@ -909,7 +910,7 @@ class ModelBuilder(ModelBuilderBase):
                             logNorms.append((errline[b][p], n))
                     elif pdf == "gmM":
                         factors.append(n)
-                    elif pdf == "trG" or pdf == "unif" or pdf == "flatParam" or pdf == "dFD" or pdf == "dFD2":
+                    elif pdf == "trG" or pdf == "unif" or pdf == "dFD" or pdf == "dFD2":
                         myname = "n_exp_shift_bin%s_proc_%s_%s" % (b, p, n)
                         self.doObj(myname, ROOFIT_EXPR, "'1+%f*@0', %s" % (errline[b][p], n))
                         factors.append(myname)

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -522,11 +522,14 @@ class ModelBuilder(ModelBuilderBase):
             elif pdf == "unif":
                 self.doObj("%s_Pdf" % n, "Uniform", "%s[%f,%f]" % (n, args[0], args[1]))
             elif pdf == "flatParam" and self.options.flatParamPrior:
+                self.doExp(
+                    "%s_expr" % n,
+                    "%s-%s_In" % (n,n),
+                    "%s[-1,1],%s_In[0,-1,1]" % (n,n))
                 self.doObj(
-                        "%s_Pdf" % n,
-                        "Uniform",
-                        "%s[-1,1]" % (n))
-                self.doVar("%s_In[0,-1,1]" % (n))
+                    "%s_Pdf" % n,
+                    "Uniform",
+                    "%s_expr" % n)
                 self.out.var("%s_In" % n).setConstant(True)       
                 globalobs.append("%s_In" % n)
             elif pdf == "dFD" or pdf == "dFD2":

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -523,14 +523,8 @@ class ModelBuilder(ModelBuilderBase):
             elif pdf == "unif":
                 self.doObj("%s_Pdf" % n, "Uniform", "%s[%f,%f]" % (n, args[0], args[1]))
             elif pdf == "flatParam" and self.options.flatParamPrior:
-                self.doExp(
-                    "%s_expr" % n,
-                    "%s-%s_In" % (n, n),
-                    "%s[-1,1],%s_In[0,-1,1]" % (n, n))
-                self.doObj(
-                    "%s_Pdf" % n,
-                    "Uniform",
-                    "%s_expr" % n)
+                self.doExp("%s_expr" % n, "%s-%s_In" % (n, n), "%s[-1,1],%s_In[0,-1,1]" % (n, n))
+                self.doObj("%s_Pdf" % n, "Uniform", "%s_expr" % n)
                 self.out.var("%s_In" % n).setConstant(True)
                 globalobs.append("%s_In" % n)
             elif pdf == "dFD" or pdf == "dFD2":

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -137,7 +137,6 @@ class ModelBuilderBase:
             return self.factory_("%s::%s(%s)" % (type, name, X))
         else:
             self.out.write("%s = %s(%s);\n" % (name, type, X))
-
     def addDiscrete(self, var):
         if self.options.removeMultiPdf:
             return
@@ -522,6 +521,14 @@ class ModelBuilder(ModelBuilderBase):
                 self.doObj("%s_Pdf" % n, "Uniform", "%s[-1,1]" % n)
             elif pdf == "unif":
                 self.doObj("%s_Pdf" % n, "Uniform", "%s[%f,%f]" % (n, args[0], args[1]))
+            elif pdf == "flatParam" and self.options.flatParamPrior:
+                self.doObj(
+                        "%s_Pdf" % n,
+                        "Uniform",
+                        "%s[-1,1]" % (n))
+                self.doVar("%s_In[0,-1,1]" % (n))
+                self.out.var("%s_In" % n).setConstant(True)       
+                globalobs.append("%s_In" % n)
             elif pdf == "dFD" or pdf == "dFD2":
                 dFD_min = -(1 + 8 / args[0])
                 dFD_max = +(1 + 8 / args[0])
@@ -878,7 +885,7 @@ class ModelBuilder(ModelBuilderBase):
                         continue
                     if pdf == "constr":
                         continue
-                    if pdf == "rateParam":
+                    if pdf == "rateParam" or pdf=="flatParam":
                         continue
                     if p not in errline[b]:
                         continue

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -888,7 +888,7 @@ class ModelBuilder(ModelBuilderBase):
                         continue
                     if pdf == "constr":
                         continue
-                    if pdf == "rateParam" or pdf=="flatParam":
+                    if pdf == "rateParam":
                         continue
                     if p not in errline[b]:
                         continue
@@ -909,7 +909,7 @@ class ModelBuilder(ModelBuilderBase):
                             logNorms.append((errline[b][p], n))
                     elif pdf == "gmM":
                         factors.append(n)
-                    elif pdf == "trG" or pdf == "unif" or pdf == "dFD" or pdf == "dFD2":
+                    elif pdf == "trG" or pdf == "unif" or pdf == "flatParam" or pdf == "dFD" or pdf == "dFD2":
                         myname = "n_exp_shift_bin%s_proc_%s_%s" % (b, p, n)
                         self.doObj(myname, ROOFIT_EXPR, "'1+%f*@0', %s" % (errline[b][p], n))
                         factors.append(myname)


### PR DESCRIPTION
An attempt to solve the issue https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/issues/819, i.e. introduce RooUniform pdf for `flatParam` NP if the `--X-assign-flatParam-prior` option is provided to `text2workspace.py`. 