### PR TITLE
Add a CMakeLists.txt for compiling with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ install(DIRECTORY scripts/ DESTINATION bin)
 ## The the Python library installation directory relative to the install prefix.
 #file(RELATIVE_PATH Python_SITELIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX} ${Python_SITELIB})
 
-set(Python_SITLIB_IN_PREFIX "python")
+set(Python_SITELIB_IN_PREFIX "python")
 
 
 message (STATUS "Using Python install location:" ${Python_SITELIB_IN_PREFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(CMSCombine VERSION 0.0.1)
 # make -j4
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
-find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory )
+find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory RooFitHS3)
 find_package(Eigen3 REQUIRED)
 find_package(Vdt)
 find_package(LCG QUIET) # only used for FindBoost in StatAnalysis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory )
 find_package(Eigen3 REQUIRED)
 find_package(Vdt)
-find_package(LCG) # only used for FindBoost in StatAnalysis
-find_package( Boost COMPONENTS program_options filesystem )
+find_package(LCG QUIET) # only used for FindBoost in StatAnalysis
+find_package( Boost REQUIRED COMPONENTS program_options filesystem )
 
 message(STATUS "Using ROOT From: ${ROOT_INCLUDE_DIRS}")
 include(${ROOT_USE_FILE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required( VERSION 3.11 FATAL_ERROR )
 set(CMAKE_CXX_STANDARD 17)
 project(CMSCombine VERSION 0.0.1)
 
+# Can build with CMake after e.g. setting up StatAnalysis release like this:
+# export ATLAS_LOCAL_ROOT_BASE=/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase
+# source $ATLAS_LOCAL_ROOT_BASE/user/atlasLocalSetup.sh; asetup StatAnalysis,0.3.2
+# mkdir build; cd build
+# cmake path/to/source # change this path to where-ever you cloned Combine repo to
+# make -j4
+
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory )
 find_package(Eigen3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats 
 find_package(Eigen3 REQUIRED)
 find_package(Vdt)
 find_package(LCG) # only used for FindBoost in StatAnalysis
-find_package( Boost REQUIRED COMPONENTS program_options filesystem )
+find_package( Boost COMPONENTS program_options filesystem )
 
 message(STATUS "Using ROOT From: ${ROOT_INCLUDE_DIRS}")
 include(${ROOT_USE_FILE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required( VERSION 3.11 FATAL_ERROR )
+set(CMAKE_CXX_STANDARD 17)
+project(CMSCombine VERSION 0.0.1)
+
+list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
+find_package( ROOT REQUIRED COMPONENTS Core MathMore RooFitCore RooFit RooStats Minuit HistFactory )
+find_package(Eigen3 REQUIRED)
+find_package(Vdt)
+find_package(LCG) # only used for FindBoost in StatAnalysis
+find_package( Boost REQUIRED COMPONENTS program_options filesystem )
+
+message(STATUS "Using ROOT From: ${ROOT_INCLUDE_DIRS}")
+include(${ROOT_USE_FILE})
+
+include_directories(${ROOT_INCLUDE_DIRS})
+
+add_definitions(${ROOT_CXX_FLAGS})
+
+set(LIBNAME CMSCombine)
+
+file(GLOB HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} interface/*.h)
+file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} src/*.c*)
+
+# includes require "HiggsAnalysis/CombinedLimit" prefix in many places
+# so create a symlink in the build dir
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/HiggsAnalysis)
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/HiggsAnalysis/CombinedLimit" )
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+ROOT_GENERATE_DICTIONARY(G__${LIBNAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/classes.h LINKDEF src/classes_def.xml
+        MODULE ${LIBNAME}
+        OPTIONS --deep)
+add_library(${LIBNAME} SHARED ${SOURCES} G__${LIBNAME}.cxx)
+set_target_properties(${LIBNAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
+target_link_libraries (${LIBNAME} Eigen3::Eigen ${ROOT_LIBRARIES} ${Boost_LIBRARIES} VDT::VDT)
+
+add_executable(combine bin/combine.cpp)
+target_link_libraries(combine PUBLIC ${LIBNAME})
+
+
+# Create empty __init__.py file in the build directory that will be installed
+# in the Python library directories.
+set(empty_init_py "${CMAKE_CURRENT_BINARY_DIR}/__init__.py")
+
+#####################
+# Installation part #
+#####################
+
+
+# Install the dictionaries.
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib${LIBNAME}_rdict.pcm
+        ${CMAKE_CURRENT_BINARY_DIR}/lib${LIBNAME}.rootmap
+        DESTINATION lib)
+
+# Install the libraries and header files.
+install(TARGETS ${LIBNAME}
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/HiggsAnalysis/CombinedLimit/interface
+        )
+
+# Install the "combine" executable in the bin directory.
+install(TARGETS combine DESTINATION bin)
+
+# Install the scripts like "text2workspace" to the bin directory.
+install(DIRECTORY scripts/ DESTINATION bin)
+
+# This block is commented out for now, while using the less sophisticated location below
+# Check if the Python library installation directory is outside the install
+# prefix. If it is, we error out because CMake should not install files outside
+# the prefix. In the future, one can imagine to let the user choose where the
+# Python libraries get installed in the prefix with a CMake configuration flag.
+#find_package(Python COMPONENTS Interpreter Development) # To get the Python library install directory into Python_SITELIB
+#cmake_path(IS_PREFIX CMAKE_INSTALL_PREFIX "${Python_SITELIB}" sitelib_in_prefix)
+#if(NOT ${sitelib_in_prefix})
+#    message( FATAL_ERROR "Your Python library installation directory ${Python_SITELIB} "
+#            "is outside the install prefix ${CMAKE_INSTALL_PREFIX}! "
+#            "This is not supported for now. Consider changing the install prefix "
+#            "with the -DCMAKE_INSTALL_PREFIX:PATH=<path> cmake configuration option.")
+#endif()
+#
+## The the Python library installation directory relative to the install prefix.
+#file(RELATIVE_PATH Python_SITELIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX} ${Python_SITELIB})
+
+set(Python_SITLIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX}/python)
+
+
+message (STATUS "Using Python install location:" ${Python_SITELIB_IN_PREFIX})
+# The python package will be installed in such a way that the original
+# CMSSW-style directory structure is kept, for maximal compatibility.
+install(DIRECTORY python/ DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit)
+
+# Create empty __init__.py files in the Python package subdirectories such that
+# the Python imports work.
+file(TOUCH ${empty_init_py})
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/__init__.py)
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit/__init__.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,5 +99,5 @@ install(DIRECTORY python/ DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/
 # Create empty __init__.py files in the Python package subdirectories such that
 # the Python imports work.
 file(TOUCH ${empty_init_py})
-INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/__init__.py)
-INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit/__init__.py)
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/)
+INSTALL(FILES ${empty_init_py} DESTINATION ${Python_SITELIB_IN_PREFIX}/HiggsAnalysis/CombinedLimit/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ install(DIRECTORY scripts/ DESTINATION bin)
 ## The the Python library installation directory relative to the install prefix.
 #file(RELATIVE_PATH Python_SITELIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX} ${Python_SITELIB})
 
-set(Python_SITLIB_IN_PREFIX ${CMAKE_INSTALL_PREFIX}/python)
+set(Python_SITLIB_IN_PREFIX "python")
 
 
 message (STATUS "Using Python install location:" ${Python_SITELIB_IN_PREFIX})


### PR DESCRIPTION
This is tested by compiling on top of the StatAnalysis releases (setup instructions in comments in the CMakeLists.txt)

There will be conflicts for some classes which are compiled by both combine and RooFitExtensions (the ATLAS extra-classes library), which we should ultimately decide how to resolve (push common classes into RooFit, is best option).