### PR TITLE
Add instructions for lxplus9

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,22 @@ make -j 4
 
 You will need to source `env_standalone.sh` each time you want to use the package, or add it to your login environment.
 
+##### Compilation on lxplus9
+
+For slc9 architectures, you will need to do the compilation in an slc7 environment using apptainer. You can then source the standalone script outside of the apptainer.
+On lxplus this can be done as follows:
+
+```
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+cd HiggsAnalysis/CombinedLimit/ 
+# git checkout <some release>
+cmssw-el7
+. env_standalone.sh
+make -j 4
+exit
+source . env_standalone.sh
+```
+
 ##### Standalone compilation with LCG
 For compilation outside of CMSSW, for example to use ROOT versions not yet available in CMSSW, one can compile against LCG releases. The current default is to compile with LCG_102, which contains ROOT 6.26:
 ```sh


### PR DESCRIPTION
Adressing #923 

Until combine v10 is ready standalone compilation does not work on slc9 out-of-the-box, including instructions on using apptainer from lxplus9 to do standalone compilation there.