### PR TITLE
Fix mike deploy command in github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ jobs:
         git fetch origin gh-pages --depth=1
         git config user.name ci-bot
         git config user.email ci-bot@example.com
-        mike deploy --push latest 
+        mike deploy --push v9.2.0 latest 


### PR DESCRIPTION
Small bug fix following up on #918 

I thought that the `mike deploy` command could just use the alias, but apparently the version also needs to be included, note that this means that this will also need to be updated when we release new versions.