### PR TITLE
Suppress warning in t2w when using full path

### DIFF
--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -1020,8 +1020,9 @@ class ModelBuilder(ModelBuilderBase):
             discparams.add(self.out.cat(cpar))
         self.out._import(discparams, discparams.GetName())
         self.out.writeToFile(self.options.out)
-        mystr = ROOT.TNamed("myname", self.stringout)
-        fileout = ROOT.TFile("./" + self.options.out, "UPDATE")
+        mystr = ROOT.TNamed("stxs_scaling", self.stringout)
+        filename_fornamed = self.options.out if self.options.out.startswith("/") else "./" + self.options.out
+        fileout = ROOT.TFile(filename_fornamed, "UPDATE")
         mystr.Write()
         fileout.Close()
 


### PR DESCRIPTION
This avoids a (harmless) error related to writing a string into the workspace (which I believe contains information on the STXS model used) when running text2workspace with an absolute path. I'm actually not sure if anyone is using that string at all, but when I added it N years ago I found it useful, so a little hesitant to remove it altogether, although that would be fine for me also. FYI @jonathon-langford  