### PR TITLE
Fix a bug in RooParametricHist

### DIFF
--- a/src/RooParametricHist.cxx
+++ b/src/RooParametricHist.cxx
@@ -97,7 +97,6 @@ double RooParametricHist::getFullSum() const {
 	  double thisVal = static_cast<RooAbsReal&>(pars[i]).getVal();
 	  if (_hasMorphs) thisVal*=evaluateMorphFunction(i);
 	  sum+=thisVal;
-	  i++;
     }
     return sum;
 }


### PR DESCRIPTION
Removing a remnant from the deprecated TIterator which were removed in #874 