### PR TITLE
Add flags for SinglePdfGenInfo to avoid using gen spec when  changing nuisances per toy.

### DIFF
--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -10,7 +10,7 @@ namespace toymcoptutils {
     class SinglePdfGenInfo {
         public:
             enum Mode { Binned, BinnedNoWorkaround, Poisson, Unbinned, Counting };
-            SinglePdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData = NULL, int forceEvents = 0) ;
+            SinglePdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData = NULL, int forceEvents = 0, bool canUseSpec = true) ;
             ~SinglePdfGenInfo() ;
             RooAbsData *generate(const RooDataSet* protoData = NULL, int forceEvents = 0) ;
             RooDataSet *generateAsimov(RooRealVar *&weightVar, double weightScale = 1.0, int verbose = 0) ;
@@ -22,6 +22,7 @@ namespace toymcoptutils {
             Mode mode_;
             RooAbsPdf *pdf_; 
             RooArgSet observables_;
+            bool       canUseSpec_;
             RooAbsPdf::GenSpec *spec_;
             TH1        *histoSpec_;
             bool        keepHistoSpec_;
@@ -33,7 +34,7 @@ namespace toymcoptutils {
     };
     class SimPdfGenInfo {
         public:
-            SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData = NULL, int forceEvents = 0) ;
+            SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData = NULL, int forceEvents = 0, bool canUseSpec = true) ;
             ~SimPdfGenInfo() ;
             RooAbsData *generate(RooRealVar *&weightVar, const RooDataSet* protoData = NULL, int forceEvents = 0) ;
             RooAbsData *generateAsimov(RooRealVar *&weightVar, int verbose = 0 ) ;

