### PR TITLE
Fix arguments for setting pdfindex for toys in tutorial

### DIFF
--- a/docs/tutorial2023/parametric_exercise.md
+++ b/docs/tutorial2023/parametric_exercise.md
@@ -890,7 +890,7 @@ Compile the datacard with:
 text2workspace.py datacard_part5.txt -m 125
 ```
 
-The `RooMultiPdf` is a handy object for performing bias studies as all functions can be stored in a single workspace. You can then set which function is used for generating the toys with the `--setParameters pdfindex=i` option, and which function is used for fitting with `--setParameters pdfindex=i --freezeParameters pdfindex=j` options. 
+The `RooMultiPdf` is a handy object for performing bias studies as all functions can be stored in a single workspace. You can then set which function is used for generating the toys with the `--setParameters pdfindex_Tag0=i` option, and which function is used for fitting with `--setParameters pdfindex_Tag0=j --freezeParameters pdfindex_Tag0` options. 
 
 * It would be a useful exercise to repeat the bias studies from part 4 but using the RooMultiPdf workspace. What happens when you do not freeze the index in the fitting step?
 


### PR DESCRIPTION
Fixing a small mistake in the parametric fit tutorial documentation about using `RooMultiPDF`

As pointed out on cms talk, the current documentation says to use

```
--setParameters pdfindex=i --freezeParameters pdfindex=j
```
 when doing the fit, to test the fit using a different pdf than was used to generate the toys. But the second part is not a valid argument, it should only take the parameter name, not a value.
 
 