### PR TITLE
Fix RooStats::ToyMCSampler pointer issue for ROOT v6.22/09

### DIFF
--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -29,7 +29,7 @@ ToyMCSamplerOpt::ToyMCSamplerOpt(RooStats::TestStatistic& ts, Int_t ntoys, RooAb
 }
 
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,24,0)
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,22,9)
 // A private std::unique_ptr was introduced in RooStats::ToyMCSampler, disallowing copy construction
 ToyMCSamplerOpt::ToyMCSamplerOpt(const RooStats::ToyMCSampler &base) :
     ToyMCSampler(base),


### PR DESCRIPTION
ROOT v6.22/09 is actually not an official release but is in the [v6-22-00-patches branch](https://github.com/root-project/root/tree/v6-22-00-patches), which got this change: https://github.com/root-project/root/commit/e24f87734ca447e0e9c3e26d47496c02d2a2f4f9 that also went into all later releases (6.24 onwards).
