### PR TITLE
Add Contributing Document

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions to combine of all sizes, from minor documentation updates, to big code improvements, are welcome and encouraged.
+Contributions to combine of all sizes, from minor documentation updates to big code improvements, are welcome and encouraged.
 
 To ensure good development of the tool, we try to coordinate contributions.
 However, we are happy to help overcome any steps that may pose issues for contributors.

--- a/contributing.md
+++ b/contributing.md
@@ -82,7 +82,13 @@ The documentation files are all under the `docs/` folder.
 Which pages get included in the site, and other configuration details are set in the `mkdocs.yml` file.
 
 In order to check the documentation rendering (features such as latex math rendering, etc) locally, you can generate the site on your local computer and check it in your browser.
-To do so, after [installing mkdocs](https://www.mkdocs.org/getting-started/) and [pymdown extensions](https://facelessuser.github.io/pymdown-extensions/installation/) you can do:
+To do so, after [installing mkdocs](https://www.mkdocs.org/getting-started/) and [pymdown extensions](https://facelessuser.github.io/pymdown-extensions/installation/) and the [cinder theme](https://sourcefoundry.org/cinder/) via:
+
+```
+python -m pip install mkdocs pymdown-extensions mkdocs-cinder
+```
+
+ you can do:
 
 ```
 mkdocs build

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,109 @@
+# Contributing
+
+Contributions to combine of all sizes, from minor documentation updates, to big code improvements, are welcome and encouraged.
+
+To ensure good development of the tool, we try to coordinate contributions.
+However, we are happy to help overcome any steps that may pose issues for contributors.
+
+Guidelines for contributions are below.
+
+In general you should always perform the following steps when contributing.
+
+1. Make your changes;
+2. Test your changes to ensure they work and don't break anything;
+3. If this changes any user-facing aspect, ensure that the appropriate documentation is updated;
+4. Check code style (see below), and fix any issues;
+5. Create your pull request;
+6. Iterate with the maintainers until the request is merged.
+
+## Code Style
+
+
+We ask that you put some effort into the readability of your code.
+We are, however, always happy to help if there is an issue.
+
+We use linting as part of our ci/cd for the python code. 
+That means your code will be checked automatically, and you must make sure it confirms to certain rules.
+
+Currently no linting or automatic checks of C++ code is implemented.
+Although we do not have a well-defined style guide for C++, we always appreciate readable and well-formatted code.
+
+### Technical details on linting
+
+we use `flake8` and `black` for linting. 
+To run the linting locally before making your pull request, or before making a commit, you can do the following.
+
+ensure `flake8` and `black` are installed: 
+
+```
+ python -m pip install -q flake8 black
+```
+
+and then from the main directory of this repository run
+
+
+flake8:
+```
+flake8 .
+```
+
+and black:
+
+```
+black -l 160 --check --diff .
+```
+
+If you'd like to see the details of the configuration `flake8` is using, check the `.flake8` file in the main directory.
+The black linting uses the default [black style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) (for v23.3.0), with only the command line options shown above.
+
+
+## Updating Documentation
+
+It is crucial to our user base and developers that the documentation is well-mainted.
+For that reason, whenever you make a change you should consider whether this requires a corresponding documentation update.
+
+If the change is user-facing it almost certainly does require a documentation update.
+
+Documentation is **very important** to us. 
+Therefore, we will be picky to make sure it is done well!
+However, we don't want to put extra burden on you, so we are happy to help and will make our own edits and updates to improve the documentation of your change.
+
+We appreciate you putting in some effort and thought to ensure:
+
+- your documentation is understandable to the audience being targeted;
+- your documentation is clear and concise; and
+- your documentation fits in properly with the overall documentation structure.
+
+### Technical details of the documentation
+
+We use [mkdocs](www.mkdocs.org) to produce the static website that documents combine.
+
+The documentation files are all under the `docs/` folder.
+Which pages get included in the site, and other configuration details are set in the `mkdocs.yml` file.
+
+In order to check the documentation rendering (features such as latex math rendering, etc) locally, you can generate the site on your local computer and check it in your browser.
+To do so, after [installing mkdocs](https://www.mkdocs.org/getting-started/) you can do:
+
+```
+mkdocs build
+mkdocs serve
+```
+
+from the main repository directory. mkdocs will then print a link you can open to check the page generated in your browser.
+
+## Big Code Changes
+
+We welcome large contributions to combine. 
+Note, however, that we also follow long term planning, and there is a dedicated group stewarding the overall direction and development of the code.
+
+This means that the code development should fit in with our long term vision;
+if you have an idea for a big improvement or change it will be most efficient if you [contact us](mailto:cms-cat-stats-conveners@cern.ch) first, in order to ensure that we can integrate it as seemlessly as possible into our plans.
+This will simplify any potential conflicts when you make your pull request.
+
+## Solicited Changes
+
+As part of the long term planning, we have a number of changes we are targetting, but have not yet had a chance to implement.
+As well as the issues listed on the github issues tracker, you can see the projects listed, where we have defined several areas we are targetting.
+If you're interested in getting involved in any of these projects please contact us at [cms-cat-stats-conveners@cern.ch](mailto:cms-cat-stats-conveners@cern.ch).
+
+

--- a/contributing.md
+++ b/contributing.md
@@ -23,9 +23,9 @@ We ask that you put some effort into the readability of your code.
 We are, however, always happy to help if there is an issue.
 
 We use linting as part of our ci/cd for the python code. 
-That means your code will be checked automatically, and you must make sure it confirms to certain rules.
+That means your code will be checked automatically, and you must make sure it conforms to certain rules.
 
-Currently no linting or automatic checks of C++ code is implemented.
+Currently no linting or automatic checks of C++ code are implemented.
 Although we do not have a well-defined style guide for C++, we always appreciate readable and well-formatted code.
 
 ### Technical details on linting
@@ -59,13 +59,13 @@ The black linting uses the default [black style](https://black.readthedocs.io/en
 
 ## Updating Documentation
 
-It is crucial to our user base and developers that the documentation is well-mainted.
+It is crucial to our user base and developers that the documentation is well-maintained.
 For that reason, whenever you make a change you should consider whether this requires a corresponding documentation update.
 
 If the change is user-facing it almost certainly does require a documentation update.
 
 Documentation is **very important** to us. 
-Therefore, we will be picky to make sure it is done well!
+Therefore, we will be picky and make sure it is done well!
 However, we don't want to put extra burden on you, so we are happy to help and will make our own edits and updates to improve the documentation of your change.
 
 We appreciate you putting in some effort and thought to ensure:
@@ -91,7 +91,7 @@ mkdocs serve
 
 from the main repository directory. mkdocs will then print a link you can open to check the page generated in your browser.
 
-## Big Code Changes
+## Big Contributions
 
 We welcome large contributions to combine. 
 Note, however, that we also follow long term planning, and there is a dedicated group stewarding the overall direction and development of the code.
@@ -100,10 +100,10 @@ This means that the code development should fit in with our long term vision;
 if you have an idea for a big improvement or change it will be most efficient if you [contact us](mailto:cms-cat-stats-conveners@cern.ch) first, in order to ensure that we can integrate it as seemlessly as possible into our plans.
 This will simplify any potential conflicts when you make your pull request.
 
-## Solicited Changes
+## Requested Contributions
 
-As part of the long term planning, we have a number of changes we are targetting, but have not yet had a chance to implement.
-As well as the issues listed on the github issues tracker, you can see the projects listed, where we have defined several areas we are targetting.
+As part of the long term planning, we have a number of changes we are targeting, but have not yet had a chance to implement.
+As well as the [issues](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/issues) listed on the github issues tracker, you can see the [projects](https://github.com/orgs/cms-analysis/projects) listed under the general cms-analysis organization, where we have defined several projects and areas we are targeting.
 If you're interested in getting involved in any of these projects please contact us at [cms-cat-stats-conveners@cern.ch](mailto:cms-cat-stats-conveners@cern.ch).
 
 

--- a/contributing.md
+++ b/contributing.md
@@ -82,7 +82,7 @@ The documentation files are all under the `docs/` folder.
 Which pages get included in the site, and other configuration details are set in the `mkdocs.yml` file.
 
 In order to check the documentation rendering (features such as latex math rendering, etc) locally, you can generate the site on your local computer and check it in your browser.
-To do so, after [installing mkdocs](https://www.mkdocs.org/getting-started/) you can do:
+To do so, after [installing mkdocs](https://www.mkdocs.org/getting-started/) and [pymdown extensions](https://facelessuser.github.io/pymdown-extensions/installation/) you can do:
 
 ```
 mkdocs build

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,10 @@ The code can be checked out from GIT and compiled on top of a CMSSW release that
 
 # Installation instructions
 
+Installation instructions and recommended versions can be found below. 
+Since v9.0.0, the versioning follows the [semantic versioning 2.0.0 standard](https://semver.org/).
+Earlier versions are not guaranteed to follow the standard.
+
 ## Within CMSSW (recommended for CMS users)
 
 The instructions below are for installation within a CMSSW environment. For end
@@ -167,6 +171,9 @@ _Prerequisites_
 2. Register your SSH key on github: [https://help.github.com/articles/generating-ssh-keys](https://help.github.com/articles/generating-ssh-keys) 1 Fork the repository to create your copy of it: [https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/fork](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/fork) (more documentation at [https://help.github.com/articles/fork-a-repo](https://help.github.com/articles/fork-a-repo) )
 
 You will now be able to browse your fork of the repository from [https://github.com/your-github-user-name/HiggsAnalysis-CombinedLimit](https://github.com/your-github-user-name/HiggsAnalysis-CombinedLimit)
+
+We strongly encourage you to contribute any developments you make back into the main repository. 
+See [contributing.md](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/main/contributing.md) for details about contributing. 
 
 # Combine Tool
 


### PR DESCRIPTION
Adding a contributing document with some details on what is expected as well as technical information such as how to perform the linting locally.

Also adding some information about versioning standard to the main page.

Long term, we plan to have a much more complete developer guides and documentation. In the short term, I hope this serves as a small useful start.