### PR TITLE
Add path within github repo for unfolding tutorial material

### DIFF
--- a/docs/tutorial2023_unfolding/unfolding_exercise.md
+++ b/docs/tutorial2023_unfolding/unfolding_exercise.md
@@ -7,9 +7,7 @@ To get started, you should have a working setup of Combine and CombineHarvester.
 After setting up CMSSW, you can access the working directory for this tutorial which contains all of the inputs and scripts needed to run the unfolding fitting exercise:
 
 ```shell
-cd $CMSSW_BASE/src/
-git clone https://gitlab.cern.ch/cms-analysis/general/combine-unfolding-tutorial-2023.git
-cd combine-unfolding-tutorial-2023
+cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/data/tutorials/tutorial_unfolding_2023/
 ```
 
 ## Exercise outline


### PR DESCRIPTION
Some documentation updates which should be merged at the time we update the recommended release, so that the documentation matches whats in the recommended release (and isn't ahead of it).