### PR TITLE
No need to document every minor version, just 9.2.X is fine

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ jobs:
         git fetch origin gh-pages --depth=1
         git config user.name ci-bot
         git config user.email ci-bot@example.com
-        mike deploy --push v9.2.0 latest 
+        mike deploy --push v9.2.X latest 


### PR DESCRIPTION
Since we've updated to v9.2.1 this should be reflected accurately in the webpage docs version