### PR TITLE
Don't trigger doc builds on pushing to 102x

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 102x
+      - main
 
 jobs:
   docs:
@@ -18,11 +18,8 @@ jobs:
         python-version: 3.8
     - name: Build documentation
       run: |
-        python3 -m pip install mkdocs pymdown-extensions mkdocs-cinder
-        mkdocs build --verbose --clean
-    - name: Deploy documentation
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./site
-
+        python3 -m pip install mkdocs pymdown-extensions mkdocs-material mike
+        git fetch origin gh-pages --depth=1
+        git config user.name ci-bot
+        git config user.email ci-bot@example.com
+        mike deploy --push v9.2.0 latest 


### PR DESCRIPTION
Change the docs action so it isnt triggered on pushes to this branch, use only main for documentation updates