### PR TITLE
Suppress output in low verbose mode

### DIFF
--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -1031,12 +1031,12 @@ cacheutils::CachingSimNLL::setup_()
         }
     }   
 
-    std::cout << "SimNLL created with " << nchannels << " channels, " <<
-                 constrainPdfs_.size() << " generic constraints, " << 
-                 constrainPdfsFast_.size() << " fast gaussian constraints, " << 
-                 constrainPdfsFastPoisson_.size() << " fast poisson constraints, " << 
-                 constrainPdfGroups_.size() << " fast group constraints, " << 
-                 std::endl;
+     
+    if (verb) {
+            CombineLogger::instance().log("CachingNLL.cc",__LINE__,std::string(Form(
+	    "SimNLL created with %d channels, %d generic constraints, %d fast gaussian constraints, %d fast poisson constraints, %d fast group constraints.",
+	    (int)nchannels, (int)constrainPdfs_.size(),(int)constrainPdfsFast_.size(),(int)constrainPdfsFastPoisson_.size(),(int)constrainPdfGroups_.size())),__func__);
+    }
     setValueDirty();
 }
 

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -273,7 +273,7 @@ void HybridNew::setupPOI(RooStats::ModelConfig *mc_s) {
 }
 
 bool HybridNew::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) {
-    RooFitGlobalKillSentry silence(verbose <= 1 ? RooFit::WARNING : RooFit::DEBUG);
+    RooFitGlobalKillSentry silence(verbose <= 1 ? RooFit::FATAL : RooFit::DEBUG);
 
     //double minimizerTolerance_  = ROOT::Math::MinimizerOptions::DefaultTolerance();
     //std::string minimizerAlgo_  = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();


### PR DESCRIPTION
Suppress lots of repeated warnings and info when running HybridNew (not particularly helpful output is now suppressed in default verbosity mode)