### PR TITLE
Replace deprecated legacy iterators

### DIFF
--- a/interface/AtlasPdfs.h
+++ b/interface/AtlasPdfs.h
@@ -372,9 +372,6 @@ protected:
   mutable std::vector<int> _nnuis; 
   mutable std::vector<double> _nref;
 
-  TIterator* _parItr ;  //! do not persist
-  TIterator* _obsItr ;  //! do not persist
-  TIterator* _pdfItr ;  //!
   mutable TMatrixD* _M; //!
 
   Setting _setting;

--- a/interface/FastTemplateFunc.h
+++ b/interface/FastTemplateFunc.h
@@ -19,15 +19,12 @@ public:
   virtual inline ~FastTemplateFunc_t(){}
 
   void setProxyList(RooListProxy& proxyList, RooArgList& varList){
-    TIterator* varIter = varList.createIterator();
-    RooAbsArg* var;
-    while ((var = (RooAbsArg*)varIter->Next())) {
+    for (RooAbsArg *var : varList) {
       if (!dynamic_cast<RooAbsReal*>(var)) {
         assert(0);
       }
       proxyList.add(*var);
     }
-    delete varIter;
   }
 
   virtual TObject* clone(const char* newname) const = 0;

--- a/interface/HZZ4L_RooSpinZeroPdf_1D.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_1D.h
@@ -28,7 +28,6 @@ protected:
 //  RooRealProxy ksmd ;
   RooRealProxy fai ;
   RooListProxy _coefList ;  //  List of funcficients
-  TIterator* _coefIter ;    //! Iterator over funcficient lis
   Double_t evaluate() const ;
 public:
   HZZ4L_RooSpinZeroPdf_1D() {} ; 

--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -1,7 +1,6 @@
 #ifndef HiggsAnalysis_CombinedLimit_ProcessNormalization_h
 #define HiggsAnalysis_CombinedLimit_ProcessNormalization_h
 
-#include <TIterator.h>
 #include <RooAbsReal.h>
 #include "RooListProxy.h"
 

--- a/interface/RooMultiPdf.h
+++ b/interface/RooMultiPdf.h
@@ -17,7 +17,6 @@
 #include "RooConstVar.h"
 
 
-#include "TIterator.h"
 #include "RooListProxy.h"
 
 #include <iostream>

--- a/interface/SimpleCacheSentry.h
+++ b/interface/SimpleCacheSentry.h
@@ -3,7 +3,6 @@
 
 #include "RooRealVar.h"
 #include "RooSetProxy.h"
-#include "TIterator.h"
 
 class SimpleCacheSentry : public RooAbsArg {
     public:

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -41,8 +41,6 @@ protected:
   RooListProxy _coefList ;  //  List of coefficients
   Double_t     _smoothRegion;
   Int_t        _smoothAlgo;
-  TIterator* _funcIter ;     //! Iterator over FUNC list
-  TIterator* _coefIter ;    //! Iterator over coefficient list
 
   // TH1 containing the histogram of this pdf
   mutable SimpleCacheSentry _sentry; // !not to be serialized
@@ -93,8 +91,6 @@ protected:
   RooListProxy _coefList ;  //  List of coefficients
   Double_t     _smoothRegion;
   Int_t        _smoothAlgo;
-  TIterator* _funcIter ;     //! Iterator over FUNC list
-  TIterator* _coefIter ;    //! Iterator over coefficient list
 
   // TH1 containing the histogram of this pdf
   mutable bool              _init; //! not to be serialized

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -46,8 +46,6 @@ protected:
   RooListProxy _coefList ;  //  List of coefficients
   Double_t     _quadraticRegion;
   Int_t        _quadraticAlgo;
-  TIterator* _funcIter ;     //! Iterator over FUNC list
-  TIterator* _coefIter ;    //! Iterator over coefficient list
 
   Double_t _pdfFloorVal; // PDF floor should be customizable, default is 1e-15
   Double_t _integralFloorVal; // PDF integral floor should be customizable, default is 1e-10

--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <stdexcept>
-#include <TIterator.h>
 #include <RooAbsData.h>
 #include <RooArgSet.h>
 #include <RooProdPdf.h>
@@ -21,8 +20,7 @@ RooAbsData *asimovutils::asimovDatasetNominal(RooStats::ModelConfig *mc, double 
 
 	if (verbose>2) {
 	    CombineLogger::instance().log("AsimovUtils.cc",__LINE__,"Parameters after fit for asimov dataset",__func__);
-    	    std::unique_ptr<TIterator> iter(mc->GetPdf()->getParameters((const RooArgSet*) 0)->createIterator());
-    	    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    	    for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc->GetPdf()->getParameters((const RooArgSet*) 0)}) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("AsimovUtils.cc",__LINE__,std::string(Form("%s",varstring.Data())),__func__);
 	    }
@@ -45,8 +43,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
             } else {
                 // Do we have free parameters anyway that need fitting?
                 std::unique_ptr<RooArgSet> params(mc->GetPdf()->getParameters(realdata));
-                std::unique_ptr<TIterator> iter(params->createIterator());
-                for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+                for (RooAbsArg *a : *params) {
                     RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
                     if ( rrv != 0 && rrv->isConstant() == false ) { needsFit &= true; break; }
                 } 
@@ -67,8 +64,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
 
 	if (verbose>2) { 
 	    CombineLogger::instance().log("AsimovUtils.cc",__LINE__,"Parameters after fit for asimov dataset",__func__);
-    	    std::unique_ptr<TIterator> iter(mc->GetPdf()->getParameters(realdata)->createIterator());
-    	    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+            for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc->GetPdf()->getParameters(realdata)}) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("AsimovUtils.cc",__LINE__,std::string(Form("%s",varstring.Data())),__func__);
 	    }
@@ -92,8 +88,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
             std::unique_ptr<RooAbsPdf> nuispdf(utils::makeNuisancePdf(*mc));
             RooProdPdf *prod = dynamic_cast<RooProdPdf *>(nuispdf.get());
             if (prod == 0) throw std::runtime_error("AsimovUtils: the nuisance pdf is not a RooProdPdf!");
