### PR TITLE
Fix equation rendering 

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,9 +1,11 @@
 window.MathJax = {
+  loader: {load: ['[tex]/boldsymbol']},
   tex: {
     inlineMath: [["\\(", "\\)"]],
     displayMath: [["\\[", "\\]"]],
     processEscapes: true,
-    processEnvironments: true
+    processEnvironments: true,
+    packages: {'[+]': ['boldsymbol']}
   },
   options: {
     ignoreHtmlClass: ".*|",

--- a/docs/part2/bin-wise-stats.md
+++ b/docs/part2/bin-wise-stats.md
@@ -28,7 +28,7 @@ $n_{\text{tot}} = \sum_{i\,\in\,\text{bkg}}n_i$, $e_{\text{tot}} = \sqrt{\sum_{i
  4. If $n_{\text{tot}}^{\text{eff}} \leq n^{\text{threshold}}$: separate uncertainties will be created for each process. Processes where $e_{i} = 0$ are skipped. If the number of effective events for a given process is lower than $n^{\text{threshold}}$ a Poisson-constrained parameter will be created. Otherwise a Gaussian-constrained parameter is used.
  5. If $n_{\text{tot}}^{\text{eff}} \gt n^{\text{threshold}}$: A single Gaussian-constrained Barlow-Beeston-lite parameter is created that will scale the total yield in the bin.
  6. Note that the values of $e_{i}$, and therefore $e_{tot}$, will be updated automatically in the model whenever the process normalizations change.
- 7. A Gaussian-constrained parameter $x$ has a nominal value of zero and scales the yield as $n_{\text{tot}} + x \cdot e_{\text{tot}}$. The Poisson-constrained parameters are expressed as a yield multiplier with nominal value one: $n_{\text{tot}} \cdot x$.
+ 7. A Gaussian-constrained parameter $\nu$ has a nominal value of zero and scales the yield as $n_{\text{tot}} + \nu \cdot e_{\text{tot}}$. The Poisson-constrained parameters are expressed as a yield multiplier with nominal value one: $n_{\text{tot}} \cdot \nu$.
 
 The output from `text2workspace.py` will give details on how each bin has been treated by this algorithm, for example:
 

--- a/docs/part3/commonstatsmethods.md
+++ b/docs/part3/commonstatsmethods.md
@@ -333,7 +333,7 @@ The choice of test statistic can be made via the option `--testStat`. Different 
 
 * **LHC-style**: `--LHCmode LHC-limits`
 , which is the shortcut for `--testStat LHC --generateNuisances=0 --generateExternalMeasurements=1 --fitNuisances=1`
-    * The test statistic is defined using the ratio of likelihoods $q_{\mu} = -2\ln[\mathcal{L}(\mu,\hat{\hat{\nu}}(\mu))/\mathcal{L}(\hat{\mu},\hat{\nu})]$ , in which the nuisance parameters are profiled separately for $mu=\hat{\mu}$ and $\mu$.
+    * The test statistic is defined using the ratio of likelihoods $q_{\mu} = -2\ln[\mathcal{L}(\mu,\hat{\hat{\nu}}(\mu))/\mathcal{L}(\hat{\mu},\hat{\nu})]$ , in which the nuisance parameters are profiled separately for $\mu=\hat{\mu}$ and $\mu$.
     * The value of $q_{\mu}$ set to 0 when $\hat{\mu}>\mu$ giving a one-sided limit. Furthermore, the constraint $\mu>0$ is enforced in the fit. This means that if the unconstrained value of $\hat{\mu}$ would be negative, the test statistic $q_{\mu}$ is evaluated as $-2\ln[\mathcal{L}(\mu,\hat{\hat{\nu}}(\mu))/\mathcal{L}(0,\hat{\hat{\nu}}(0))]$.
     * For the purposes of toy generation, the nuisance parameters are fixed to their **post-fit** values from the data (conditionally on the value of $\mu$), while the constraint terms are randomized in the evaluation of the likelihood.
 

--- a/docs/part3/validation.md
+++ b/docs/part3/validation.md
@@ -164,7 +164,7 @@ Where `value_u` and `value_d` are the values of the 'up' and 'down' normalizatio
 ### Uncertainty probably has no genuine shape effect
 
 In this check, applying only to shape uncertainties, the normalized nominal templates are compared with the normalized templates for the 'up' and 'down' systematic variations. The script calculates
-$$ \Sigma_i \frac{2|\text{up}(i) - \text{nominal}(i)|}{|\text{up}(i)| + |\text{nominal}(i)|}$$ and $$ \Sigma_i \frac{2|\text{down}(i) - \text{nominal}(i)|}{|\text{down}(i)| + |\text{nominal}(i)|} $$
+$\Sigma_i \frac{2|\text{up}(i) - \text{nominal}(i)|}{|\text{up}(i)| + |\text{nominal}(i)|}$ and $\Sigma_i \frac{2|\text{down}(i) - \text{nominal}(i)|}{|\text{down}(i)| + |\text{nominal}(i)|}$.
 
 where the sums run over all bins in the histograms, and 'nominal', 'up', and 'down' are the central template and up and down varied templates, all normalized.
 

--- a/docs/part5/roofit.md
+++ b/docs/part5/roofit.md
@@ -692,20 +692,20 @@ This is exactly what needs to be done when you want to use shape based datacards
 ## A likelihood for a counting experiment
 An introductory presentation about likelihoods and interval estimation is available [here](https://indico.cern.ch/event/976099/contributions/4138517/).
 
-**Note: We will use python syntax in this section; you should use a .py script. Make sure to do `import ROOT` at the top of your script **
+**Note: We will use python syntax in this section; you should use a .py script. Make sure to do `import ROOT` at the top of your script**
 
 We have seen how to create variables and PDFs, and how to fit a PDF to data. But what if we have a counting experiment, or a histogram template shape? And what about systematic uncertainties?  We are going to build a likelihood 
 for this:
 
 $\mathcal{L} \propto p(\text{data}|\text{parameters})$
 
-where our parameters are parameters of interest, $\mu$, and nuisance parameters, $\theta$. The nuisance parameters are constrained by external measurements, so we add constraint terms $\pi(\vec{\theta}_0|\vec{\theta})$
+where our parameters are parameters of interest, $\mu$, and nuisance parameters, $\nu$. The nuisance parameters are constrained by external measurements, so we add constraint terms $\pi(\vec{\nu}_0|\vec{\nu})$
 
 So we have
-$\mathcal{L} \propto p(\text{data}|\mu,\vec{\theta})\cdot \pi(\vec{\theta}_0|\vec{\theta})$
+$\mathcal{L} \propto p(\text{data}|\mu,\vec{\nu})\cdot \pi(\vec{\nu}_0|\vec{\nu})$
 
 now we will try to build the likelihood by hand for a 1-bin counting experiment.
-The data is the number of observed events $N$, and the probability is just a Poisson probability $p(N|\lambda) = \frac{\lambda^N e^{-\lambda}}{N!}$, where $\lambda$ is the number of events expected in our signal+background model: $\lambda = \mu\cdot s(\vec{\theta}) + b(\vec{\theta})$. 
+The data is the number of observed events $N$, and the probability is just a Poisson probability $p(N|\lambda) = \frac{\lambda^N e^{-\lambda}}{N!}$, where $\lambda$ is the number of events expected in our signal+background model: $\lambda = \mu\cdot s(\vec{\nu}) + b(\vec{\nu})$. 
 
 In the expression, s and b are the numbers of expected signal and background events, which both depend on the nuisance parameters. We will start by building a simple likelihood function with one signal process and one background process. We will assume there are no nuisance parameters for now. The number of observed events in data is 15, the expected number of signal events is 5 and the expected number of background events 8.1.
 

--- a/docs/what_combine_does/statistical_tests.md
+++ b/docs/what_combine_does/statistical_tests.md
@@ -99,7 +99,7 @@ This is important in limit setting for example, where we perform statistical tes
 In these cases, the likelihood ratio (or a function of it) can be used to define a set of test statistics parameterized by the model parameters.
 For example, a very useful set of test statistics is:
 
-$$ t_{\vec{\mu}} \propto -\log\left(\frac{\mathcal{L}(\vec{\mu})}{\mathcal{L}(\vec{\hat{\mu}})}\right) $$.
+$$ t_{\vec{\mu}} \propto -\log\left(\frac{\mathcal{L}(\vec{\mu})}{\mathcal{L}(\vec{\hat{\mu}})}\right) $$
 
 Where the likelihood parameters in the bottom are fixed to their maximum likelihood values, but the parameter $\vec{\mu}$ indexing the test statistic appears in the numerator of the likelihood ratio.
 

--- a/docs/what_combine_does/statistical_tests.md
+++ b/docs/what_combine_does/statistical_tests.md
@@ -203,7 +203,7 @@ $$
 \end{cases}
 $$
 
-Which also has a [known distribution](https://ar5iv.labs.arxiv.org/html/1007.1727#S3.SS7) under appropriate conditions, or can be estimated from pseudo-experiments. One can then set a limit at a given confidence level, $\mathrm{CL}$, by finding the value of $\mu$ for which $p_{\mu} \equiv p(t_{\mu}(\mathrm{data});\mathcal{M}_{\mu}) = 1 - \mathrm{CL}$. Larger values of $\mu$ will have smaller p-values and are considered excluded at the given confidence level.
+Which also has a [known distribution](https://ar5iv.labs.arxiv.org/html/1007.1727#S3.SS7) under appropriate conditions, or can be estimated from pseudo-experiments. One can then set a limit at a given confidence level, $\mathrm{CL}$, by finding the smallest value of $\mu$ for which $p_{\mu} \equiv P( t_{\mu} \gt t_{\mu}(\mathrm{data});\mathcal{M}_{\mu}) = 1 - \mathrm{CL}$. Larger values of $\mu$ will have smaller p-values and are considered excluded at the given confidence level.
 
 However, this procedure is rarely used, in almost every case we use a modified test procedure which uses the $\mathrm{CL}_{s}$ criterion, explained below.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ theme:
 
 plugins:
     - mike
+    - search
 
 extra:
     version:


### PR DESCRIPTION
Standalone equation blocks using $$ [eqn] $$ can't have any other text on the same line, fixing one instance I spotted.

A few more issues that were spotted and fixed:

Inline equation renderd `$ ... $` doesn't seem to work if there are spaces between the `$` and the start/end of the equation.
Bold text `** ... **` doesn't work if there are spaces between the asterices(sp?) and the text
`\boldsymbol` needed a mathjax fix
other minor consistency with paper notation or missing `\` etc.