### PR TITLE
Fix the Build ci job for python>=3p8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install build environment
       shell: bash -l {0}
       run: |
-        mamba install -c conda-forge python==${{ matrix.python }} pip pandas root==${{ matrix.root }} gsl tbb vdt boost pcre eigen
+        mamba install -c conda-forge python==${{ matrix.python }} pip pandas root==${{ matrix.root }} gsl tbb vdt boost-cpp boost pcre eigen
         cd HiggsAnalysis/CombinedLimit
         bash set_conda_env_vars.sh
     - name: Build


### PR DESCRIPTION
In the recent updates to the PRs https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/862 and https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/839 @kcormi and I noticed that the build jobs in the ci are failing. From the output I found that the lboost(boost-cpp) library is missing. Looks like once the `ubuntu-latest ` moved to the most recent [image build](https://github.com/actions/runner-images/blob/releases/ubuntu22/20230924/images/linux/Ubuntu2204-Readme.md) the boost-cpp is not being installed together with boost. I have no idea why, but this should fix the issue. 