--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -78,7 +78,7 @@ class ToyMCSamplerOpt : public RooStats::ToyMCSampler{
         // We can't use the NuisanceParameterSampler because, even if public, there's no interface file for it
         mutable RooDataSet *nuisValues_; 
         mutable int nuisIndex_;
-        mutable bool genNuis_;
+        bool genNuis_;
 
         mutable RooRealVar *weightVar_;
         mutable std::map<RooAbsPdf *, toymcoptutils::SimPdfGenInfo *> genCache_;

--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -78,6 +78,7 @@ class ToyMCSamplerOpt : public RooStats::ToyMCSampler{
         // We can't use the NuisanceParameterSampler because, even if public, there's no interface file for it
         mutable RooDataSet *nuisValues_; 
         mutable int nuisIndex_;
+        mutable bool genNuis_;
 
         mutable RooRealVar *weightVar_;
         mutable std::map<RooAbsPdf *, toymcoptutils::SimPdfGenInfo *> genCache_;

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -956,7 +956,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
             utils::setAllConstant(*mc->GetParametersOfInterest(), false);
             w->saveSnapshot("clean", utils::returnAllVars(w));
         } else {
-            toymcoptutils::SimPdfGenInfo newToyMC(*genPdf, *observables, !unbinned_); 
+            toymcoptutils::SimPdfGenInfo newToyMC(*genPdf, *observables, !unbinned_);
 
 	    // print the values of the parameters used to generate the toy
 	    if (verbose > 2) {
@@ -999,7 +999,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   std::unique_ptr<RooAbsPdf> nuisancePdf;
   if (nToys > 0) {
     if (genPdf == 0) throw std::invalid_argument("You can't generate background-only toys if you have no background-only pdf in the workspace and you have set --noMCbonly");
-    toymcoptutils::SimPdfGenInfo newToyMC(*genPdf, *observables, !unbinned_); 
+    toymcoptutils::SimPdfGenInfo newToyMC(*genPdf, *observables, !unbinned_, NULL, 0, toysFrequentist_); 
     double expLimit = 0;
     unsigned int nLimits = 0;
     w->loadSnapshot("clean");

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -63,9 +63,10 @@ ToyMCSamplerOpt::~ToyMCSamplerOpt()
 }
 
 
-toymcoptutils::SinglePdfGenInfo::SinglePdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents) :
+toymcoptutils::SinglePdfGenInfo::SinglePdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents, bool canUseSpec) :
    mode_(pdf.canBeExtended() ? (preferBinned ? Binned : Unbinned) : Counting),
    pdf_(&pdf),
+   canUseSpec_(canUseSpec),
    spec_(0),histoSpec_(0),keepHistoSpec_(0),weightVar_(0)
 {
    if (pdf.canBeExtended()) {
@@ -104,7 +105,7 @@ toymcoptutils::SinglePdfGenInfo::generate(const RooDataSet* protoData, int force
     RooAbsData *ret = 0;
     switch (mode_) {
         case Unbinned:
-            if (spec_ == 0) spec_ = protoData ? pdf_->prepareMultiGen(observables_, RooFit::Extended(), RooFit::ProtoData(*protoData, true, true))
+            if (spec_ == 0 && canUseSpec_) spec_ = protoData ? pdf_->prepareMultiGen(observables_, RooFit::Extended(), RooFit::ProtoData(*protoData, true, true))
                                               : pdf_->prepareMultiGen(observables_, RooFit::Extended());
             if (spec_) ret = pdf_->generate(*spec_);
             else ret = pdf_->generate(observables_, RooFit::Extended());
@@ -324,7 +325,7 @@ toymcoptutils::SinglePdfGenInfo::setToExpected(RooPoisson &pois, RooArgSet &obs)
     myobs->setVal(myexp->getVal());
 }
 
-toymcoptutils::SimPdfGenInfo::SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents) :
+toymcoptutils::SimPdfGenInfo::SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents, bool canUseSpec) :
     pdf_(&pdf),
     cat_(0),
     observables_(observables),
@@ -342,13 +343,13 @@ toymcoptutils::SimPdfGenInfo::SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& obs
             RooAbsPdf *pdfi = simPdf->getPdf(cat_->getLabel());
             if (pdfi == 0) throw std::logic_error(std::string("Unmapped category state: ") + cat_->getLabel());
             RooAbsPdf *newpdf = utils::factorizePdf(observables, *pdfi, dummy);
-            pdfs_[ic] = new SinglePdfGenInfo(*newpdf, observables, preferBinned);
+            pdfs_[ic] = new SinglePdfGenInfo(*newpdf, observables, preferBinned, NULL, 0, canUseSpec);
             if (newpdf != 0 && newpdf != pdfi) {
                 ownedCrap_.addOwned(*newpdf); 
             }
         }
     } else {
-        pdfs_.push_back(new SinglePdfGenInfo(pdf, observables, preferBinned, protoData, forceEvents));
+        pdfs_.push_back(new SinglePdfGenInfo(pdf, observables, preferBinned, protoData, forceEvents, canUseSpec));
     }
 }
 

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -22,7 +22,7 @@ ToyMCSamplerOpt::ToyMCSamplerOpt(RooStats::TestStatistic& ts, Int_t ntoys, RooAb
     ToyMCSampler(ts, ntoys),
     globalObsPdf_(globalObsPdf),
     globalObsValues_(0), globalObsIndex_(-1),
-    nuisValues_(0), nuisIndex_(-1),
+    nuisValues_(0), nuisIndex_(-1), genNuis_(generateNuisances),
     weightVar_(0)
 {
     if (!generateNuisances) fPriorNuisance = 0; // set things straight from the beginning
@@ -706,7 +706,7 @@ ToyMCSamplerOpt::Generate(RooAbsPdf& pdf, RooArgSet& observables, const RooDataS
    //utils::printPdf(&pdf);
    toymcoptutils::SimPdfGenInfo *& info = genCache_[&pdf];
    if (info == 0) { 
-       info = new toymcoptutils::SimPdfGenInfo(pdf, observables, fGenerateBinned, protoData, forceEvents);
+       info = new toymcoptutils::SimPdfGenInfo(pdf, observables, fGenerateBinned, protoData, forceEvents, !genNuis_);
        info->setCopyData(false);
        if (!fPriorNuisance && importanceSnapshots_.empty()) info->setCacheTemplates(true);
    }

--- a/test/plotting/qmuPlot.cxx
+++ b/test/plotting/qmuPlot.cxx
@@ -278,7 +278,7 @@ TCanvas *qmuPlot(float mass, std::string poinam, double poival, int mode=0, int 
     double pSerr  = clS * TMath::Hypot(pBerr/pB, pMUerr/pMU);
     printf("Pmu   = %.4f +/- %.4f\n", pMU , pMUerr);
     printf("1-Pb   = %.4f +/- %.4f\n", pB , pBerr);
-    printf("CLs    = %.4f +/- %.4f\n", pMu , pMuerr);
+    printf("CLs    = %.4f +/- %.4f\n", clS , pSerr);
 
     // Worst way to calculate !
     TH1F *qS1 = tail(qS, qObs,mode); 
@@ -316,7 +316,7 @@ TCanvas *qmuPlot(float mass, std::string poinam, double poival, int mode=0, int 
     leg2->AddEntry(qS1, Form("p_{#mu} = %.4f", pMU), "F"); 
     //if (mode==0) 
     leg2->AddEntry(qB1, Form("1-p_{b}  = %.4f", pB), "F");
-    leg2->AddEntry("",  Form("CL_{s}   = %.4f", pS), "");
+    leg2->AddEntry("",  Form("CL_{s}   = %.4f", clS), "");
 
     qB->Draw();
 


### PR DESCRIPTION
We don't want to use a GenSpec object for generating the toys if we want to change the nuisance (i.e. when not doing frequentist toys) values for each toy, since the genSpec object is fixed, and updating the values of the nuisance parameters in the pdf won't change the values the toys are generated with.

For frequentist toys, only the constraint term (i.e. global observable) is changed, which doesn't affect the observed data so using the genSpec is fine.

I've added a flag in the `SimPdfGenInfo` constructor which enables or disables the use of the spec object when generating events.
By default this is allowed, so the default behaviour when this flag isnt passed is unchanged.
I think this only needed to be changed when generating the toys from the `Combine` object itself, as other places where the `SimPdfGenInfo` object is used seem only to need Asimov Toys, and then there is no problem.

@nucleosynthesis, it would be good to test this with your setup where you spotted the bug, to make sure its actually fixed. I've only run a couple simple sanity checks, not tested it thoroughly. 