### PR TITLE
Don't do public accessor workarounds if not needed

### DIFF
--- a/interface/utils.h
+++ b/interface/utils.h
@@ -56,8 +56,10 @@ namespace utils {
 
     /// factorize a RooAbsReal
     void factorizeFunc(const RooArgSet &observables, RooAbsReal &pdf, RooArgList &obsTerms, RooArgList &otherTerms, bool keepDuplicates = true, bool debug=false);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,28,0)
     /// workaround for RooProdPdf::components()
     RooArgList factors(const RooProduct &prod) ;
+#endif
 
     /// Note: doesn't recompose Simultaneous pdfs properly, for that use factorizePdf method
     RooAbsPdf *makeObsOnlyPdf(RooStats::ModelConfig &model, const char *name="obsPdf") ;

--- a/src/CachingMultiPdf.cc
+++ b/src/CachingMultiPdf.cc
@@ -134,7 +134,11 @@ void cacheutils::CachingAddPdf::setIncludeZeroWeights(bool includeZeroWeights)
 cacheutils::CachingProduct::CachingProduct(const RooProduct &pdf, const RooArgSet &obs) :
     pdf_(&pdf)
 {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,28,0)
     const RooArgList & pdfs = utils::factors(pdf);
+#else
+    const RooArgList & pdfs = pdf.realComponents();
+#endif
     //std::cout << "Making a CachingProduct for " << pdf.GetName() << " with " << pdfs.getSize() << " pdfs, " << coeffs.getSize() << " coeffs." << std::endl;
     for (int i = 0, n = pdfs.getSize(); i < n; ++i) {
         RooAbsReal *pdfi = (RooAbsReal*) pdfs.at(i);


### PR DESCRIPTION
Some public accessor hacks are now hidden behind preprocessor macros. This will serve as a reminder to remove these workarounds in the far future when combine doesn't support old ROOT versions anymore.