-            std::unique_ptr<TIterator> iter(prod->pdfList().createIterator());
-            for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+            for (RooAbsArg *a : prod->pdfList()) {
                 RooAbsPdf *cterm = dynamic_cast<RooAbsPdf *>(a); 
                 if (!cterm) throw std::logic_error("AsimovUtils: a factor of the nuisance pdf is not a Pdf!");
                 if (!cterm->dependsOn(nuis)) continue; // dummy constraints
@@ -109,8 +104,7 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                 if (cpars->getSize() == 1) {
                     match = dynamic_cast<RooAbsReal *>(cpars->first());
                 } else {
-                    std::unique_ptr<TIterator> iter2(cpars->createIterator());
-                    for (RooAbsArg *a2 = (RooAbsArg *) iter2->Next(); a2 != 0; a2 = (RooAbsArg *) iter2->Next()) {
+                    for (RooAbsArg *a2 : *cpars) {
                         RooRealVar *rrv2 = dynamic_cast<RooRealVar *>(a2); 
                         if (rrv2 != 0 && !rrv2->isConstant()) {
                             if (match != 0) throw std::runtime_error(Form("AsimovUtils: constraint term %s has multiple floating params", cterm->GetName()));
@@ -138,10 +132,10 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
                     // we want to set the global obs to a value for which the current value 
                     // of the nuisance is the best fit one.
                     // best fit x = (k-1)*theta    ---->  k = x/theta + 1
-                    RooArgList leaves; cterm->leafNodeServerList(&leaves);
-                    std::unique_ptr<TIterator> iter2(leaves.createIterator());
+                    RooArgList leaves;
+                    cterm->leafNodeServerList(&leaves);
                     RooAbsReal *match2 = 0;
-                    for (RooAbsArg *a2 = (RooAbsArg *) iter2->Next(); a2 != 0; a2 = (RooAbsArg *) iter2->Next()) {
+                    for (RooAbsArg *a2 : leaves) {
                         RooAbsReal *rar = dynamic_cast<RooAbsReal *>(a2);
                         if (rar == 0 || rar == match || rar == &rrv) continue;
                         if (!rar->isConstant()) throw std::runtime_error(Form("AsimovUtils: extra floating parameter %s of RooGamma %s.", rar->GetName(), cterm->GetName()));

--- a/src/AsymptoticLimits.cc
+++ b/src/AsymptoticLimits.cc
@@ -107,8 +107,7 @@ bool AsymptoticLimits::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
     */
     hasDiscreteParams_ = false;  
     if (params_.get() == 0) params_.reset(mc_s->GetPdf()->getParameters(data));
-    std::unique_ptr<TIterator> itparam(params_->createIterator());
-    for (RooAbsArg *a = (RooAbsArg *) itparam->Next(); a != 0; a = (RooAbsArg *) itparam->Next()) {
+    for (RooAbsArg *a : *params_) {
       if (a->IsA()->InheritsFrom(RooCategory::Class())) { hasDiscreteParams_ = true; break; }
     }
 
@@ -164,8 +163,7 @@ bool AsymptoticLimits::runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, Ro
   if (params_.get() == 0) params_.reset(mc_s->GetPdf()->getParameters(data));
 
   hasFloatParams_ = false;
-  std::unique_ptr<TIterator> itparam(params_->createIterator());
-  for (RooAbsArg *a = (RooAbsArg *) itparam->Next(); a != 0; a = (RooAbsArg *) itparam->Next()) {
+  for (RooAbsArg *a : *params_) {
       RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
       if ( rrv != 0 && rrv != r && rrv->isConstant() == false ) { hasFloatParams_ = true; break; }
   }

--- a/src/AtlasPdfs.cxx
+++ b/src/AtlasPdfs.cxx
@@ -433,10 +433,8 @@ RooBSpline::RooBSpline(const char* name, const char* title,
 
   //bool even = fabs(_n/2-_n/2.) < 0.0000000001;
   bool first=1;
-  TIterator* pointIter = controlPoints.createIterator() ;
-  RooAbsArg* point ;
   RooAbsArg* lastPoint=NULL ;
-  while((point = (RooAbsArg*)pointIter->Next())) {
+  for (RooAbsArg * point : controlPoints) {
     if (!dynamic_cast<RooAbsReal*>(point)) {
       coutE(InputArguments) << "RooBSpline::ctor(" << GetName() << ") ERROR: control point " << point->GetName() 
 			    << " is not of type RooAbsReal" << std::endl ;
@@ -456,19 +454,9 @@ RooBSpline::RooBSpline(const char* name, const char* title,
     lastPoint=point;
   }
   for (int i=0;i<(_n)/2;i++) _controlPoints.add(*lastPoint);
-  delete pointIter ;
 
 
-  TIterator* varItr = vars.createIterator();
-  RooAbsArg* arg;
-  while ((arg=(RooAbsArg*)varItr->Next())) {
-    //std::cout << "======== Adding "<<arg->GetName()<<" to list of _vars of "<<name<<"." << std::endl;
-    _vars.add(*arg);
-  }
-//   std::cout << "all _vars: " << std::endl;
-//   _vars.Print("V");
-  delete varItr;
-  //std::cout << "out Ctor" << std::endl;
+  _vars.add(vars);
 }
 
 //_____________________________________________________________________________
@@ -556,10 +544,8 @@ void RooBSpline::setWeights(const RooArgList& weights)
 {
   _weights.removeAll();
   bool first=1;
-  TIterator* pointIter = weights.createIterator() ;
-  RooAbsArg* point ;
   RooAbsArg* lastPoint=NULL ;
-  while((point = (RooAbsArg*)pointIter->Next())) {
+  for (RooAbsArg *point : weights) {
     if (!dynamic_cast<RooAbsReal*>(point)) {
       coutE(InputArguments) << "RooBSpline::ctor(" << GetName() << ") ERROR: control point " << point->GetName() 
 			    << " is not of type RooAbsReal" << std::endl ;
@@ -577,7 +563,6 @@ void RooBSpline::setWeights(const RooArgList& weights)
     lastPoint=point;
   }
   for (int i=0;i<(_n+1)/2;i++) _weights.add(*lastPoint);
-  delete pointIter;
 }
 
 
@@ -1235,9 +1220,6 @@ RooStarMomentMorph::RooStarMomentMorph() :
 {
 
   // coverity[UNINIT_CTOR]
-  _parItr    = _parList.createIterator() ;
-  _obsItr    = _obsList.createIterator() ;
-  _pdfItr    = _pdfList.createIterator() ; 
 }
 
 
@@ -1269,45 +1251,31 @@ RooStarMomentMorph::RooStarMomentMorph(const char *name, const char *title,
   // CTOR
 
   // fit parameters
-  TIterator* parItr = parList.createIterator() ;
-  RooAbsArg* par ;
-  for (Int_t i=0; (par = (RooAbsArg*)parItr->Next()); ++i) {
+  for (RooAbsArg *par : parList) {
     if (!dynamic_cast<RooAbsReal*>(par)) {
       coutE(InputArguments) << "RooStarMomentMorph::ctor(" << GetName() << ") ERROR: parameter " << par->GetName() << " is not of type RooAbsReal" << endl ;
       throw std::string("RooStarMomentMorh::ctor() ERROR parameter is not of type RooAbsReal") ;
     }
     _parList.add(*par) ;
   }
-  delete parItr ;
 
   // observables
-  TIterator* obsItr = obsList.createIterator() ;
-  RooAbsArg* var ;
-  for (Int_t i=0; (var = (RooAbsArg*)obsItr->Next()); ++i) {
+  for (RooAbsArg *var : obsList) {
     if (!dynamic_cast<RooAbsReal*>(var)) {
       coutE(InputArguments) << "RooStarMomentMorph::ctor(" << GetName() << ") ERROR: variable " << var->GetName() << " is not of type RooAbsReal" << endl ;
       throw std::string("RooStarMomentMorh::ctor() ERROR variable is not of type RooAbsReal") ;
     }
     _obsList.add(*var) ;
   }
-  delete obsItr ;
 
   // reference p.d.f.s
-  TIterator* pdfItr = pdfList.createIterator() ;
-  RooAbsPdf* pdf ;
-  for (Int_t i=0; (pdf = dynamic_cast<RooAbsPdf*>(pdfItr->Next())); ++i) {
-    if (!pdf) {
+  for (RooAbsArg *pdf : pdfList) {
+    if (!dynamic_cast<RooAbsPdf*>(pdf)) {
       coutE(InputArguments) << "RooStarMomentMorph::ctor(" << GetName() << ") ERROR: pdf " << pdf->GetName() << " is not of type RooAbsPdf" << endl ;
       throw std::string("RooStarMomentMorph::ctor() ERROR pdf is not of type RooAbsPdf") ;
     }
     _pdfList.add(*pdf) ;
   }
-  delete pdfItr ;
-
-  _parItr    = _parList.createIterator() ;
-  _obsItr    = _obsList.createIterator() ;
-  _pdfItr    = _pdfList.createIterator() ; 
-
 
   // initialization
   initialize();
@@ -1329,12 +1297,6 @@ RooStarMomentMorph::RooStarMomentMorph(const RooStarMomentMorph& other, const ch
   _nnuisvar(other._nnuisvar),
   _useHorizMorph(other._useHorizMorph)
 { 
- 
-
-  _parItr    = _parList.createIterator() ;
-  _obsItr    = _obsList.createIterator() ;
-  _pdfItr    = _pdfList.createIterator() ; 
-
   // nref is resized in initialize, so reduce the size here
   if (_nref.size()>0) {
     _nref.resize( _nref.size()-1 );
@@ -1347,9 +1309,6 @@ RooStarMomentMorph::RooStarMomentMorph(const RooStarMomentMorph& other, const ch
 //_____________________________________________________________________________
 RooStarMomentMorph::~RooStarMomentMorph() 
 {
-  if (_parItr) delete _parItr;
-  if (_obsItr) delete _obsItr;
-  if (_pdfItr) delete _pdfItr;
   if (_M)      delete _M;
 }
 
@@ -1512,15 +1471,11 @@ RooStarMomentMorph::CacheElem* RooStarMomentMorph::getCache(const RooArgSet* /*n
   //}
 
   // construction of unit pdfs
-  _pdfItr->Reset();
-  RooAbsPdf* pdf;
   RooArgList transPdfList;
 
   for (Int_t i=0; i<nPdf; ++i) {
-    _obsItr->Reset() ;
-    RooRealVar* var ;
 
-    pdf = (RooAbsPdf*)_pdfItr->Next();
+    RooAbsPdf* pdf = &(RooAbsPdf&)_pdfList[i];
 
     std::string pdfName = Form("pdf_%d",i);
     RooCustomizer cust(*pdf,pdfName.c_str());
@@ -1545,7 +1500,7 @@ RooStarMomentMorph::CacheElem* RooStarMomentMorph::getCache(const RooArgSet* /*n
       ownedComps.add(RooArgSet(*slope[sij(i,j)],*offsetVar[sij(i,j)])) ;
       
       // linear transformations, so pdf can be renormalized easily
-      var = (RooRealVar*)(_obsItr->Next());
+      RooRealVar *var = (RooRealVar*)(_obsList[j]);
       std::string transVarName = Form("%s_transVar_%d_%d",GetName(),i,j);
       transVar[sij(i,j)] = new RooLinearVar(transVarName.c_str(),transVarName.c_str(),*var,*slope[sij(i,j)],*offsetVar[sij(i,j)]);
 
@@ -1680,7 +1635,6 @@ void RooStarMomentMorph::CacheElem::calculateFractions(const RooStarMomentMorph&
       //int nObs=self._obsList.getSize();
       
       // loop over parList
-      self._parItr->Reset();
       int nnuis=0;
       
       // zero all fractions
@@ -1691,7 +1645,7 @@ void RooStarMomentMorph::CacheElem::calculateFractions(const RooStarMomentMorph&
       }
       for (Int_t j=0; j<self._parList.getSize(); j++) {
 	
-	RooRealVar* m = (RooRealVar*)(self._parItr->Next());
+	RooRealVar* m = &(RooRealVar&)self._parList[j];
 	double m0=m->getVal();
 	
 	if (m0==0.) continue;

--- a/src/CMSHggFormula.cc
+++ b/src/CMSHggFormula.cc
@@ -11,8 +11,7 @@ CMSHggFormulaA1::CMSHggFormulaA1(const char* name, const char* title, RooAbsReal
       p3_("p3", "p3", this, p3),
       terms_("terms", "terms", this),
       coeffs_(coeffs) {
-  RooFIter iter = terms.fwdIterator();
-  for (RooAbsArg* a = iter.next(); a != 0; a = iter.next()) {
+  for (RooAbsArg* a : terms) {
     RooAbsReal* rar = dynamic_cast<RooAbsReal*>(a);
     if (!rar) {
       throw std::invalid_argument(std::string("Component ") + a->GetName() +
@@ -61,8 +60,7 @@ CMSHggFormulaA2::CMSHggFormulaA2(const char* name, const char* title, RooAbsReal
       p3_("p3", "p3", this, p3),
       terms_("terms", "terms", this),
       coeffs_(coeffs) {
-  RooFIter iter = terms.fwdIterator();
-  for (RooAbsArg* a = iter.next(); a != 0; a = iter.next()) {
+  for (RooAbsArg *a : terms) {
     RooAbsReal* rar = dynamic_cast<RooAbsReal*>(a);
     if (!rar) {
       throw std::invalid_argument(std::string("Component ") + a->GetName() +
@@ -107,8 +105,7 @@ CMSHggFormulaB1::CMSHggFormulaB1(const char* name, const char* title, RooAbsReal
       p0_("p0", "p0", this, p0),
       terms_("terms", "terms", this),
       coeffs_(coeffs) {
-  RooFIter iter = terms.fwdIterator();
-  for (RooAbsArg* a = iter.next(); a != 0; a = iter.next()) {
+  for (RooAbsArg *a : terms) {
     RooAbsReal* rar = dynamic_cast<RooAbsReal*>(a);
     if (!rar) {
       throw std::invalid_argument(std::string("Component ") + a->GetName() +
@@ -150,8 +147,7 @@ CMSHggFormulaB2::CMSHggFormulaB2(const char* name, const char* title, double con
       p0_(p0),
       terms_("terms", "terms", this),
       coeffs_(coeffs) {
-  RooFIter iter = terms.fwdIterator();
-  for (RooAbsArg* a = iter.next(); a != 0; a = iter.next()) {
+  for (RooAbsArg* a : terms) {
     RooAbsReal* rar = dynamic_cast<RooAbsReal*>(a);
     if (!rar) {
       throw std::invalid_argument(std::string("Component ") + a->GetName() +
@@ -192,8 +188,7 @@ CMSHggFormulaC1::CMSHggFormulaC1(const char* name, const char* title, RooArgList
     : RooAbsReal(name, title),
       terms_("terms", "terms", this),
       coeffs_(coeffs) {
-  RooFIter iter = terms.fwdIterator();
-  for (RooAbsArg* a = iter.next(); a != 0; a = iter.next()) {
+  for (RooAbsArg* a : terms) {
     RooAbsReal* rar = dynamic_cast<RooAbsReal*>(a);
     if (!rar) {
       throw std::invalid_argument(std::string("Component ") + a->GetName() +

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -249,9 +249,7 @@ void CMSHistErrorPropagator::setAnalyticBarlowBeeston(bool flag) const {
       if (bintypes_[j][0] == 1 && !vbinpars_[j][0]->isConstant()) {
         bb_.use.push_back(j);
         double gobs_val = 0.;
-        RooFIter iter = vbinpars_[j][0]->valueClientMIterator();
-        RooAbsArg *arg = nullptr;
-        while((arg = iter.next())) {
+        for (RooAbsArg * arg : vbinpars_[j][0]->valueClients()) {
           if (arg == this || arg == &binsentry_) {
             // std::cout << "Skipping " << this << " " << this->GetName() << "\n";
           } else {

--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -1202,9 +1202,7 @@ Double_t CMSHistFunc::analyticalIntegral(Int_t code,
 }
 
 CMSHistFuncWrapper const* CMSHistFunc::wrapper() const {
-  RooFIter iter = this->valueClientMIterator();
-  RooAbsArg *arg = nullptr;
-  while((arg = iter.next())) {
+  for (RooAbsArg *arg : valueClients()) {
     CMSHistFuncWrapper const* wrapper = dynamic_cast<CMSHistFuncWrapper const*>(arg);
     if (wrapper) return wrapper;
   }

--- a/src/CMSHistFuncWrapper.cc
+++ b/src/CMSHistFuncWrapper.cc
@@ -47,9 +47,7 @@ void CMSHistFuncWrapper::initialize() const {
   pfunc_ = dynamic_cast<CMSHistFunc const*>(&(func_.arg()));
   perr_ = dynamic_cast<CMSHistErrorPropagator *>(err_.absArg());
   auto sentry_args = perr_->getSentryArgs();
-  RooFIter iter = sentry_args->fwdIterator() ;
-  RooAbsArg* arg;
-  while((arg = iter.next())) {
+  for (RooAbsArg *arg : *sentry_args) {
     sentry_.addArg(*arg);
   }
   sentry_.setValueDirty();

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -474,9 +474,7 @@ void CMSHistSum::setAnalyticBarlowBeeston(bool flag) const {
       if (bintypes_[j][0] == 1 && !vbinpars_[j][0]->isConstant()) {
         bb_.use.push_back(j);
         double gobs_val = 0.;
-        RooFIter iter = vbinpars_[j][0]->valueClientMIterator();
-        RooAbsArg *arg = nullptr;
-        while((arg = iter.next())) {
+        for (RooAbsArg *arg : vbinpars_[j][0]->valueClients()) {
           if (arg == this || arg == &binsentry_) {
             // std::cout << "Skipping " << this << " " << this->GetName() << "\n";
           } else {

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -117,10 +117,7 @@ namespace { unsigned long CachingSimNLLEvalCount = 0; }
 
 cacheutils::ArgSetChecker::ArgSetChecker(const RooAbsCollection &set) 
 {
-    std::unique_ptr<TIterator> iter(set.createIterator());
-    for (RooAbsArg *a  = dynamic_cast<RooAbsArg *>(iter->Next()); 
-                    a != 0; 
-                    a  = dynamic_cast<RooAbsArg *>(iter->Next())) {
+    for (RooAbsArg *a : set) {
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv) { // && !rrv->isConstant()) { 
             vars_.push_back(rrv);
@@ -375,10 +372,9 @@ cacheutils::ReminderSum::ReminderSum(const char *name, const char *title, const 
     RooAbsReal(name,title),
     list_("deps","",this)
 {
-    RooLinkedListIter iter(sumSet.iterator());
-    for (RooAbsReal *rar = (RooAbsReal *) iter.Next(); rar != 0; rar = (RooAbsReal *) iter.Next()) {
+    for (RooAbsArg * rar : sumSet) {
         list_.add(*rar);
-        terms_.push_back(rar);
+        terms_.push_back(static_cast<RooAbsReal*>(rar));
     }
 }
 Double_t cacheutils::ReminderSum::evaluate() const {
@@ -585,8 +581,7 @@ cacheutils::CachingAddNLL::setup_()
     }
 
     std::unique_ptr<RooArgSet> params(pdf_->getParameters(*data_));
-    std::unique_ptr<TIterator> iter(params->createIterator());
-    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    for (RooAbsArg *a : *params) {
         if (dynamic_cast<RooRealVar *>(a))  params_.add(*a);
         else if (dynamic_cast<RooCategory *>(a)) catParams_.add(*a);
     }
@@ -1309,8 +1304,7 @@ void cacheutils::CachingSimNLL::setMaskNonDiscreteChannels(bool mask) {
         unsigned int idx = 0;
         for (std::vector<CachingAddNLL*>::const_iterator it = pdfs_.begin(), ed = pdfs_.end(); it != ed; ++it, ++idx) {
             if ((*it) == 0) continue;
-            RooLinkedListIter iter = (*it)->catParams().iterator();
-            for (RooAbsArg *P = (RooAbsArg *) iter.Next(); P != 0; P = (RooAbsArg *) iter.Next()) {
+            for (RooAbsArg *P : (*it)->catParams()) {
                 RooCategory *cat = dynamic_cast<RooCategory *>(P);
                 if (!cat) continue;
                 if (cat && !cat->isConstant()) {

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -911,8 +911,7 @@ bool CascadeMinimizer::autoBoundsOk(int verbose) {
     for (int bothBounds = 0; bothBounds <= 1; ++bothBounds) {
       const RooArgSet * pois = (bothBounds ? poisForAutoBounds_ : poisForAutoMax_);
       if (!pois) continue;
-      RooFIter f = pois->fwdIterator();
-      for (RooAbsArg *a = f.next(); a != 0; a = f.next()) {
+      for (RooAbsArg *a : *pois) {
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv && !rrv->isConstant() && rrv->hasMax() && rrv->hasMin()) {
             double val = rrv->getVal(), lo = rrv->getMin(), hi = rrv->getMax();

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -19,7 +19,6 @@
 #include <TFile.h>
 #include <TFileCacheRead.h>
 #include <TGraphErrors.h>
-#include <TIterator.h>
 #include <TLine.h>
 #include <TMath.h>
 #include <TString.h>
@@ -227,8 +226,7 @@ std::string Combine::parseRegex(std::string instr, const RooArgSet *nuisances, R
     std::regex rgx( reg_esp, std::regex::ECMAScript);
     
     std::string matchingParams="";
-    std::unique_ptr<TIterator> iter(nuisances->createIterator());
-    for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
+    for (RooAbsArg *a : *nuisances) {
         const std::string &target = a->GetName();
         std::smatch match;
         if (std::regex_match(target, match, rgx)) {
@@ -251,8 +249,7 @@ std::string Combine::parseRegex(std::string instr, const RooArgSet *nuisances, R
     std::regex rgx( reg_esp, std::regex::ECMAScript);
     
     std::string matchingParams="";
-    std::unique_ptr<TIterator> iter(w->componentIterator());
-    for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
+    for (RooAbsArg *a : w->components()) {
 
         if ( ! (a->IsA()->InheritsFrom(RooRealVar::Class()) || a->IsA()->InheritsFrom(RooCategory::Class()))) continue;
 
@@ -540,8 +537,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   if (nuisances && runtimedef::get("ADD_DISCRETE_FALLBACK")) {
     RooArgSet newNuis;
     std::string startswith = "u_CMS_Hgg_env_pdf_";
-    TIterator *np = nuisances->createIterator();
-    while (RooRealVar *arg = (RooRealVar*)np->Next()) {
+    for (RooAbsArg *arg : *nuisances) {
       if (std::string(arg->GetName()).compare(0, startswith.size(), startswith)) {
         newNuis.add(*arg);
       } else {
@@ -616,11 +612,10 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 
   if (redefineSignalPOIs_ != "") {
       RooArgSet newPOIs(w->argSet(redefineSignalPOIs_.c_str()));
-      TIterator *np = newPOIs.createIterator();
-      while (RooRealVar *arg = (RooRealVar*)np->Next()) {
+      for (RooAbsArg *arg : newPOIs) {
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(arg);
         if (rrv == 0) { std::cerr << "MultiDimFit: Parameter of interest " << arg->GetName() << " which is not a RooRealVar will be ignored" << std::endl; continue; }
-	arg->setConstant(0);
+	rrv->setConstant(0);
 	// also set ignoreConstraint flag for constraint PDF 
 	if ( w->pdf(Form("%s_Pdf",arg->GetName())) ) w->pdf(Form("%s_Pdf",arg->GetName()))->setAttribute("ignoreConstraint");
       }
@@ -639,9 +634,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
 
   // Always reset the POIs to floating (post-fit workspaces can actually have them frozen in some cases, in any case they can be re-frozen in the next step 
-  TIterator *pois = POI->createIterator();
-  while (RooRealVar *arg = (RooRealVar*)pois->Next()) {
-      arg->setConstant(0);
+  for (RooAbsArg *arg : *POI) {
+      static_cast<RooRealVar*>(arg)->setConstant(0);
   }
 
   if (floatNuisances_ != "") {
@@ -671,8 +665,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (verbose > 0) {  
       	//std::cout << "Floating the following parameters: "; toFloat.Print(""); 
         CombineLogger::instance().log("Combine.cc",__LINE__,"Floating the following parameters:",__func__); 
-        std::unique_ptr<TIterator> iter(toFloat.createIterator());
-        for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
+        for (RooAbsArg *a : toFloat) {
            CombineLogger::instance().log("Combine.cc",__LINE__,a->GetName(),__func__); 
 	      }
       }
@@ -706,8 +699,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (verbose > 0) {  
       	//std::cout << "Freezing the following parameters: "; toFreeze.Print("");
         CombineLogger::instance().log("Combine.cc",__LINE__,"Freezing the following parameters: ",__func__); 
-        std::unique_ptr<TIterator> iter(toFreeze.createIterator());
-        for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
+        for (RooAbsArg *a : toFreeze) {
            CombineLogger::instance().log("Combine.cc",__LINE__,a->GetName(),__func__); 
 	      }
       }
@@ -764,9 +756,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     for (auto const& attr : nuisanceAttrs) {
       RooArgSet toFreeze;
       if (nuisances) {
-         RooAbsArg *arg = nullptr;
-         auto iter = nuisances->createIterator();
-         while ((arg = (RooAbsArg*)iter->Next())) {
+         for (RooAbsArg *arg : *nuisances) {
            if (arg->attributes().count(attr)) toFreeze.add(*arg);
          }
          if (verbose > 0) {  std::cout << "Freezing the following nuisance parameters: "; toFreeze.Print(""); }
@@ -983,8 +973,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	    // print the values of the parameters used to generate the toy
 	    if (verbose > 2) {
 	      CombineLogger::instance().log("Combine.cc",__LINE__, "Generate Asimov toy from parameter values ... ",__func__);
-    	  std::unique_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
-    	  for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+              for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{genPdf->getParameters((const RooArgSet*)0)}) {
 	  	    TString varstring = utils::printRooArgAsString(a);
 	  	    CombineLogger::instance().log("Combine.cc",__LINE__,varstring.Data(),__func__);
 	      }
@@ -1080,8 +1069,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	std::cout << "Generate toy " << iToy << "/" << nToys << std::endl;
 	if (verbose > 2) {
 	  CombineLogger::instance().log("Combine.cc",__LINE__, std::string(Form("Generating toy %d/%d, from parameter values ... ",iToy,nToys)),__func__);
-    std::unique_ptr<TIterator> iter(genPdf->getParameters((const RooArgSet*)0)->createIterator());
-    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{genPdf->getParameters((const RooArgSet*)0)}) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("Combine.cc" ,__LINE__,varstring.Data(),__func__);
 	  }
@@ -1198,8 +1186,7 @@ void Combine::addPOI(const RooArgSet *poi){
    // RooArgSet *nuisances = (RooArgSet*) w->set("nuisances");
     CascadeMinimizerGlobalConfigs::O().parametersOfInterest = RooArgList();
     if (poi != 0) {
-        TIterator *pp = poi->createIterator();
-        while (RooAbsArg *arg = (RooAbsArg*)pp->Next()) (CascadeMinimizerGlobalConfigs::O().parametersOfInterest).add(*arg);
+        for (RooAbsArg *arg : *poi) (CascadeMinimizerGlobalConfigs::O().parametersOfInterest).add(*arg);
     }
 
 }
@@ -1208,20 +1195,15 @@ void Combine::addNuisances(const RooArgSet *nuisances){
    // RooArgSet *nuisances = (RooArgSet*) w->set("nuisances");
     CascadeMinimizerGlobalConfigs::O().nuisanceParameters = RooArgList();
     if (nuisances != 0) {
-        TIterator *np = nuisances->createIterator();
-        while (RooAbsArg *arg = (RooAbsArg*)np->Next()) (CascadeMinimizerGlobalConfigs::O().nuisanceParameters).add(*arg);
+        for (RooAbsArg *arg : *nuisances) (CascadeMinimizerGlobalConfigs::O().nuisanceParameters).add(*arg);
     }
 
 }
 void Combine::addFloatingParameters(const RooArgSet &parameters){
     CascadeMinimizerGlobalConfigs::O().allFloatingParameters = RooArgList();
-    //if (parameters != 0) {
-        TIterator *np = parameters.createIterator();
-        while (RooAbsArg *arg = (RooAbsArg*)np->Next()) {
+        for (RooAbsArg *arg : parameters) {
 	 if (! arg->isConstant()) (CascadeMinimizerGlobalConfigs::O().allFloatingParameters).add(*arg);
         }
-    //}
-
 }
 void Combine::addDiscreteNuisances(RooWorkspace *w){
 
@@ -1231,8 +1213,7 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
     CascadeMinimizerGlobalConfigs::O().allRooMultiPdfParams = RooArgList();
 
     if (discreteParameters != 0) {
-        TIterator *dp = discreteParameters->createIterator();
-        while (RooAbsArg *arg = (RooAbsArg*)dp->Next()) {
+        for (RooAbsArg *arg : *discreteParameters) {
           RooCategory *cat = dynamic_cast<RooCategory*>(arg);
           if (cat && (!cat->isConstant() || runtimedef::get("ADD_DISCRETE_FALLBACK"))) {
 	        if (verbose){
@@ -1246,8 +1227,7 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
     // Run through all of the categories in the workspace and look for "pdfindex" -> fall back option 
     else if (runtimedef::get("ADD_DISCRETE_FALLBACK")) {
         RooArgSet discreteParameters_C = w->allCats();
-        TIterator *dp = discreteParameters_C.createIterator();
-        while (RooAbsArg *arg = (RooAbsArg*)dp->Next()) {
+        for (RooAbsArg *arg : discreteParameters_C) {
          RooCategory *cat = dynamic_cast<RooCategory*>(arg);
          if (! (std::string(cat->GetName()).find("pdfindex") != std::string::npos )) continue;
          if (cat/* && !cat->isConstant()*/) {
@@ -1262,14 +1242,11 @@ void Combine::addDiscreteNuisances(RooWorkspace *w){
     // Now lets go through the list of parameters which are associated to this discrete nuisance
     RooArgSet clients;
     utils::getClients(CascadeMinimizerGlobalConfigs::O().pdfCategories,(w->allPdfs()),clients);
-    TIterator *it = clients.createIterator();
-    // clients.Print();
-    while (RooAbsArg *arg = (RooAbsArg*)it->Next()) {
+    for (RooAbsArg *arg : clients) {
       (CascadeMinimizerGlobalConfigs::O().allRooMultiPdfs).add(*(dynamic_cast<RooMultiPdf*>(arg)));
       RooAbsPdf *pdf = dynamic_cast<RooAbsPdf*>(arg);
-      RooArgSet *pdfPars = pdf->getParameters((const RooArgSet*)0);
-      std::unique_ptr<TIterator> iter_v(pdfPars->createIterator());
-      for (RooAbsArg *a = (RooAbsArg *) iter_v->Next(); a != 0; a = (RooAbsArg *) iter_v->Next()) {
+      std::unique_ptr<RooArgSet> pdfPars{pdf->getParameters((const RooArgSet*)0)};
+      for (RooAbsArg *a : *pdfPars) {
 	RooRealVar *v = dynamic_cast<RooRealVar *>(a);
 	if (!v) continue;
 	if (! (v->isConstant())) (CascadeMinimizerGlobalConfigs::O().allRooMultiPdfParams).add(*v) ;
@@ -1289,8 +1266,7 @@ void Combine::addBranches(const std::string& trackString, RooWorkspace* w, std::
           std::regex rgx( reg_esp, std::regex::ECMAScript);
 
           RooArgSet allParams(w->allVars());
-          std::unique_ptr<TIterator> iter(allParams.createIterator());
-          for (RooAbsArg *a = (RooAbsArg*) iter->Next(); a != 0; a = (RooAbsArg*) iter->Next()) {
+          for (RooAbsArg *a : allParams) {
               Var *tmp = dynamic_cast<Var *>(a);
               if(tmp==nullptr) continue;
               const std::string &target = tmp->GetName();

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -1211,16 +1211,14 @@ void FitDiagnostics::getNormalizations(RooAbsPdf *pdf, const RooArgSet &obs, Roo
 //void FitDiagnostics::setFitResultTrees(const RooArgSet *args, std::vector<double> *vals){
 void FitDiagnostics::setFitResultTrees(const RooArgSet *args, double * vals){
 	
-         TIterator* iter(args->createIterator());
 	 int count=0;
 	 
-         for (TObject *a = iter->Next(); a != 0; a = iter->Next()) { 
+         for (RooAbsArg *a : *args) {
                  RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);        
 		 //std::string name = rrv->GetName();
 		 vals[count]=rrv->getVal();
 		 count++;
          }
-	 delete iter;
 	 return;
 }
 
@@ -1259,17 +1257,15 @@ void FitDiagnostics::resetFitResultTrees(bool withSys){
 }
 void FitDiagnostics::setNormsFitResultTrees(const RooArgSet *args, double * vals){
 	
-         TIterator* iter(args->createIterator());
 	 int count=0;
 	 
-         for (TObject *a = iter->Next(); a != 0; a = iter->Next()) { 
+         for (RooAbsArg *a : *args) {
                  RooRealVar *rcv = dynamic_cast<RooRealVar *>(a);   
 		 // std::cout << "index " << count << ", Name " << rcv->GetName() << ", val " <<  rcv->getVal() << std::endl;
 		 //std::string name = rcv->GetName();
 		 vals[count]=rcv->getVal();
 		 count++;
          }
-	 delete iter;
 	 return;
 }
 
@@ -1346,8 +1342,7 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 	  nuisanceParameters_= new double[nuis->getSize()];
 	  overallNuis_ = nuis->getSize();
 
-          TIterator* iter_c(cons->createIterator());
-          for (TObject *a = iter_c->Next(); a != 0; a = iter_c->Next()) { 
+          for (RooAbsArg * a : *cons) {
                  RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);        
 		 std::string name = rrv->GetName();
 		 globalObservables_[count]=0;
@@ -1357,8 +1352,7 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 		 count++;
 	  }         
 	  count = 0;
-          TIterator* iter_n(nuis->createIterator());
-          for (TObject *a = iter_n->Next(); a != 0; a = iter_n->Next()) { 
+          for (RooAbsArg * a : *nuis) {
                  RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);        
 		 std::string name = rrv->GetName();
 		 nuisanceParameters_[count] = 0;
@@ -1371,8 +1365,7 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
          }
 
 	 count = 0;
-         TIterator* iter_no(norms->createIterator());
-         for (TObject *a = iter_no->Next(); a != 0; a = iter_no->Next()) { 
+          for (RooAbsArg * a : *norms) {
                  RooRealVar *rcv = dynamic_cast<RooRealVar *>(a);        
 		 std::string name = rcv->GetName();
 		 processNormalizations_[count] = -999;

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -151,9 +151,8 @@ bool FitterAlgoBase::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
               break;
       }
 
-      std::unique_ptr<RooArgSet>  params(mc_s->GetPdf()->getParameters(data));
-      RooLinkedListIter iter = params->iterator(); int i = 0;
-      for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next(), ++i) {
+      ;
+      for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc_s->GetPdf()->getParameters(data)}) {
           RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
           if (rrv == 0 || rrv->isConstant()) continue;
           if (profileMode_ == ProfileUnconstrained && mc_s->GetNuisanceParameters()->find(*rrv) != 0) {
@@ -679,8 +678,7 @@ double FitterAlgoBase::findCrossingNew(CascadeMinimizer &minim, RooAbsReal &nll,
 
 void FitterAlgoBase::optimizeBounds(const RooWorkspace *w, const RooStats::ModelConfig *mc) {
     if (runtimedef::get("UNBOUND_GAUSSIANS") && mc->GetNuisanceParameters() != 0) {
-        RooLinkedListIter iter = mc->GetNuisanceParameters()->iterator();
-        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+        for (RooAbsArg *a : *mc->GetNuisanceParameters()) {
             RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
             if (rrv != 0) {
                 RooAbsPdf *pdf = w->pdf((std::string(a->GetName())+"_Pdf").c_str());
@@ -692,8 +690,7 @@ void FitterAlgoBase::optimizeBounds(const RooWorkspace *w, const RooStats::Model
         } 
     }
     if (runtimedef::get("OPTIMIZE_BOUNDS") && mc->GetNuisanceParameters() != 0) {
-        RooLinkedListIter iter = mc->GetNuisanceParameters()->iterator();
-        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+        for (RooAbsArg *a : *mc->GetNuisanceParameters()) {
             RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
             //std::cout << (rrv ? "Var" : "Arg") << ": " << a->GetName()  << ": " << a->getAttribute("optimizeBounds") << std::endl;
             if (rrv != 0 && rrv->getAttribute("optimizeBounds")) {
@@ -707,8 +704,7 @@ void FitterAlgoBase::optimizeBounds(const RooWorkspace *w, const RooStats::Model
 }
 void FitterAlgoBase::restoreBounds(const RooWorkspace *w, const RooStats::ModelConfig *mc) {
     if (runtimedef::get("OPTIMIZE_BOUNDS") && mc->GetNuisanceParameters() != 0) {
-        RooLinkedListIter iter = mc->GetNuisanceParameters()->iterator();
-        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+        for (RooAbsArg *a : *mc->GetNuisanceParameters()) {
             RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
             if (rrv != 0 && rrv->getAttribute("optimizeBounds")) {
                 rrv->setRange(rrv->getMin("optimizeBoundRange"), rrv->getMax("optimizeBoundRange"));

--- a/src/HWWLVJJRooPdfs.cc
+++ b/src/HWWLVJJRooPdfs.cc
@@ -16,16 +16,13 @@ RooChebyshevPDF::RooChebyshevPDF(const char *name, const char *title,
   x("x", "x", this, var),
   coefs("coefs", "coefs", this) {
 
-  TIterator *cx = coefList.createIterator();
-  RooAbsReal *coef;
-  while ((coef = (RooAbsReal*)cx->Next())) {
+  for (RooAbsArg * coef : coefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       std::cerr << "Coefficient " << coef->GetName() << " is not good." << std::endl;
       assert(0);
     }
     coefs.add(*coef);
   }
-  delete cx;
 }
 
 RooChebyshevPDF::RooChebyshevPDF(const RooChebyshevPDF& other, 
@@ -444,16 +441,13 @@ RooExpPoly::RooExpPoly(const char *name, const char *title,
   x("x","x",this,_x),
   coefs("coefs","coefs",this)
 {
-  TIterator *cx = _coefs.createIterator();
-  RooAbsReal *coef;
-  while ((coef = (RooAbsReal*)cx->Next())) {
+  for (RooAbsArg * coef : _coefs) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       std::cerr << "Coefficient " << coef->GetName() << " is not good." << std::endl;
       assert(0);
     }
     coefs.add(*coef);
   }
-  delete cx;
 }
 
 

--- a/src/HWWLVJRooPdfs.cxx
+++ b/src/HWWLVJRooPdfs.cxx
@@ -25,7 +25,6 @@
 #include "TString.h"
 #include "TRandom3.h"
 #include "TCanvas.h"
-#include "TIterator.h"
 #include "RooHist.h"
 #include "RooRealVar.h"
 #include "RooFitResult.h"

--- a/src/HZZ4L_RooCTauPdf_1D.cc
+++ b/src/HZZ4L_RooCTauPdf_1D.cc
@@ -31,16 +31,13 @@ _coefList("coefList", "List of funcficients", this),
 ctau_min(_ctau_min),
 ctau_max(_ctau_max)
 {
-	TIterator* coefIter = inCoefList.createIterator();
-	RooAbsArg* func;
-	while ((func = (RooAbsArg*)coefIter->Next())) {
+	for (RooAbsArg* func : inCoefList) {
 		if (!dynamic_cast<RooAbsReal*>(func)) {
 			coutE(InputArguments) << "ERROR: :HZZ4L_RooCTauPdf_1D(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << endl;
 			assert(0);
 		}
 		_coefList.add(*func);
 	}
-	delete coefIter;
 
 	nbins_ctau = _coefList.getSize();
 	for(int mp=0;mp<(nbins_ctau>101 ? 101 : nbins_ctau);mp++) Integral_T[mp] = dynamic_cast<const RooHistFunc*>(_coefList.at(mp))->analyticalIntegral(1000);

--- a/src/HZZ4L_RooCTauPdf_1D_Expanded.cc
+++ b/src/HZZ4L_RooCTauPdf_1D_Expanded.cc
@@ -42,9 +42,7 @@ nLinearVariations(nLinearVariations_)
   nCoef=0;
   nFuncs=0;
 
-  TIterator* coefIter = inCoefList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *coef : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       coutE(InputArguments) << "ERROR::HZZ4L_RooCTauPdf_1D_Expanded(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
@@ -52,7 +50,6 @@ nLinearVariations(nLinearVariations_)
     _coefList.add(*coef);
     nCoef++;
   }
-  delete coefIter;
 
   if (nCoef>2){
     coutE(InputArguments) << "ERROR::HZZ4L_RooCTauPdf_1D_Expanded(" << GetName() << ") number coefficients " << nCoef << " is not supported." << endl;
@@ -60,9 +57,7 @@ nLinearVariations(nLinearVariations_)
   }
 //  else cout << "Number of coefficients: " << nCoef << endl;
 
-  TIterator* funcIter = inFuncList.createIterator();
-	RooAbsArg* func;
-	while ((func = (RooAbsArg*)funcIter->Next())) {
+	for (RooAbsArg *func : inFuncList) {
 		if (!dynamic_cast<RooAbsReal*>(func)) {
 			coutE(InputArguments) << "ERROR::HZZ4L_RooCTauPdf_1D_Expanded(" << GetName() << ") function " << func->GetName() << " is not of type RooAbsReal" << endl;
 			assert(0);
@@ -70,7 +65,6 @@ nLinearVariations(nLinearVariations_)
 		_funcList.add(*func);
     nFuncs++;
   }
-	delete funcIter;
 
   if (nLinearVariations>nCoef){
     coutE(InputArguments) << "ERROR::HZZ4L_RooCTauPdf_1D_Expanded(" << GetName() << ") number of linear variations (" << nLinearVariations << ") is more than the number of coefficients (" << nCoef << ")!!!" << endl;

--- a/src/HZZ4L_RooCTauPdf_2D.cc
+++ b/src/HZZ4L_RooCTauPdf_2D.cc
@@ -33,16 +33,13 @@ _coefList("coefList", "List of funcficients", this),
 ctau_min(_ctau_min),
 ctau_max(_ctau_max)
 {
-	TIterator* coefIter = inCoefList.createIterator();
-	RooAbsArg* func;
-	while ((func = (RooAbsArg*)coefIter->Next())) {
+    for (RooAbsArg *func : inCoefList) {
 		if (!dynamic_cast<RooAbsReal*>(func)) {
 			coutE(InputArguments) << "ERROR: :HZZ4L_RooCTauPdf_2D(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << endl;
 			assert(0);
 		}
 		_coefList.add(*func);
 	}
-	delete coefIter;
 
 	nbins_ctau = _coefList.getSize();
 	Integral_T = new double[nbins_ctau];

--- a/src/HZZ4L_RooSpinZeroPdf.cc
+++ b/src/HZZ4L_RooSpinZeroPdf.cc
@@ -26,21 +26,17 @@ ClassImp(HZZ4L_RooSpinZeroPdf)
   _coefList("coefList","List of funcficients",this) 
   
  { 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg* func : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(func)) {
       coutE(InputArguments) << "ERROR: :HZZ4L_RooSpinZeroPdf(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*func) ;
   }
-  delete coefIter;
   
   Integral_T1 = dynamic_cast<const RooHistFunc*>(_coefList.at(0))-> analyticalIntegral(1000);
   Integral_T2 = dynamic_cast<const RooHistFunc*>(_coefList.at(1))-> analyticalIntegral(1000);
   Integral_T4 = dynamic_cast<const RooHistFunc*>(_coefList.at(2))-> analyticalIntegral(1000);
-// _coefIter = _coefList.createIterator() ;
  } 
 
 
@@ -55,7 +51,6 @@ ClassImp(HZZ4L_RooSpinZeroPdf)
 	 Integral_T1 = other.Integral_T1;
 	 Integral_T2 = other.Integral_T2;
 	 Integral_T4 = other.Integral_T4;
- // _coefIter = _coefList.createIterator() ;
  } 
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_1D.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_1D.cc
@@ -27,18 +27,13 @@ ClassImp(HZZ4L_RooSpinZeroPdf_1D)
   _coefList("coefList","List of funcficients",this) 
   
  { 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *func : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(func)) {
       coutE(InputArguments) << "ERROR: :HZZ4L_RooSpinZeroPdf_1D(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*func) ;
   }
-  delete coefIter;
-  
-  _coefIter = _coefList.createIterator() ;
  } 
 
 
@@ -51,7 +46,6 @@ ClassImp(HZZ4L_RooSpinZeroPdf_1D)
   _coefList("coefList",this,other._coefList)
 
  { 
-  _coefIter = _coefList.createIterator() ;
  } 
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_1D_fast.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_1D_fast.cc
@@ -28,27 +28,21 @@ HZZ4L_RooSpinZeroPdf_1D_fast::HZZ4L_RooSpinZeroPdf_1D_fast(
   obsList("obsList", "List of pdf observables", this),
   coefList("coefList", "List of pdf components", this)
 {
-  TIterator* coefIter = inObsList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inObsList) {
     if (!dynamic_cast<RooAbsReal*>(coef)){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_1D_fast(" << GetName() << ") observable " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
     }
     obsList.add(*coef);
   }
-  delete coefIter;
 
-  coefIter = inCoefList.createIterator();
-  coef=0;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inCoefList) {
     if (dynamic_cast<FastTemplateFunc_f*>(coef)==0 && dynamic_cast<FastTemplateFunc_d*>(coef)==0){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_1D_fast(" << GetName() << ") component " << coef->GetName() << " is not of type FastTemplateFunc_f" << endl;
       assert(0);
     }
     coefList.add(*coef);
   }
-  delete coefIter;
 }
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_2D.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_2D.cc
@@ -32,16 +32,13 @@ ClassImp(HZZ4L_RooSpinZeroPdf_2D)
   _coefList("coefList","List of funcficients",this) 
   
  { 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *func : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(func)) {
       coutE(InputArguments) << "ERROR: :HZZ4L_RooSpinZeroPdf_2D(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*func) ;
   }
-  delete coefIter;
 
   Integral_T1 = dynamic_cast<const RooHistFunc*>(_coefList.at(0))-> analyticalIntegral(1000);
   Integral_T2 = dynamic_cast<const RooHistFunc*>(_coefList.at(1))-> analyticalIntegral(1000);
@@ -52,8 +49,6 @@ ClassImp(HZZ4L_RooSpinZeroPdf_2D)
   Integral_T7 = dynamic_cast<const RooHistFunc*>(_coefList.at(6))-> analyticalIntegral(1000);
   Integral_T8 = dynamic_cast<const RooHistFunc*>(_coefList.at(7))-> analyticalIntegral(1000);
   Integral_T9 = dynamic_cast<const RooHistFunc*>(_coefList.at(8))-> analyticalIntegral(1000);
-
-// _coefIter = _coefList.createIterator() ;
  } 
 
 
@@ -78,8 +73,6 @@ ClassImp(HZZ4L_RooSpinZeroPdf_2D)
 	 Integral_T7 = other.Integral_T7;
 	 Integral_T8 = other.Integral_T8;
 	 Integral_T9 = other.Integral_T9;
-
- // _coefIter = _coefList.createIterator() ;
  } 
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_2D_fast.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_2D_fast.cc
@@ -37,27 +37,21 @@ HZZ4L_RooSpinZeroPdf_2D_fast::HZZ4L_RooSpinZeroPdf_2D_fast(
   obsList("obsList", "List of pdf observables", this),
   coefList("coefList", "List of pdf components", this)
 {
-  TIterator* coefIter = inObsList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inObsList) {
     if (!dynamic_cast<RooAbsReal*>(coef)){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_2D_fast(" << GetName() << ") observable " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
     }
     obsList.add(*coef);
   }
-  delete coefIter;
 
-  coefIter = inCoefList.createIterator();
-  coef=0;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inCoefList) {
     if (dynamic_cast<FastTemplateFunc_f*>(coef)==0 && dynamic_cast<FastTemplateFunc_d*>(coef)==0){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_2D_fast(" << GetName() << ") component " << coef->GetName() << " is not of type FastTemplateFunc_f" << endl;
       assert(0);
     }
     coefList.add(*coef);
   }
-  delete coefIter;
 }
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_phase.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_phase.cc
@@ -28,22 +28,18 @@ ClassImp(HZZ4L_RooSpinZeroPdf_phase)
   _coefList("coefList","List of funcficients",this) 
   
  { 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *func : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(func)) {
       coutE(InputArguments) << "ERROR: :HZZ4L_RooSpinZeroPdf_phase(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*func) ;
   }
-  delete coefIter;
 
   Integral_T1 = dynamic_cast<const RooHistFunc*>(_coefList.at(0))-> analyticalIntegral(1000);
   Integral_T2 = dynamic_cast<const RooHistFunc*>(_coefList.at(1))-> analyticalIntegral(1000);
   Integral_T4 = dynamic_cast<const RooHistFunc*>(_coefList.at(2))-> analyticalIntegral(1000);
   Integral_T5 = dynamic_cast<const RooHistFunc*>(_coefList.at(3))-> analyticalIntegral(1000);
-// _coefIter = _coefList.createIterator() ;
  } 
 
 
@@ -61,7 +57,6 @@ ClassImp(HZZ4L_RooSpinZeroPdf_phase)
 	 Integral_T2 = other.Integral_T2;
 	 Integral_T4 = other.Integral_T4;
 	 Integral_T5 = other.Integral_T5;
- // _coefIter = _coefList.createIterator() ;
  } 
 
 

--- a/src/HZZ4L_RooSpinZeroPdf_phase_fast.cc
+++ b/src/HZZ4L_RooSpinZeroPdf_phase_fast.cc
@@ -31,27 +31,21 @@ HZZ4L_RooSpinZeroPdf_phase_fast::HZZ4L_RooSpinZeroPdf_phase_fast(
   obsList("obsList", "List of pdf observables", this),
   coefList("coefList", "List of pdf components", this)
 {
-  TIterator* coefIter = inObsList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inObsList) {
     if (!dynamic_cast<RooAbsReal*>(coef)){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_phase_fast(" << GetName() << ") observable " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
     }
     obsList.add(*coef);
   }
-  delete coefIter;
 
-  coefIter = inCoefList.createIterator();
-  coef=0;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inCoefList) {
     if (dynamic_cast<FastTemplateFunc_f*>(coef)==0 && dynamic_cast<FastTemplateFunc_d*>(coef)==0){
       coutE(InputArguments) << "HZZ4L_RooSpinZeroPdf_phase_fast(" << GetName() << ") component " << coef->GetName() << " is not of type FastTemplateFunc_f" << endl;
       assert(0);
     }
     coefList.add(*coef);
   }
-  delete coefIter;
 }
 
 

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -313,9 +313,8 @@ bool HybridNew::runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s, Ro
     }
     if (saveHybridResult_) {
         TString name = TString::Format("HypoTestResult_mh%g",mass_);
-        RooLinkedListIter it = rValues_.iterator();
-        for (RooRealVar *rIn = (RooRealVar*) it.Next(); rIn != 0; rIn = (RooRealVar*) it.Next()) {
-            name += Form("_%s%g", rIn->GetName(), rIn->getVal());
+        for (RooAbsArg *rIn : rValues_) {
+            name += Form("_%s%g", rIn->GetName(), static_cast<RooRealVar*>(rIn)->getVal());
         }
         name += Form("_%u", RooRandom::integer(std::numeric_limits<UInt_t>::max() - 1));
         writeToysHere->WriteTObject(new HypoTestResult(*hcResult), name);
@@ -693,8 +692,8 @@ std::pair<double, double> HybridNew::eval(RooWorkspace *w, RooStats::ModelConfig
     }
 
     HybridNew::Setup setup;
-    RooLinkedListIter it = rVals.iterator();
-    for (RooRealVar *rIn = (RooRealVar*) it.Next(); rIn != 0; rIn = (RooRealVar*) it.Next()) {
+    for (RooAbsArg *rInAbsArg : rVals) {
+        RooRealVar *rIn = static_cast<RooRealVar*>(rInAbsArg);
         RooRealVar *r = dynamic_cast<RooRealVar *>(mc_s->GetParametersOfInterest()->find(rIn->GetName()));
         r->setVal(rIn->getVal());
         if (verbose) std::cout << "  " << r->GetName() << " = " << rIn->getVal() << " +/- " << r->getError() << std::endl;
@@ -811,8 +810,7 @@ std::unique_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, R
     // print the values of the parameters used to generate the toy
     if (verbose > 2) {
       CombineLogger::instance().log("HybridNew.cc",__LINE__,"Using the following (post-fit) parameters for No signal hypothesis ",__func__);
-      std::unique_ptr<TIterator> iter(paramsToFit->createIterator());
-      for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+      for (RooAbsArg *a : *paramsToFit) {
   	TString varstring = utils::printRooArgAsString(a);
   	CombineLogger::instance().log("HybridNew.cc",__LINE__,std::string(Form(" %s",varstring.Data())),__func__);
       }
@@ -839,8 +837,7 @@ std::unique_ptr<RooStats::HybridCalculator> HybridNew::create(RooWorkspace *w, R
       CombineLogger::instance().log("HybridNew.cc",__LINE__,"Using the following (post-fit) parameters for S+B hypothesis ",__func__);
       RooArgSet reportParams; 
       reportParams.add(*paramsToFit); reportParams.add(poi);
-      std::unique_ptr<TIterator> iter(reportParams.createIterator());
-      for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+      for (RooAbsArg *a : reportParams) {
   	TString varstring = utils::printRooArgAsString(a);
   	CombineLogger::instance().log("HybridNew.cc",__LINE__,std::string(Form(" %s",varstring.Data())),__func__);
       }
@@ -1148,9 +1145,8 @@ HybridNew::eval(RooStats::HybridCalculator &hc, const RooAbsCollection & rVals, 
     }
     if (saveHybridResult_) {
         TString name = TString::Format("HypoTestResult_mh%g",mass_);
-        RooLinkedListIter it = rVals.iterator();
-        for (RooRealVar *rIn = (RooRealVar*) it.Next(); rIn != 0; rIn = (RooRealVar*) it.Next()) {
-            name += Form("_%s%g", rIn->GetName(), rIn->getVal());
+        for (RooAbsArg * rIn : rVals) {
+            name += Form("_%s%g", rIn->GetName(), static_cast<RooRealVar*>(rIn)->getVal());
         }
         name += Form("_%u", RooRandom::integer(std::numeric_limits<UInt_t>::max() - 1));
         writeToysHere->WriteTObject(new HypoTestResult(*hcResult), name);
@@ -1454,8 +1450,8 @@ RooStats::HypoTestResult * HybridNew::readToysFromFile(const RooAbsCollection & 
     if (verbose) std::cout << "Reading toys for ";
     TString prefix1 = TString::Format("HypoTestResult_mh%g",mass_);
     TString prefix2 = TString::Format("HypoTestResult");
-    RooLinkedListIter it = rVals.iterator();
-    for (RooRealVar *rIn = (RooRealVar*) it.Next(); rIn != 0; rIn = (RooRealVar*) it.Next()) {
+    for (RooAbsArg *rInAbsArg : rVals) {
+        RooRealVar *rIn = static_cast<RooRealVar*>(rInAbsArg);
         if (verbose) std::cout << rIn->GetName() << " = " << rIn->getVal() << "   ";
         prefix1 += Form("_%s%g", rIn->GetName(), rIn->getVal());
         prefix2 += Form("_%s%g", rIn->GetName(), rIn->getVal());

--- a/src/MarkovChainMC.cc
+++ b/src/MarkovChainMC.cc
@@ -262,8 +262,7 @@ int MarkovChainMC::runOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStat
                 if (verbose > 1) { std::cout << "\nDiscrete model point " << (i+1) << std::endl; discreteModelPointSets_[i].Print("V"); }
             }
             RooArgSet discretePOI;
-            RooLinkedListIter iter = poi.iterator();
-            for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+            for (RooAbsArg *a : poi) {
                 if (discreteModelPointSets_[0].find(a->GetName())) discretePOI.add(*a);
             }
             if (verbose > 1) { std::cout << "Discrete POI: " ; discretePOI.Print(""); }

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -166,9 +166,8 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
     nOtherFloatingPoi_ = 0;
     deltaNLL_ = 0;
     int nConstPoi=0;
-    RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();
     std::string setConstPOI;
-    for (RooAbsArg *a = (RooAbsArg*) iterP.Next(); a != 0; a = (RooAbsArg*) iterP.Next()) {
+    for (RooAbsArg *a : *mc_s->GetParametersOfInterest()) {
         if (poiList_.contains(*a)) continue;
         RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
         if (rrv == 0) { std::cerr << "MultiDimFit: Parameter of interest " << a->GetName() << " which is not a RooRealVar will be ignored" << std::endl; continue; }
@@ -311,8 +310,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 
     RooArgSet mcPoi(*mc_s->GetParametersOfInterest());
     if (poi_.empty()) {
-        RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();
-        for (RooAbsArg *a = (RooAbsArg*) iterP.Next(); a != 0; a = (RooAbsArg*) iterP.Next()) {
+        for (RooAbsArg *a : *mc_s->GetParametersOfInterest()) {
             poi_.push_back(a->GetName());
         }
     }
@@ -372,8 +370,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 	    RooArgSet mcNuis(*mc_s->GetNuisanceParameters());
 	    if(saveSpecifiedNuis_=="all"){
 		    specifiedNuis_.clear();
-		    RooLinkedListIter iterN = mc_s->GetNuisanceParameters()->iterator();
-		    for (RooAbsArg *a = (RooAbsArg*) iterN.Next(); a != 0; a = (RooAbsArg*) iterN.Next()) {
+            for (RooAbsArg *a : *mc_s->GetNuisanceParameters()) {
 			    if (poiList_.contains(*a)) continue;
 			    specifiedNuis_.push_back(a->GetName());
 		    }
@@ -384,8 +381,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 		    while(token) {
 			    const RooArgSet* group = mc_s->GetWS()->set((std::string("group_") + token).data());
 			    if (group){
-				    RooLinkedListIter iterN = group->iterator();
-				    for (RooAbsArg *a = (RooAbsArg*) iterN.Next(); a != 0; a = (RooAbsArg*) iterN.Next()) {
+                    for (RooAbsArg *a : *group) {
 					    specifiedNuis_.push_back(a->GetName());
 				    }
 			    }else if (!poiList_.find(token)){
@@ -406,8 +402,7 @@ void MultiDimFit::initOnce(RooWorkspace *w, RooStats::ModelConfig *mc_s) {
 	    }
     }
     if(saveInactivePOI_){
-	    RooLinkedListIter iterP = mc_s->GetParametersOfInterest()->iterator();
-	    for (RooAbsArg *a = (RooAbsArg*) iterP.Next(); a != 0; a = (RooAbsArg*) iterP.Next()) {
+        for (RooAbsArg *a : *mc_s->GetParametersOfInterest()) {
 		    if (poiList_.contains(*a)) continue;
 		    if (specifiedList_.contains(*a)) continue;
 		    RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);

--- a/src/ProcessNormalization.cc
+++ b/src/ProcessNormalization.cc
@@ -59,26 +59,23 @@ void ProcessNormalization::addOtherFactor(RooAbsReal &factor) {
 Double_t ProcessNormalization::evaluate() const {
     double logVal = 0.0;
     if (thetaListVec_.empty()) {
-        RooFIter iterTheta = thetaList_.fwdIterator();
         std::vector<RooAbsReal *> & thetaListVec = const_cast<std::vector<RooAbsReal *>&>(thetaListVec_);
         thetaListVec.reserve(thetaList_.getSize());
-        for (RooAbsArg *a = iterTheta.next(); a != 0; a = iterTheta.next()) {
+        for (RooAbsArg *a : thetaList_) {
             thetaListVec.push_back(dynamic_cast<RooAbsReal *>(a));
         }
     }
     if (asymmThetaListVec_.empty()) {
-        RooFIter iterTheta = asymmThetaList_.fwdIterator();
         std::vector<RooAbsReal *> & asymmThetaListVec = const_cast<std::vector<RooAbsReal *>&>(asymmThetaListVec_);
         asymmThetaListVec.reserve(asymmThetaList_.getSize());
-        for (RooAbsArg *a = iterTheta.next(); a != 0; a = iterTheta.next()) {
+        for (RooAbsArg *a : asymmThetaList_) {
             asymmThetaListVec.push_back(dynamic_cast<RooAbsReal *>(a));
         }
     }
     if (otherFactorListVec_.empty()) {
-        RooFIter iterOther = otherFactorList_.fwdIterator();
         std::vector<RooAbsReal *> & otherFactorListVec = const_cast<std::vector<RooAbsReal *>&>(otherFactorListVec_);
         otherFactorListVec.reserve(otherFactorList_.getSize());
-        for (RooAbsArg *a = iterOther.next(); a != 0; a = iterOther.next()) {
+        for (RooAbsArg *a : otherFactorList_) {
             otherFactorListVec.push_back(dynamic_cast<RooAbsReal *>(a));
         }
     }

--- a/src/ProfiledLikelihoodRatioTestStatExt.cc
+++ b/src/ProfiledLikelihoodRatioTestStatExt.cc
@@ -152,8 +152,7 @@ ProfiledLikelihoodTestStatOpt::ProfiledLikelihoodTestStatOpt(
     DBG(DBG_PLTestStat_ctor, (std::cout << "All params: " << std::endl))  DBG(DBG_PLTestStat_ctor, (params_->Print("V")))
     DBG(DBG_PLTestStat_ctor, (std::cout << "Snapshot: " << std::endl))    DBG(DBG_PLTestStat_ctor, (snap_.Print("V")))
     DBG(DBG_PLTestStat_ctor, (std::cout << "POI: " << std::endl))         DBG(DBG_PLTestStat_ctor, (poi_.Print("V")))
-    RooLinkedListIter it = poi.iterator();
-    for (RooAbsArg *a = (RooAbsArg*) it.Next(); a != 0; a = (RooAbsArg*) it.Next()) {
+    for (RooAbsArg *a : poi) {
         // search for this poi in the parameters and in the snapshot
         RooAbsArg *ps = snap_.find(a->GetName());   
         RooAbsArg *pp = params_->find(a->GetName());

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -36,10 +36,8 @@ void RobustHesse::initialize() {
 
   // Get a list of the floating RooRealVars
   std::unique_ptr<RooArgSet> allpars(nll_->getParameters(RooArgSet()));
-  RooFIter iter = allpars->fwdIterator();
-  RooAbsArg *item;
   std::vector<Var> allVars;
-  while ((item = iter.next())) {
+  for (RooAbsArg *item : *allpars) {
     RooRealVar *rrv = dynamic_cast<RooRealVar*>(item);
     if (rrv && !rrv->isConstant()) {
       allVars.push_back(Var());
@@ -587,9 +585,7 @@ void RobustHesse::LoadHessianFromFile(std::string const& filename) {
 
 void RobustHesse::ProtectArgSet(RooArgSet const& set) {
   std::vector<std::string> names;
-  RooFIter iter = set.fwdIterator();
-  RooAbsArg *item;
-  while ((item = iter.next())) {
+  for (RooAbsArg *item : set) {
     RooRealVar *rrv = dynamic_cast<RooRealVar*>(item);
     if (rrv && !rrv->isConstant()) {
       names.push_back(rrv->GetName());

--- a/src/RooCheapProduct.cc
+++ b/src/RooCheapProduct.cc
@@ -6,8 +6,7 @@ RooCheapProduct::RooCheapProduct(const char *name, const char *title, const RooA
     terms_("!terms","Set of real product components",this),
     offset_(1.0)
 {
-    RooFIter iter = terms.fwdIterator();
-    for (RooAbsArg *a = iter.next(); a != 0; a = iter.next()) {
+    for (RooAbsArg *a : terms) {
         RooAbsReal *rar = dynamic_cast<RooAbsReal *>(a);
         if (!rar) { 
             throw std::invalid_argument(std::string("Component ")+a->GetName()+" of RooCheapProduct is a "+a->ClassName()); 
@@ -32,10 +31,9 @@ RooCheapProduct::RooCheapProduct(const RooCheapProduct& other, const char* name)
 Double_t RooCheapProduct::evaluate() const 
 {
     if (vterms_.empty()) {
-        RooFIter iter = terms_.fwdIterator();
         std::vector<RooAbsReal *> & vterms = const_cast<std::vector<RooAbsReal *>&>(vterms_);
         vterms.reserve(terms_.getSize());
-        for (RooAbsArg *a = iter.next(); a != 0; a = iter.next()) {
+        for (RooAbsArg *a : terms_) {
             vterms.push_back(dynamic_cast<RooAbsReal *>(a));
         }
     }

--- a/src/RooEFTScalingFunction.cc
+++ b/src/RooEFTScalingFunction.cc
@@ -1,4 +1,4 @@
-#include "HiggsAnalysis/CombinedLimit/interface/RooEFTScalingFunction.h"
+#include "../interface/RooEFTScalingFunction.h"
 
 ClassImp(RooEFTScalingFunction)
 
@@ -10,8 +10,7 @@ RooEFTScalingFunction::RooEFTScalingFunction(const char *name, const char *title
 {
 
     // Add Wilson coefficients to terms_ container
-    RooFIter iter = terms.fwdIterator();
-    for( RooAbsArg *a = iter.next(); a != 0; a = iter.next()) {
+    for (RooAbsArg *a : terms) {
         RooAbsReal *rar = dynamic_cast<RooAbsReal *>(a);
         if (!rar) {
             throw std::invalid_argument(std::string("Term ")+a->GetName()+" of RooEFTScalingFunction is a "+a->ClassName());

--- a/src/RooMorphingPdf.cc
+++ b/src/RooMorphingPdf.cc
@@ -48,11 +48,7 @@ RooMorphingPdf::RooMorphingPdf(const char* name, const char* title,
       mh_lo_(0.),
       mh_hi_(0.) {
   SetAxisInfo();
-  TIterator* pdf_iter = pdfs.createIterator();
-  RooAbsArg* pdf;
-  while ((pdf = reinterpret_cast<RooAbsArg*>(pdf_iter->Next())))
-    pdfs_.add(*pdf);
-  delete pdf_iter;
+  pdfs_.add(pdfs);
 }
 
 RooMorphingPdf::RooMorphingPdf(const RooMorphingPdf& other, const char* name)

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -24,11 +24,9 @@ RooMultiPdf::RooMultiPdf(const char *name, const char *title, RooCategory& _x, c
   c("_pdfs","The list of pdfs",this),
   x("_index","the pdf index",this,_x) 
 {
-  TIterator *pdfIter=_c.createIterator(); 
   int count=0;
 
-  RooAbsPdf *fPdf;
-  while ( (fPdf = (RooAbsPdf*) pdfIter->Next()) ){
+  for (RooAbsArg *fPdf : _c) {
 	c.add(*fPdf);
 	// This is done by the user BUT is there a way to do it at construction?
 	_x.defineType(Form("_pdf%d",count),count);//(fPdf->getParameters())->getSize());
@@ -54,10 +52,7 @@ RooMultiPdf::RooMultiPdf(const RooMultiPdf& other, const char* name) :
  fIndex=other.fIndex;
  nPdfs=other.nPdfs;
 
- TIterator *pdfIter=(other.c).createIterator();
-
- RooAbsPdf *fPdf;
- while ( (fPdf = (RooAbsPdf*) pdfIter->Next()) ){
+ for (RooAbsArg *fPdf : other.c) {
 	c.add(*fPdf);
   std::unique_ptr<RooArgSet> variables(fPdf->getVariables());
   std::unique_ptr<RooAbsCollection> nonConstVariables(variables->selectByAttrib("Constant", false));

--- a/src/RooParametricHist.cxx
+++ b/src/RooParametricHist.cxx
@@ -17,9 +17,6 @@
 #include "RooFit.h"
 
 #include "TFile.h"
-#include "TIterator.h"
-
-//using namespace RooFit ;
 
 ClassImp(RooParametricHist)
 
@@ -34,11 +31,7 @@ RooParametricHist::RooParametricHist(const char *name,
   pars("pars","pars",this)
   //SM_shape("SM_shape","SM_shape",this,_SM_shape),
 {
-  TIterator *varIter=_pars.createIterator();
-  RooAbsReal *fVar;
-  while ( (fVar = (RooAbsReal*)varIter->Next()) ){
-	pars.add(*fVar);
-  }
+  pars.add(_pars);
   if ( pars.getSize() != _shape.GetNbinsX() ){
 	std::cerr << " Warning, number of parameters not equal to number of bins in shape histogram! " << std::endl;
 	assert(0);
@@ -60,17 +53,8 @@ RooParametricHist::RooParametricHist(const RooParametricHist& other, const char*
   _hasMorphs=other._hasMorphs;
   _cval = other._cval;
 
-  TIterator *varIter=other.pars.createIterator();
-  RooAbsReal *fVar;
-  while ( (fVar = (RooAbsReal*) varIter->Next()) ){
-	pars.add(*fVar);
-  }
-
-  TIterator *cIter=other._coeffList.createIterator();
-  RooAbsReal *cVar;
-  while ( (cVar = (RooAbsReal*) cIter->Next()) ){
-  _coeffList.add(*cVar);
-  }
+  pars.add(other.pars);
+  _coeffList.add(other._coeffList);
 
   for(int i=0; i<=N_bins; i++) {
      bins.push_back(other.bins[i]);
@@ -109,11 +93,8 @@ RooArgList & RooParametricHist::getAllBinVars() const {
 
 double RooParametricHist::getFullSum() const {
     double sum=0;
-    TIterator *varIter=pars.createIterator();
-    RooAbsReal *fVar;
-    int i=0;
-    while ( (fVar = (RooAbsReal*) varIter->Next()) ){
-	  double thisVal = fVar->getVal();
+    for (int i = 0; i < pars.getSize(); ++i) {
+	  double thisVal = static_cast<RooAbsReal&>(pars[i]).getVal();
 	  if (_hasMorphs) thisVal*=evaluateMorphFunction(i);
 	  sum+=thisVal;
 	  i++;

--- a/src/RooParametricHist2D.cxx
+++ b/src/RooParametricHist2D.cxx
@@ -33,29 +33,13 @@ RooParametricHist2D::RooParametricHist2D( const char *name,
     pars("pars","pars",this)
     //SM_shape("SM_shape","SM_shape",this,_SM_shape),
 { 
-    // std::cout << "Constructing..." << std::endl;
-    // std::cout << "_pars size... " << _pars.getSize() << std::endl;
-    // std::cout << "_pars type... " << typeid(_pars.first()).name() << std::endl;
-
-    TIterator *varIter=_pars.createIterator(); 
-    RooAbsReal *fVar;
-    while ( (fVar = (RooAbsReal*)varIter->Next()) ){
-        // std::cout << "fVar type... " << typeid(fVar).name() << std::endl;
-        // std::cout << "*fVar type... " << typeid(*fVar).name() << std::endl;
-
-        pars.add(*fVar);
-    }
-
-    // std::cout << "Constructed..." << std::endl;
-    // std::cout << "pars size... " << pars.getSize() << std::endl;
-    // std::cout << "pars type... " << typeid(pars.first()).name() << std::endl;
+    pars.add(_pars);
 
     if ( pars.getSize() != _shape.GetNbinsY()*_shape.GetNbinsX() ){
         std::cout << " Warning, number of parameters not equal to number of bins in shape histogram! " << std::endl;
     }
     
     initializeBins(_shape);
-    // std::cout << "Bins initialized" << std::endl;
     
 //  initializeNorm();
     cval = -1; 
@@ -75,20 +59,7 @@ RooParametricHist2D::RooParametricHist2D( const RooParametricHist2D& other,
     N_bins_y = other.N_bins_y;
     //sum    = other.sum;
 
-    // std::cout << "Clone _pars size... " << other.pars.getSize() << std::endl;
-    // std::cout << "Clone other.pars.first() type... " << typeid(other.pars.first()).name() << std::endl;
-    // std::cout << "Clone *other.pars.first() type... " << typeid(*other.pars.first()).name() << std::endl;
-    // std::cout << "Clone &other.pars.first() type... " << typeid(&other.pars.first()).name() << std::endl;
-
-
-    TIterator *varIter=other.pars.createIterator(); 
-    RooAbsReal *fVar;
-    // std::cout << "Check 1" << std::endl;
-    while ( (fVar = (RooAbsReal*)varIter->Next()) ){
-        // std::cout << fVar->GetName() << ": " << typeid(&fVar).name() << std::endl;
-        pars.add(*fVar);
-    }
-    // std::cout << "Check 2" << std::endl;
+    pars.add(other.pars);
 
     for(int i=0; i<=N_bins_x; ++i) {
         bins_x.push_back(other.bins_x[i]);
@@ -136,13 +107,10 @@ void RooParametricHist2D::initializeBins(const TH2 &shape) const {
 }
 
 double RooParametricHist2D::getFullSum() const {
-    //std::cout << "Getting full sum" << std::endl;
     double sum=0;
 
-    TIterator *varIter=pars.createIterator(); 
-    RooAbsReal *fVar;
-    while ( (fVar = (RooAbsReal*)varIter->Next()) ){
-        sum+=fVar->getVal();
+    for (RooAbsArg *arg : pars) {
+        sum += static_cast<RooAbsReal*>(arg)->getVal();
     }
 
     return sum;

--- a/src/RooParametricShapeBinPdf.cc
+++ b/src/RooParametricShapeBinPdf.cc
@@ -47,11 +47,7 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const char *name, const char 
   xMin(0)
 {
   memset(&xArray, 0, sizeof(xArray));
-  TIterator *varIter=_pars.createIterator(); 
-  RooAbsReal *fVar;
-  while ( (fVar = (RooAbsReal*)varIter->Next()) ){
-    pars.add(*fVar);
-  }
+  pars.add(_pars);
   setTH1Binning(_shape);
   RooAbsReal* myintegral;
 
@@ -93,18 +89,8 @@ RooParametricShapeBinPdf::RooParametricShapeBinPdf(const RooParametricShapeBinPd
     xArray[i] = other.xArray[i];
   }
   
-  TIterator *varIter=other.pars.createIterator(); 
-  RooAbsReal *fVar;
-  while ( (fVar = (RooAbsReal*) varIter->Next()) ){
-    pars.add(*fVar);
-  }
-
-  TIterator *intIter=other.myintegrals.createIterator(); 
-  RooAbsReal *fInt;
-  while ( (fInt = (RooAbsReal*) intIter->Next()) ){
-    myintegrals.add(*fInt);
-  }
-  
+  pars.add(other.pars);
+  myintegrals.add(other.myintegrals);
 }
 //---------------------------------------------------------------------------
 void RooParametricShapeBinPdf::setTH1Binning(const TH1 &_Hnominal){

--- a/src/RooSimultaneousOpt.cc
+++ b/src/RooSimultaneousOpt.cc
@@ -31,8 +31,7 @@ RooSimultaneousOpt::addExtraConstraints(const RooAbsCollection &pdfs)
         _extraConstraints.add(pdfs);
     } else {
         // slow
-        RooLinkedListIter iter = pdfs.iterator();
-        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+        for (RooAbsArg *a : pdfs) {
             if (!_extraConstraints.contains(*a)) _extraConstraints.add(*a);
         }
     }

--- a/src/RooSplineND.cc
+++ b/src/RooSplineND.cc
@@ -23,9 +23,8 @@ RooSplineND::RooSplineND(const char *name, const char *title, RooArgList &vars, 
 
   float *b_map = new float(ndim_);
 
-  RooAbsReal *rIt;	
-  TIterator *iter = vars.createIterator(); int it_c=0;
-  while( (rIt = (RooAbsReal*) iter->Next()) ){ 
+  int it_c=0;
+  for (RooAbsArg *rIt : vars) {
     vars_.add(*rIt);
     std::vector<double >tmpv(M_,0); 
     v_map.insert(std::pair<int, std::vector<double> >(it_c,tmpv));
@@ -75,11 +74,7 @@ RooSplineND::RooSplineND(const RooSplineND& other, const char *name) :
   eps_  = other.eps_;
   axis_pts_ = other.axis_pts_;
 
-  RooAbsReal *rIt;	
-  TIterator *iter = other.vars_.createIterator();
-  while( (rIt = (RooAbsReal*) iter->Next()) ){ 
-    vars_.add(*rIt);
-  }
+  vars_.add(other.vars_);
 
   w_mean = other.w_mean;
   w_rms  = other.w_rms;
@@ -113,11 +108,7 @@ RooSplineND::RooSplineND(const char *name, const char *title, const RooListProxy
  int ndim, int M, double eps, bool rescale, std::vector<double> &w, std::map<int,std::vector<double> > &map, std::map<int,std::pair<double,double> > &rmap,double wmean, double wrms) :
  RooAbsReal(name, title),vars_("vars",this,RooListProxy()) 
 {
-  RooAbsReal *rIt;	
-  TIterator *iter = vars.createIterator();
-  while( (rIt = (RooAbsReal*) iter->Next()) ){ 
-    vars_.add(*rIt);
-  }
+  vars_.add(vars);
   ndim_ = ndim;
   M_    = M;
   eps_  = eps;

--- a/src/SimpleCacheSentry.cc
+++ b/src/SimpleCacheSentry.cc
@@ -31,8 +31,7 @@ SimpleCacheSentry::SimpleCacheSentry(const SimpleCacheSentry &other, const char 
 
 void SimpleCacheSentry::addVars(const RooAbsCollection &vars) 
 {
-    TIterator *iter = vars.createIterator();
-    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    for (RooAbsArg* a : vars) {
         if (_deps.containsInstance(*a)) continue;
         // RooRealVars can return true to isDerived() if the ranges or binning depend on
         // other parameters, so always add RooRealVars to the list
@@ -44,7 +43,6 @@ void SimpleCacheSentry::addVars(const RooAbsCollection &vars)
           _deps.add(*a);
         }
     }
-    delete iter;
 }
 
 void SimpleCacheSentry::addFunc(const RooAbsArg &func, const RooArgSet *obs) 

--- a/src/SimpleProdPdf.cc
+++ b/src/SimpleProdPdf.cc
@@ -10,9 +10,7 @@ SimpleProdPdf::SimpleProdPdf() : RooAbsPdf() {}
 
 SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooArgList const& pdfList)
     : RooAbsPdf(name, title), _pdfList("!pdfs", "List of PDFs", this) {
-  RooFIter iter = pdfList.fwdIterator();
-  RooAbsArg* arg;
-  while ((arg = (RooAbsArg*)iter.next())) {
+  for (RooAbsArg *arg : pdfList) {
     RooAbsPdf* pdf = dynamic_cast<RooAbsPdf*>(arg);
     if (!pdf) {
       coutW(InputArguments) << "SimpleProdPdf::SimpleProdPdf(" << GetName() << ") list arg "
@@ -27,10 +25,8 @@ SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooArgList con
 SimpleProdPdf::SimpleProdPdf(const char* name, const char* title, RooArgList& pdfList,
                              std::vector<int> const& pdfSettings)
     : RooAbsPdf(name, title), _pdfList("!pdfs", "List of PDFs", this) {
-  RooFIter iter = pdfList.fwdIterator();
-  RooAbsArg* arg;
   int iSetting = -1;
-  while ((arg = (RooAbsArg*)iter.next())) {
+  for (RooAbsArg *arg : pdfList) {
     ++iSetting;
     RooAbsPdf* pdf = dynamic_cast<RooAbsPdf*>(arg);
     if (!pdf) {
@@ -130,10 +126,8 @@ void SimpleProdPdf::printMetaArgs(std::ostream& os) const
 
 std::list<Double_t>* SimpleProdPdf::binBoundaries(RooAbsRealLValue& obs, Double_t xlo,
                                                   Double_t xhi) const {
-  RooAbsPdf* pdf;
-  RooFIter pdfIter = _pdfList.fwdIterator();
-  while ((pdf = (RooAbsPdf*)pdfIter.next())) {
-    std::list<Double_t>* hint = pdf->binBoundaries(obs, xlo, xhi);
+  for (RooAbsArg *pdf : _pdfList) {
+    std::list<Double_t>* hint = static_cast<RooAbsPdf*>(pdf)->binBoundaries(obs, xlo, xhi);
     if (hint) {
       return hint;
     }

--- a/src/SimplerLikelihoodRatioTestStatExt.cc
+++ b/src/SimplerLikelihoodRatioTestStatExt.cc
@@ -56,11 +56,10 @@ SimplerLikelihoodRatioTestStatOpt::Evaluate(RooAbsData& data, RooArgSet& nullPOI
     if (paramsAlt_.get() == 0)  paramsAlt_.reset(pdfAlt_->getParameters(data));
 
     // if the dataset is not empty, redirect pdf nodes to the dataset
-    std::unique_ptr<TIterator> iterDepObs(pdfDepObs_.createIterator());
     bool nonEmpty = data.numEntries() > 0;
     if (nonEmpty) {
         const RooArgSet *entry = data.get(0);
-        for (RooAbsArg *a = (RooAbsArg *) iterDepObs->Next(); a != 0; a = (RooAbsArg *) iterDepObs->Next()) {
+        for (RooAbsArg *a : pdfDepObs_) {
             a->redirectServers(*entry);    
         }
     }
@@ -76,8 +75,7 @@ SimplerLikelihoodRatioTestStatOpt::Evaluate(RooAbsData& data, RooArgSet& nullPOI
 
     // put back links in pdf nodes, otherwise if the dataset goes out of scope they have dangling pointers
     if (nonEmpty) {
-        iterDepObs->Reset();
-        for (RooAbsArg *a = (RooAbsArg *) iterDepObs->Next(); a != 0; a = (RooAbsArg *) iterDepObs->Next()) {
+        for (RooAbsArg *a : pdfDepObs_) {
             a->redirectServers(*obs_);    
         }
     }

--- a/src/TestProposal.cc
+++ b/src/TestProposal.cc
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
-#include <TIterator.h>
 #include <RooRandom.h>
 #include <RooStats/RooStatsUtils.h>
 
@@ -31,11 +30,10 @@ TestProposal::TestProposal(double divisor, const RooArgList &alwaysStepMe) :
 void TestProposal::Propose(RooArgSet& xPrime, RooArgSet& x )
 {
    RooStats::SetParameters(&x, &xPrime);
-   RooLinkedListIter it(xPrime.iterator());
-   RooRealVar* var;
    int n = xPrime.getSize(), j = floor(RooRandom::uniform()*n);
    const RooRealVar *indicatorPrime = discreteModelIndicator_ ? (RooRealVar*)xPrime.find(discreteModelIndicator_->GetName()) : 0;
-   for (int i = 0; (var = (RooRealVar*)it.Next()) != NULL; ++i) {
+   for (int i = 0; i < xPrime.getSize(); ++i) {
+      RooRealVar* var = static_cast<RooRealVar*>(xPrime[i]);
       if (i == j) {
         if (alwaysStepMe_.contains(*var)) break; // don't step twice
         if (discreteModelIndicator_ != 0) {
@@ -55,8 +53,7 @@ void TestProposal::Propose(RooArgSet& xPrime, RooArgSet& x )
         break;
       }
    }
-   it = alwaysStepMe_.iterator();
-   for (RooRealVar *poi = (RooRealVar*)it.Next(); poi != NULL; poi = (RooRealVar*)it.Next()) {
+   for (RooAbsArg *poi : alwaysStepMe_) {
         RooRealVar *var = (RooRealVar*) xPrime.find(poi->GetName());
         if (var == 0) {
             std::cout << "ERROR: missing POI " << poi->GetName() << " in xPrime" << std::endl;

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -145,8 +145,7 @@ toymcoptutils::SinglePdfGenInfo::generateAsimov(RooRealVar *&weightVar, double w
     if (boostAPA>0) {  // trigger adaptive PA (setting boostAPA=1 will just use internal logic)
         if ( verbose > 0 ) CombineLogger::instance().log("ToyMCSamplerOpt.cc",__LINE__, "Using internal logic for binned/unbinned Asimov dataset generation",__func__);
         int nbins = 1;
-        RooLinkedListIter iter = observables_.iterator(); 
-        for (RooAbsArg *a = (RooAbsArg *) iter.Next(); a != 0; a = (RooAbsArg *) iter.Next()) {
+        for (RooAbsArg *a : observables_) {
             RooRealVar *rrv = dynamic_cast<RooRealVar *>(a); 
             int mybins = rrv->getBins();
             nbins *= (mybins ? mybins : 100);
@@ -283,8 +282,7 @@ toymcoptutils::SinglePdfGenInfo::generateCountingAsimov()
 void
 toymcoptutils::SinglePdfGenInfo::setToExpected(RooProdPdf &prod, RooArgSet &obs) 
 {
-    std::unique_ptr<TIterator> iter(prod.pdfList().createIterator());
-    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    for (RooAbsArg *a : prod.pdfList()) {
         if (!a->dependsOn(obs)) continue;
         RooPoisson *pois = 0;
         if ((pois = dynamic_cast<RooPoisson *>(a)) != 0) {
@@ -302,8 +300,7 @@ toymcoptutils::SinglePdfGenInfo::setToExpected(RooPoisson &pois, RooArgSet &obs)
 {
     RooRealVar *myobs = 0;
     RooAbsReal *myexp = 0;
-    std::unique_ptr<TIterator> iter(pois.serverIterator());
-    for (RooAbsArg *a = (RooAbsArg *) iter->Next(); a != 0; a = (RooAbsArg *) iter->Next()) {
+    for (RooAbsArg *a : pois.servers()) {
         if (obs.contains(*a)) {
             assert(myobs == 0 && "SinglePdfGenInfo::setToExpected(RooPoisson): Two observables??");
             myobs = dynamic_cast<RooRealVar *>(a);

--- a/src/VBFHZZ4L_RooSpinZeroPdf.cc
+++ b/src/VBFHZZ4L_RooSpinZeroPdf.cc
@@ -34,23 +34,19 @@ ClassImp(VBFHZZ4L_RooSpinZeroPdf)
    ai("ai","ai",this,_ai),
   _coefList("coefList","List of funcficients",this)
  {
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *func : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(func)) {
       coutE(InputArguments) << "ERROR: :VBFHZZ4L_RooSpinZeroPdf(" << GetName() << ") funcficient " << func->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*func) ;
   }
-  delete coefIter;
 
   Integral_T1 = dynamic_cast<const RooHistFunc*>(_coefList.at(0))-> analyticalIntegral(1000);
   Integral_T2 = dynamic_cast<const RooHistFunc*>(_coefList.at(1))-> analyticalIntegral(1000);
   Integral_T3 = dynamic_cast<const RooHistFunc*>(_coefList.at(2))-> analyticalIntegral(1000);
   Integral_T4 = dynamic_cast<const RooHistFunc*>(_coefList.at(3))-> analyticalIntegral(1000);
   Integral_T5 = dynamic_cast<const RooHistFunc*>(_coefList.at(4))-> analyticalIntegral(1000);
-// _coefIter = _coefList.createIterator() ;
  }
 
 

--- a/src/VBFHZZ4L_RooSpinZeroPdf_fast.cc
+++ b/src/VBFHZZ4L_RooSpinZeroPdf_fast.cc
@@ -31,27 +31,21 @@ VBFHZZ4L_RooSpinZeroPdf_fast::VBFHZZ4L_RooSpinZeroPdf_fast(
   obsList("obsList", "List of pdf observables", this),
   coefList("coefList", "List of pdf components", this)
 {
-  TIterator* coefIter = inObsList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inObsList) {
     if (!dynamic_cast<RooAbsReal*>(coef)){
       coutE(InputArguments) << "VBFHZZ4L_RooSpinZeroPdf_fast(" << GetName() << ") observable " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
     }
     obsList.add(*coef);
   }
-  delete coefIter;
 
-  coefIter = inCoefList.createIterator();
-  coef=0;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inCoefList) {
     if (dynamic_cast<FastTemplateFunc_f*>(coef)==0 && dynamic_cast<FastTemplateFunc_d*>(coef)==0){
       coutE(InputArguments) << "VBFHZZ4L_RooSpinZeroPdf_fast(" << GetName() << ") component " << coef->GetName() << " is not of type FastTemplateFunc_f" << endl;
       assert(0);
     }
     coefList.add(*coef);
   }
-  delete coefIter;
 }
 
 

--- a/src/VVHZZ4L_RooSpinZeroPdf_1D_fast.cc
+++ b/src/VVHZZ4L_RooSpinZeroPdf_1D_fast.cc
@@ -28,27 +28,21 @@ VVHZZ4L_RooSpinZeroPdf_1D_fast::VVHZZ4L_RooSpinZeroPdf_1D_fast(
   obsList("obsList", "List of pdf observables", this),
   coefList("coefList", "List of pdf components", this)
 {
-  TIterator* coefIter = inObsList.createIterator();
-  RooAbsArg* coef;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inObsList) {
     if (!dynamic_cast<RooAbsReal*>(coef)){
       coutE(InputArguments) << "VVHZZ4L_RooSpinZeroPdf_1D_fast(" << GetName() << ") observable " << coef->GetName() << " is not of type RooAbsReal" << endl;
       assert(0);
     }
     obsList.add(*coef);
   }
-  delete coefIter;
 
-  coefIter = inCoefList.createIterator();
-  coef=0;
-  while ((coef = (RooAbsArg*)coefIter->Next())){
+  for (RooAbsArg *coef : inCoefList) {
     if (dynamic_cast<FastTemplateFunc_f*>(coef)==0 && dynamic_cast<FastTemplateFunc_d*>(coef)==0){
       coutE(InputArguments) << "VVHZZ4L_RooSpinZeroPdf_1D_fast(" << GetName() << ") component " << coef->GetName() << " is not of type FastTemplateFunc_f" << endl;
       assert(0);
     }
     coefList.add(*coef);
   }
-  delete coefIter;
 }
 
 

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -6,7 +6,6 @@
 #include "RooFit.h"
 #include "Riostream.h"
 
-#include "TIterator.h"
 #include "RooRealVar.h"
 #include "RooMsgService.h"
 #include "RooAbsData.h"
@@ -103,8 +102,6 @@ VerticalInterpHistPdf::VerticalInterpHistPdf() :
    _cacheSingleGood(0) 
 {
   // Default constructor
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter  = _coefList.createIterator() ;
 }
 
 
@@ -127,9 +124,7 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const char *name, const char *title
     assert(0);
   }
 
-  TIterator* funcIter = inFuncList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)funcIter->Next())) {
+  for (RooAbsArg *func : inFuncList) {
     RooAbsPdf *pdf = dynamic_cast<RooAbsPdf*>(func);
     if (!pdf) {
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") function  " << func->GetName() << " is not of type RooAbsPdf" << std::endl;
@@ -143,22 +138,14 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const char *name, const char *title
     delete params;
     _funcList.add(*func) ;
   }
-  delete funcIter;
 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* coef;
-  while((coef = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *coef : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*coef) ;    
   }
-  delete coefIter;
-
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
-
 }
 
 
@@ -177,9 +164,6 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const VerticalInterpHistPdf& other,
   _cacheSingleGood(0) 
 {
   // Copy constructor
-
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
 }
 
 
@@ -188,8 +172,6 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const VerticalInterpHistPdf& other,
 VerticalInterpHistPdf::~VerticalInterpHistPdf()
 {
   // Destructor
-  delete _funcIter ;
-  delete _coefIter ;
   if (_cacheTotal) {
       delete _cacheTotal;
       for (int i = 0; i < _funcList.getSize(); ++i) delete _cacheSingle[i]; 
@@ -254,11 +236,11 @@ void VerticalInterpHistPdf::syncTotal() const {
     }
     for (int b = 1, nb = _cacheTotal->GetNbinsX(); b <= nb; ++b) {
         double val = _cacheSingle[0]->GetBinContent(b);
-        _coefIter->Reset();
-        for (int i = 0; i < ndim; ++i) {
+        int i = 0;
+        for (RooAbsArg *coef : _coefList) {
             double dhi = _cacheSingle[2*i+1]->GetBinContent(b);
             double dlo = _cacheSingle[2*i+2]->GetBinContent(b);
-            double x = (dynamic_cast<RooAbsReal *>(_coefIter->Next()))->getVal();
+            double x = dynamic_cast<RooAbsReal *>(coef)->getVal();
             double alpha = x * 0.5 * ((dhi-dlo) + (dhi+dlo)*smoothStepFunc(x));
             // alpha(0) = 0
             // alpha(+1) = dhi 
@@ -271,6 +253,7 @@ void VerticalInterpHistPdf::syncTotal() const {
             } else {
                 val += alpha; 
             }
+            ++i;
         }    
         if (val <= 0) val = 1e-9;
         _cacheTotal->SetBinContent(b, val);
@@ -306,8 +289,6 @@ ClassImp(FastVerticalInterpHistPdf3D)
 FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase() 
 {
   // Default constructor
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter  = _coefList.createIterator() ;
 }
 
 
@@ -329,9 +310,7 @@ FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase(const char *name, c
     assert(0);
   }
 
-  TIterator* funcIter = inFuncList.createIterator() ;
-  RooAbsArg* func;
-  while((func = (RooAbsArg*)funcIter->Next())) {
+  for (RooAbsArg *func : inFuncList) {
     RooAbsPdf *pdf = dynamic_cast<RooAbsPdf*>(func);
     if (!pdf) {
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") function  " << func->GetName() << " is not of type RooAbsPdf" << std::endl;
@@ -345,22 +324,14 @@ FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase(const char *name, c
     delete params;
     _funcList.add(*func) ;
   }
-  delete funcIter;
 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* coef;
-  while((coef = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg *coef : inCoefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal" << std::endl;
       assert(0);
     }
     _coefList.add(*coef) ;    
   }
-  delete coefIter;
-
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
-
 }
 
 //_____________________________________________________________________________
@@ -374,20 +345,13 @@ FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase(const FastVerticalI
   _morphs(other._morphs), _morphParams(other._morphParams)
 {
   // Copy constructor
-  _funcIter  = _funcList.createIterator() ;
-  _coefIter = _coefList.createIterator() ;
   _sentry.addVars(_coefList);
   _sentry.setValueDirty(); 
 }
 
 
 //_____________________________________________________________________________
-FastVerticalInterpHistPdfBase::~FastVerticalInterpHistPdfBase()
-{
-  // Destructor
-  delete _funcIter ;
-  delete _coefIter ;
-}
+FastVerticalInterpHistPdfBase::~FastVerticalInterpHistPdfBase() = default;
 
 
 //_____________________________________________________________________________
@@ -627,12 +591,13 @@ void FastVerticalInterpHistPdf::setupCaches() const {
     _morphParams.resize(ndim);
     syncNominal();
     //printf("Nominal template has been set up: \n");  _cacheNominal.Dump();
-    _coefIter->Reset();
-    for (int i = 0; i < ndim; ++i) {
-        _morphParams[i] = dynamic_cast<RooAbsReal *>(_coefIter->Next());
+    int i = 0;
+    for (RooAbsArg *a : _coefList) {
+        _morphParams[i] = dynamic_cast<RooAbsReal *>(a);
         _morphs[i].sum.Resize(_cacheNominal.size());
         _morphs[i].diff.Resize(_cacheNominal.size());
         syncComponents(i);
+        ++i;
     } 
     _cache = FastHisto(_cacheNominal);
 
@@ -648,12 +613,13 @@ void FastVerticalInterpHistPdf2D::setupCaches() const {
     _morphParams.resize(ndim);
     syncNominal();
     //printf("Nominal template has been set up: \n");  _cacheNominal.Dump();
-    _coefIter->Reset();
-    for (int i = 0; i < ndim; ++i) {
-        _morphParams[i] = dynamic_cast<RooAbsReal *>(_coefIter->Next());
+    int i = 0;
+    for (RooAbsArg *a : _coefList) {
+        _morphParams[i] = dynamic_cast<RooAbsReal *>(a);
         _morphs[i].sum.Resize(_cacheNominal.size());
         _morphs[i].diff.Resize(_cacheNominal.size());
         syncComponents(i);
+        ++i;
     } 
     _cache = FastHisto2D(_cacheNominal);
 
@@ -668,12 +634,13 @@ void FastVerticalInterpHistPdf3D::setupCaches() const {
     _morphParams.resize(ndim);
     syncNominal();
     //printf("Nominal template has been set up: \n");  _cacheNominal.Dump();
-    _coefIter->Reset();
-    for (int i = 0; i < ndim; ++i) {
-        _morphParams[i] = dynamic_cast<RooAbsReal *>(_coefIter->Next());
+    int i = 0;
+    for (RooAbsArg *a : _coefList) {
+        _morphParams[i] = dynamic_cast<RooAbsReal *>(a);
         _morphs[i].sum.Resize(_cacheNominal.size());
         _morphs[i].diff.Resize(_cacheNominal.size());
         syncComponents(i);
+        ++i;
     } 
     _cache = FastHisto3D(_cacheNominal);
 
@@ -786,21 +753,17 @@ FastVerticalInterpHistPdf2Base::FastVerticalInterpHistPdf2Base(const char *name,
       assert(0);
     }
     if (pdf) {
-        RooArgSet *params = pdf->getParameters(obs);
+        std::unique_ptr<RooArgSet> params{pdf->getParameters(obs)};
         if (params->getSize() > 0) {
           coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") pdf  " << func->GetName() << " (" << func->ClassName()<<") has some parameters." << std::endl;
           obs.Print("");
           params->Print("");
           assert(0);
         }
-        delete params;
     }
   }
 
-  TIterator* coefIter = inCoefList.createIterator() ;
-  RooAbsArg* coef;
-  while((coef = (RooAbsArg*)coefIter->Next())) _coefList.add(*coef) ;    
-  delete coefIter;
+  _coefList.add(inCoefList);
 }
 
 //_____________________________________________________________________________
@@ -851,9 +814,7 @@ FastVerticalInterpHistPdf2Base::initBase() const
 {
     if (_initBase) return;
 
-    TIterator* coefIter = _coefList.createIterator() ;
-    RooAbsArg* coef;
-    while((coef = (RooAbsArg*)coefIter->Next())) {
+    for (RooAbsArg *coef : _coefList) {
         const RooAbsReal *rrv = dynamic_cast<RooAbsReal*>(coef);
         if (!rrv) {
             coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") coefficient " << coef->GetName() << " is not of type RooAbsReal" << std::endl;
@@ -861,8 +822,6 @@ FastVerticalInterpHistPdf2Base::initBase() const
         }
         _morphParams.push_back(rrv);
     }
-    delete coefIter;
-
 
     _sentry.addVars(_coefList);
     _sentry.setValueDirty(); 


### PR DESCRIPTION
The legacy iterators are deprecated since ROOT 6.18 and they will be removed at some point.

This commit also fixes a few memory leaks, and it might also benefit the performance a bit because the legacy iterators had quite some overhead.

After being work in progress for a bit, this PR is now done from my side and ready for review by @kcormi and @anigamova.