### PR TITLE
Update CRAB env. setup instructions

### DIFF
--- a/docs/part3/runningthetool.md
+++ b/docs/part3/runningthetool.md
@@ -316,10 +316,10 @@ When the `--dry-run` option is removed each command will be run in sequence.
 
 #### Grid submission
 
-Submission to the grid with `crab3` works in a similar way. Before doing so ensure that the `crab3` environment has been sourced, then for compatibility reasons source the CMSSW environment again. We will use the example of generating a grid of test-statistic distributions for limits.
+Submission to the grid with `crab3` works in a similar way. Before doing so ensure that the `crab3` environment has been sourced in addition to the  CMSSW environment. We will use the example of generating a grid of test-statistic distributions for limits.
 
 ```sh
-$ source /cvmfs/cms.cern.ch/crab3/crab.sh; cmsenv
+$ cmsenv; source /cvmfs/cms.cern.ch/crab3/crab.sh
 $ combineTool.py -d htt_mt.root -M HybridNew --LHCmode LHC-limits --clsAcc 0 -T 2000 -s -1 --singlePoint 0.2:2.0:0.05 --saveToys --saveHybridResult -m 125 --job-mode crab3 --task-name grid-test --custom-crab custom_crab.py
 ```
 


### PR DESCRIPTION
since a few years `cmsenv` provides all that' s needed to run CRAB CLI. Only if you use CRAB's python API, you should source ` /cvmfs/cms.cern.ch/crab3/crab.sh` **after** `cmsenv`. See https://twiki.cern.ch/twiki/bin/view/CMSPublic/CMSCrabClient#Using_CRABClient_API
note that the old `crab3/crab.sh` is now a link to the new script
```
ls -l /cvmfs/cms.cern.ch/crab3/crab.sh
lrwxrwxrwx. 1 cvmfs cvmfs 39 May 13  2020 /cvmfs/cms.cern.ch/crab3/crab.sh -> /cvmfs/cms.cern.ch/common/crab-setup.sh
```
