### PR TITLE
WIP: Fixes for EFT combination & RobustHesse parallelisation

### DIFF
--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -66,6 +66,8 @@ protected:
   static bool robustHesse_;
   static std::string robustHesseLoad_;
   static std::string robustHesseSave_;
+  static int robustHesseSplit_;
+  static unsigned robustHesseIdx_;
 
   static std::string saveSpecifiedFuncs_;
   static std::string saveSpecifiedNuis_;

--- a/interface/RobustHesse.h
+++ b/interface/RobustHesse.h
@@ -39,6 +39,8 @@ class RobustHesse {
   void ProtectArgSet(RooArgSet const& set);
   void ProtectVars(std::vector<std::string> const& names);
 
+  void SetSplitJob(int N, unsigned id);
+
   int hesse();
 
   void WriteOutputFile(std::string const& outputFileName) const;
@@ -98,6 +100,8 @@ class RobustHesse {
   double minNllForStencils_;
   double maxNllForStencils_;
   unsigned maxRemovalsFromHessian_;
+  int nParallelJobs_;
+  unsigned int jobIdx_;
 
   bool doRescale_;
 

--- a/interface/RooEFTScalingFunction.h
+++ b/interface/RooEFTScalingFunction.h
@@ -22,9 +22,10 @@ class RooEFTScalingFunction : public RooAbsReal {
     protected:
         std::map<std::string,double> coeffs_;
         RooListProxy terms_;
-        std::map< std::vector<RooAbsReal *>, double> vcomponents_;
+        mutable std::map< std::vector<RooAbsReal *>, double> vcomponents_; //! do not serialize
         double offset_;
         virtual Double_t evaluate() const ;
+        void init() const;
     private:
         ClassDef(RooEFTScalingFunction,1)
 };

--- a/src/MultiDimFit.cc
+++ b/src/MultiDimFit.cc
@@ -60,7 +60,8 @@ float MultiDimFit::centeredRange_ = -1.0;
 bool        MultiDimFit::robustHesse_ = false;
 std::string MultiDimFit::robustHesseLoad_ = "";
 std::string MultiDimFit::robustHesseSave_ = "";
-
+int MultiDimFit::robustHesseSplit_ = 0;
+unsigned MultiDimFit::robustHesseIdx_ = 0;
 
 std::string MultiDimFit::saveSpecifiedFuncs_;
 std::string MultiDimFit::saveSpecifiedIndex_;
@@ -110,6 +111,8 @@ MultiDimFit::MultiDimFit() :
     ("robustHesse",  boost::program_options::value<bool>(&robustHesse_)->default_value(robustHesse_),  "Use a more robust calculation of the hessian/covariance matrix")
     ("robustHesseLoad",  boost::program_options::value<std::string>(&robustHesseLoad_)->default_value(robustHesseLoad_),  "Load the pre-calculated Hessian")
     ("robustHesseSave",  boost::program_options::value<std::string>(&robustHesseSave_)->default_value(robustHesseSave_),  "Save the calculated Hessian")
+    ("robustHesseSplit",  boost::program_options::value<int>(&robustHesseSplit_)->default_value(robustHesseSplit_),  "Split the Hessian calculation into N jobs")
+    ("robustHesseIdx",  boost::program_options::value<unsigned>(&robustHesseIdx_)->default_value(robustHesseIdx_),  "Set job index (0..N-1) in split mode")
       ;
 }
 
@@ -241,6 +244,9 @@ bool MultiDimFit::runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooS
         }
         if (robustHesseLoad_ != "") {
           robustHesse.LoadHessianFromFile(robustHesseLoad_);
+        }
+        if (robustHesseSplit_ > 0) {
+            robustHesse.SetSplitJob(robustHesseSplit_, robustHesseIdx_);
         }
         robustHesse.hesse();
         if (saveFitResult_) {

--- a/src/RooEFTScalingFunction.cc
+++ b/src/RooEFTScalingFunction.cc
@@ -18,9 +18,12 @@ RooEFTScalingFunction::RooEFTScalingFunction(const char *name, const char *title
         }
         terms_.add(*rar);
     }
+    init();
+}
 
+void RooEFTScalingFunction::init() const {
     // Loop over elements in mapping: add components to vector depending on string
-    for( auto const& x : coeffs ) {
+    for( auto const& x : coeffs_ ) {
         TString term_name = x.first;
         double term_prefactor = x.second;
 
@@ -30,20 +33,20 @@ RooEFTScalingFunction::RooEFTScalingFunction(const char *name, const char *title
 
             // Squared-quadratic components
             if( second_term == "2" ){
-                if( terms.find(first_term) ){
+                if( terms_.find(first_term) ){
                     std::vector<RooAbsReal *> vterms;
-                    RooAbsReal *rar1 = dynamic_cast<RooAbsReal *>( terms.find(first_term) );
-                    RooAbsReal *rar2 = dynamic_cast<RooAbsReal *>( terms.find(first_term) );
+                    RooAbsReal *rar1 = dynamic_cast<RooAbsReal *>( terms_.find(first_term) );
+                    RooAbsReal *rar2 = dynamic_cast<RooAbsReal *>( terms_.find(first_term) );
                     vterms.push_back(rar1);
                     vterms.push_back(rar2);
                     vcomponents_.emplace(vterms,term_prefactor);
                 }
             } else{
                 // Cross-quadratic components
-                if( terms.find(first_term) && terms.find(second_term) ){
+                if( terms_.find(first_term) && terms_.find(second_term) ){
                     std::vector<RooAbsReal *> vterms;
-                    RooAbsReal *rar1 = dynamic_cast<RooAbsReal *>( terms.find(first_term) );
-                    RooAbsReal *rar2 = dynamic_cast<RooAbsReal *>( terms.find(second_term) );
+                    RooAbsReal *rar1 = dynamic_cast<RooAbsReal *>( terms_.find(first_term) );
+                    RooAbsReal *rar2 = dynamic_cast<RooAbsReal *>( terms_.find(second_term) );
                     vterms.push_back(rar1);
                     vterms.push_back(rar2);
                     vcomponents_.emplace(vterms,term_prefactor);
@@ -51,9 +54,9 @@ RooEFTScalingFunction::RooEFTScalingFunction(const char *name, const char *title
             }
         } else {
 
-          if( terms.find(term_name) ) {
+          if( terms_.find(term_name) ) {
               std::vector<RooAbsReal *> vterms;
-              RooAbsReal *rar = dynamic_cast<RooAbsReal *>( terms.find(term_name) );
+              RooAbsReal *rar = dynamic_cast<RooAbsReal *>( terms_.find(term_name) );
               vterms.push_back(rar);
               vcomponents_.emplace(vterms,term_prefactor);
           } 
@@ -65,15 +68,14 @@ RooEFTScalingFunction::RooEFTScalingFunction(const RooEFTScalingFunction& other,
     RooAbsReal(other, name),
     coeffs_(other.coeffs_),
     terms_("!terms",this,other.terms_),
-    vcomponents_(other.vcomponents_),
     offset_(other.offset_)
-{
-}
+{ }
 
 Double_t RooEFTScalingFunction::evaluate() const 
 {
     if (vcomponents_.empty()) {
-        return offset_;
+        init();
+        // return offset_;
     }
     double ret = offset_;
     for (auto const &x : vcomponents_) {


### PR DESCRIPTION
- Some fixes to RooEFTScalingFunction
- Option to split RobustHesse calculation in parallel jobs (to be facilitated by combineTool.py)
- Some testing still needed, plus a workflow to merge output hessian matrices (maybe with standalone inversion and RooFitResult creation, since would be pointless to re-enter combine again?)