### PR TITLE
Remove warning where not needed and add filter to printWorkspaceNormlisations.py

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -913,7 +913,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   }
 
   // Warn the user that they might be using funky values of POIs 
-  if (!expectSignalSet_ && setPhysicsModelParameterExpression_ == "" && !(POI->getSize()==1 && POI->find("r"))) {
+  if (nToys!=0 && !expectSignalSet_ && setPhysicsModelParameterExpression_ == "" && !(POI->getSize()==1 && POI->find("r"))) {
 	  std::cerr << "Warning! -- You haven't picked default values for the Parameters of Interest (either with --expectSignal or --setParameters) for generating toys. Combine will use the 'B-only' ModelConfig to generate, which may lead to undesired behaviour if not using the default Physics Model" << std::endl;	  
   }	
   // Ok now we're ready to go lets save a "clean snapshot" for the current parameters state

--- a/test/printWorkspaceNormalisations.py
+++ b/test/printWorkspaceNormalisations.py
@@ -55,7 +55,22 @@ parser.add_option(
     action="store_true",
     help="Set to true if workspace built with --use-cms-histsum option.",
 )
-parser.add_option("", "--output-json", dest="output_json", default="", help="Output norms in json.")
+parser.add_option(
+    "",
+    "--procFilter",
+    dest="process_filter_list",
+    type='string',
+    help="Filter (keep) only processes containing these names. Enter option as comma separated string",
+)
+parser.add_option(
+    "-m",
+    "--mass",
+    dest="massVal",
+    default=125,
+    type=float,
+    help="Set mass value in workspace (default=125).",
+)
+parser.add_option("", "--output-json", dest="output_json", default="", help="Output norms in json. Note, filters/thresholds are ignored for this output")
 
 
 (options, args) = parser.parse_args()
@@ -68,7 +83,8 @@ if options.max_threshold < options.min_threshold:
 
 file_in = ROOT.TFile(args[0])
 ws = file_in.Get("w")
-
+ws.var("MH").setVal(options.massVal)
+print("Normalisation Values Evaluated at MH=",options.massVal)
 
 def find_chan_proc(name):
     chan = norm_name[norm_name.find("_bin") + len("_bin") : norm_name.find("_proc")]
@@ -77,6 +93,7 @@ def find_chan_proc(name):
     proc = norm_name[norm_name.find("_proc_") + len("_proc_") :]
     return chan, proc
 
+process_filter_list = options.process_filter_list.split(',')
 
 chan_procs = {}
 
@@ -141,6 +158,11 @@ if options.use_cms_histsum:
                 if type(prop) == ROOT.CMSHistSum:
                     chan_CMSHistSum_norms[chan] = dict(prop.getProcessNorms())
 
+def checkFilter(proc):
+    for pc in process_filter_list:
+      if pc in proc: return True
+    return False
+
 # Now print out information
 default_norms = od()
 
@@ -152,6 +174,7 @@ for chan in chan_procs.keys():
     chanInfo = chan_procs[chan]
     for proc in chanInfo:
         skipProc = False
+        if not checkFilter(proc): skipProc=True
         if options.min_threshold > 0:
             skipProc = proc[1].getVal() < options.min_threshold
         if options.max_threshold > 0:


### PR DESCRIPTION
Removed a warning that was not needed if not running with toys

Added option for filtering on process names in `test/printWorkspaceNormalisations.py`