### PR TITLE
Don't use `getParameters()` inline in range-based loop

### DIFF
--- a/src/AsimovUtils.cc
+++ b/src/AsimovUtils.cc
@@ -20,7 +20,8 @@ RooAbsData *asimovutils::asimovDatasetNominal(RooStats::ModelConfig *mc, double 
 
 	if (verbose>2) {
 	    CombineLogger::instance().log("AsimovUtils.cc",__LINE__,"Parameters after fit for asimov dataset",__func__);
-    	    for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc->GetPdf()->getParameters((const RooArgSet*) 0)}) {
+    	    std::unique_ptr<RooArgSet> params{mc->GetPdf()->getParameters((const RooArgSet*) 0)};
+    	    for (RooAbsArg *a : *params) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("AsimovUtils.cc",__LINE__,std::string(Form("%s",varstring.Data())),__func__);
 	    }
@@ -64,7 +65,8 @@ RooAbsData *asimovutils::asimovDatasetWithFit(RooStats::ModelConfig *mc, RooAbsD
 
 	if (verbose>2) { 
 	    CombineLogger::instance().log("AsimovUtils.cc",__LINE__,"Parameters after fit for asimov dataset",__func__);
-            for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc->GetPdf()->getParameters(realdata)}) {
+            std::unique_ptr<RooArgSet> params{mc->GetPdf()->getParameters(realdata)};
+            for (RooAbsArg *a : *params) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("AsimovUtils.cc",__LINE__,std::string(Form("%s",varstring.Data())),__func__);
 	    }

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -973,7 +973,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	    // print the values of the parameters used to generate the toy
 	    if (verbose > 2) {
 	      CombineLogger::instance().log("Combine.cc",__LINE__, "Generate Asimov toy from parameter values ... ",__func__);
-              for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{genPdf->getParameters((const RooArgSet*)0)}) {
+              std::unique_ptr<RooArgSet> params{genPdf->getParameters((const RooArgSet*)0)};
+              for (RooAbsArg *a : *params) {
 	  	    TString varstring = utils::printRooArgAsString(a);
 	  	    CombineLogger::instance().log("Combine.cc",__LINE__,varstring.Data(),__func__);
 	      }
@@ -1069,7 +1070,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
 	std::cout << "Generate toy " << iToy << "/" << nToys << std::endl;
 	if (verbose > 2) {
 	  CombineLogger::instance().log("Combine.cc",__LINE__, std::string(Form("Generating toy %d/%d, from parameter values ... ",iToy,nToys)),__func__);
-    for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{genPdf->getParameters((const RooArgSet*)0)}) {
+    std::unique_ptr<RooArgSet> params{genPdf->getParameters((const RooArgSet*)0)};
+    for (RooAbsArg *a : *params) {
 	  	TString varstring = utils::printRooArgAsString(a);
 	  	CombineLogger::instance().log("Combine.cc" ,__LINE__,varstring.Data(),__func__);
 	  }

--- a/src/FitterAlgoBase.cc
+++ b/src/FitterAlgoBase.cc
@@ -151,8 +151,8 @@ bool FitterAlgoBase::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats:
               break;
       }
 
-      ;
-      for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{mc_s->GetPdf()->getParameters(data)}) {
+      std::unique_ptr<RooArgSet> params{mc_s->GetPdf()->getParameters(data)};
+      for (RooAbsArg *a : *params) {
           RooRealVar *rrv = dynamic_cast<RooRealVar *>(a);
           if (rrv == 0 || rrv->isConstant()) continue;
           if (profileMode_ == ProfileUnconstrained && mc_s->GetNuisanceParameters()->find(*rrv) != 0) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -387,7 +387,8 @@ bool utils::checkModel(const RooStats::ModelConfig &model, bool throwOnFail) {
         }
     }
     ;
-    for (RooAbsArg *a : *std::unique_ptr<RooArgSet>{pdf->getParameters(*model.GetObservables())}) {
+    std::unique_ptr<RooArgSet> params{pdf->getParameters(*model.GetObservables())};
+    for (RooAbsArg *a : *params) {
         if (a->getAttribute("flatParam") && a->isConstant()) {
             ok = false; errors << "ERROR: parameter " << a->GetName() << " is declared as flatParam but is constant.\n";
         }


### PR DESCRIPTION
This causes segmentation errors because of wong object lifetimes.

Follows up on https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/874.