### PR TITLE
Use `override` keyword were necessary

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+---
+Checks: -*,
+  ,modernize-use-override,
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+...

--- a/interface/AsymPow.h
+++ b/interface/AsymPow.h
@@ -26,12 +26,12 @@ class AsymPow : public RooAbsReal {
       AsymPow(const char *name, const char *title, RooAbsReal &kappaLow, RooAbsReal &kappaHigh, RooAbsReal &theta) ;
       AsymPow(const AsymPow &other, const char *newname=0) ;
 
-      ~AsymPow() ;
+      ~AsymPow() override ;
 
-      TObject * clone(const char *newname) const ;
+      TObject * clone(const char *newname) const override ;
 
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
         RooRealProxy kappaLow_, kappaHigh_;
@@ -40,7 +40,7 @@ class AsymPow : public RooAbsReal {
         // get the kappa for the appropriate x
         Double_t logKappaForX(Double_t x) const ;
 
-  ClassDef(AsymPow,1) // Asymmetric power	
+  ClassDefOverride(AsymPow,1) // Asymmetric power	
 };
 
 #endif

--- a/interface/AsymptoticLimits.h
+++ b/interface/AsymptoticLimits.h
@@ -22,16 +22,16 @@ class RooRealVar;
 class AsymptoticLimits : public LimitAlgo {
 public:
   AsymptoticLimits() ; 
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
-  virtual void applyDefaultOptions() ; 
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
+  void applyDefaultOptions() override ; 
 
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
   virtual bool runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   std::vector<std::pair<float,float> > runLimitExpected(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) ;
 
   float findExpectedLimitFromCrossing(RooAbsReal &nll, RooRealVar *r, double rMin, double rMax, double nll0, double quantile) ; 
 
-  virtual const std::string& name() const { static std::string name_ = "AsymptoticLimits"; return name_; }
+  const std::string& name() const override { static std::string name_ = "AsymptoticLimits"; return name_; }
 private:
   static double rAbsAccuracy_, rRelAccuracy_;
   static std::string what_;

--- a/interface/AtlasPdfs.h
+++ b/interface/AtlasPdfs.h
@@ -34,8 +34,8 @@ namespace HistFactory{
     RooBSplineBases(const char *name, const char *title);
     RooBSplineBases(const RooBSplineBases&, const char*);
 
-    virtual TObject* clone(const char* newname) const { return new RooBSplineBases(*this, newname); }
-    virtual ~RooBSplineBases() ;
+    TObject* clone(const char* newname) const override { return new RooBSplineBases(*this, newname); }
+    ~RooBSplineBases() override ;
 
 /*     Double_t getCurvature() const; */
 
@@ -62,9 +62,9 @@ namespace HistFactory{
     mutable std::vector<double> _t_ary;
     mutable std::vector<std::vector<double> > _bin;
 
-    Double_t evaluate() const;
+    Double_t evaluate() const override;
 
-    ClassDef(RooStats::HistFactory::RooBSplineBases,1) // Uniform B-Spline
+    ClassDefOverride(RooStats::HistFactory::RooBSplineBases,1) // Uniform B-Spline
   };
 }
 }
@@ -116,8 +116,8 @@ namespace HistFactory{
     RooBSpline(const char *name, const char *title);
     RooBSpline(const RooBSpline&, const char*);
 
-    virtual TObject* clone(const char* newname) const { return new RooBSpline(*this, newname); }
-    virtual ~RooBSpline() ;
+    TObject* clone(const char* newname) const override { return new RooBSpline(*this, newname); }
+    ~RooBSpline() override ;
 
 /*     Double_t getCurvature() const; */
 
@@ -127,8 +127,8 @@ namespace HistFactory{
     void setWeights(const RooArgList& weights);
 
     Bool_t setBinIntegrator(RooArgSet& allVars) ;
-    Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const ;
-    Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+    Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override ;
+    Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
     const RooArgList& getControlPoints() const {return _controlPoints;}
 
@@ -151,17 +151,17 @@ namespace HistFactory{
     // Cache the integrals   
     class CacheElem : public RooAbsCacheElement {
     public:
-      virtual ~CacheElem();
+      ~CacheElem() override;
       // Payload
       RooArgList _I ;
-      virtual RooArgList containedArgs(Action) ;
+      RooArgList containedArgs(Action) override ;
     };
     mutable RooObjCacheManager _cacheMgr ; // The cache manager
 
 
-    Double_t evaluate() const;
+    Double_t evaluate() const override;
 
-    ClassDef(RooStats::HistFactory::RooBSpline,2) // Uniform B-Spline
+    ClassDefOverride(RooStats::HistFactory::RooBSpline,2) // Uniform B-Spline
   };
 }
 }
@@ -209,13 +209,13 @@ public:
     RooDataSet& data, Mirror mirror= NoMirror, Double_t rho=1, Int_t nPoints=1000
   );
   RooParamKeysPdf(const RooParamKeysPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const {return new RooParamKeysPdf(*this,newname); }
-  virtual ~RooParamKeysPdf();
+  TObject* clone(const char* newname) const override {return new RooParamKeysPdf(*this,newname); }
+  ~RooParamKeysPdf() override;
   
   void LoadDataSet( RooDataSet& data);
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
   
@@ -223,7 +223,7 @@ protected:
   RooRealProxy _deltax ;
   double _centralValue;
   RooRealProxy _multiplicativeShift;
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
   
@@ -251,7 +251,7 @@ private:
   Double_t _lo, _hi, _binWidth;
   Double_t _rho;
   
-  ClassDef(RooParamKeysPdf,4) // One-dimensional non-parametric kernel estimation p.d.f.
+  ClassDefOverride(RooParamKeysPdf,4) // One-dimensional non-parametric kernel estimation p.d.f.
 };
 
 #ifdef __CINT__
@@ -304,15 +304,15 @@ public:
 
   RooStarMomentMorph(const RooStarMomentMorph& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooStarMomentMorph(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooStarMomentMorph(*this,newname); }
 
-  virtual ~RooStarMomentMorph();
+  ~RooStarMomentMorph() override;
 
   void     setMode(const Setting& setting) { _setting = setting; }
 
   int nnuisSize() { return _nnuis.size(); }
 
-  virtual Bool_t selfNormalized() const { 
+  Bool_t selfNormalized() const override { 
     // P.d.f is self normalized
     return kTRUE ; 
   }
@@ -325,7 +325,7 @@ public:
 
 #if ROOT_VERSION_CODE>=ROOT_VERSION(5,34,15)
   void fixCache() { _cacheMgr.setClearOnRedirect(kFALSE) ; }
-  virtual CacheMode canNodeBeCached() const { return RooAbsArg::NotAdvised ; } ;
+  CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
 #endif
   
 
@@ -336,9 +336,9 @@ protected:
     CacheElem(RooAbsPdf& sumPdf, RooChangeTracker& tracker, const RooArgList& flist) : _sumPdf(&sumPdf), _tracker(&tracker), _fractionsCalculated(false) { 
       _frac.add(flist) ; 
     } ;
-    void operModeHook(RooAbsArg::OperMode) {};
-    virtual ~CacheElem() ; 
-    virtual RooArgList containedArgs(Action) ;
+    void operModeHook(RooAbsArg::OperMode) override {};
+    ~CacheElem() override ; 
+    RooArgList containedArgs(Action) override ;
     RooAbsPdf* _sumPdf ;
     RooChangeTracker* _tracker ; 
     RooArgList _frac ;
@@ -353,7 +353,7 @@ protected:
 
   friend class CacheElem ; // Cache needs to be able to clear _norm pointer
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   void     initialize();
   CacheElem* getCache(const RooArgSet* nset) const ;
@@ -379,7 +379,7 @@ protected:
 
   Bool_t _useHorizMorph;
 
-  ClassDef(RooStarMomentMorph,2) // Your description goes here...
+  ClassDefOverride(RooStarMomentMorph,2) // Your description goes here...
 };
  
 #endif

--- a/interface/BayesianFlatPrior.h
+++ b/interface/BayesianFlatPrior.h
@@ -13,8 +13,8 @@
 class BayesianFlatPrior : public LimitAlgo {
 public:
   BayesianFlatPrior() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  const std::string & name() const override {
     static const std::string name("BayesianSimple");
     return name;
   }

--- a/interface/BayesianToyMC.h
+++ b/interface/BayesianToyMC.h
@@ -14,10 +14,10 @@ class RooArgSet;
 class BayesianToyMC : public LimitAlgo {
 public:
   BayesianToyMC() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
   virtual bool runBayesFactor(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
-  virtual const std::string & name() const {
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
+  const std::string & name() const override {
     static const std::string name("BayesianToyMC");
     return name;
   }

--- a/interface/BestFitSigmaTestStat.h
+++ b/interface/BestFitSigmaTestStat.h
@@ -19,9 +19,9 @@ class BestFitSigmaTestStat : public RooStats::TestStatistic {
                 const RooArgSet *nuisances, 
                 const RooArgSet & params, int verbosity=0) ; 
 
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) ;
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override ;
 
-        virtual const TString GetVarName() const { return "mu-hat`"; }
+        const TString GetVarName() const override { return "mu-hat`"; }
 
         // Verbosity (default: 0)
         void setPrintLevel(Int_t level) { verbosity_ = level; }

--- a/interface/CMSExternalMorph.h
+++ b/interface/CMSExternalMorph.h
@@ -22,7 +22,7 @@ class CMSExternalMorph : public RooAbsReal {
         const std::vector<double>& edges
     );
     CMSExternalMorph(CMSExternalMorph const& other, const char* name = 0);
-    virtual ~CMSExternalMorph();
+    ~CMSExternalMorph() override;
 
     /* Batch accessor for CMSHistFunc / CMSHistSum, to be overriden by concrete
      * implementations. hasChanged() should indicate whether or not
@@ -36,10 +36,10 @@ class CMSExternalMorph : public RooAbsReal {
     RooRealProxy x_;
     std::vector<double> edges_;
 
-    double evaluate() const;
+    double evaluate() const override;
 
   private:
-    ClassDef(CMSExternalMorph, 1)
+    ClassDefOverride(CMSExternalMorph, 1)
 };
 
 #endif // CMSExternalMorph_h

--- a/interface/CMSHggFormula.h
+++ b/interface/CMSHggFormula.h
@@ -12,8 +12,8 @@ class CMSHggFormulaA1 : public RooAbsReal {
                  RooAbsReal & p2, RooAbsReal & p3, RooArgList const& terms,
                  std::vector<double> const& coeffs);
   CMSHggFormulaA1(const CMSHggFormulaA1& other, const char* name = 0);
-  virtual ~CMSHggFormulaA1() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaA1(*this, newname); }
+  ~CMSHggFormulaA1() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaA1(*this, newname); }
 
  protected:
   RooRealProxy p0_;
@@ -23,10 +23,10 @@ class CMSHggFormulaA1 : public RooAbsReal {
   RooListProxy terms_;
   std::vector<double> coeffs_;
   mutable std::vector<RooAbsReal*> vterms_; //! not to be serialized
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaA1,1)
+  ClassDefOverride(CMSHggFormulaA1,1)
 
 };
 
@@ -37,8 +37,8 @@ class CMSHggFormulaA2 : public RooAbsReal {
                  RooAbsReal & p2, RooAbsReal & p3, RooArgList const& terms,
                  std::vector<double> const& coeffs);
   CMSHggFormulaA2(const CMSHggFormulaA2& other, const char* name = 0);
-  virtual ~CMSHggFormulaA2() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaA2(*this, newname); }
+  ~CMSHggFormulaA2() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaA2(*this, newname); }
 
  protected:
   RooRealProxy p0_;
@@ -48,10 +48,10 @@ class CMSHggFormulaA2 : public RooAbsReal {
   RooListProxy terms_;
   std::vector<double> coeffs_;
   mutable std::vector<RooAbsReal*> vterms_; //! not to be serialized
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaA2,1)
+  ClassDefOverride(CMSHggFormulaA2,1)
 
 };
 
@@ -61,18 +61,18 @@ class CMSHggFormulaB1 : public RooAbsReal {
   CMSHggFormulaB1(const char* name, const char* title, RooAbsReal & p0, RooArgList const& terms,
                  std::vector<double> const& coeffs);
   CMSHggFormulaB1(const CMSHggFormulaB1& other, const char* name = 0);
-  virtual ~CMSHggFormulaB1() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaB1(*this, newname); }
+  ~CMSHggFormulaB1() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaB1(*this, newname); }
 
  protected:
   RooRealProxy p0_;
   RooListProxy terms_;
   std::vector<double> coeffs_;
   mutable std::vector<RooAbsReal*> vterms_; //! not to be serialized
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaB1,1)
+  ClassDefOverride(CMSHggFormulaB1,1)
 
 };
 
@@ -82,18 +82,18 @@ class CMSHggFormulaB2 : public RooAbsReal {
   CMSHggFormulaB2(const char* name, const char* title, double const& p0, RooArgList const& terms,
                  std::vector<double> const& coeffs);
   CMSHggFormulaB2(const CMSHggFormulaB2& other, const char* name = 0);
-  virtual ~CMSHggFormulaB2() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaB2(*this, newname); }
+  ~CMSHggFormulaB2() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaB2(*this, newname); }
 
  protected:
   double p0_;
   RooListProxy terms_;
   std::vector<double> coeffs_;
   mutable std::vector<RooAbsReal*> vterms_; //! not to be serialized
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaB2,1)
+  ClassDefOverride(CMSHggFormulaB2,1)
 
 };
 
@@ -103,17 +103,17 @@ class CMSHggFormulaC1 : public RooAbsReal {
   CMSHggFormulaC1(const char* name, const char* title, RooArgList const& terms,
                  std::vector<double> const& coeffs);
   CMSHggFormulaC1(const CMSHggFormulaC1& other, const char* name = 0);
-  virtual ~CMSHggFormulaC1() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaC1(*this, newname); }
+  ~CMSHggFormulaC1() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaC1(*this, newname); }
 
  protected:
   RooListProxy terms_;
   std::vector<double> coeffs_;
   mutable std::vector<RooAbsReal*> vterms_; //! not to be serialized
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaC1,1)
+  ClassDefOverride(CMSHggFormulaC1,1)
 
 };
 
@@ -122,16 +122,16 @@ class CMSHggFormulaD1 : public RooAbsReal {
   CMSHggFormulaD1() {}
   CMSHggFormulaD1(const char* name, const char* title, RooAbsReal & p0, RooAbsReal & p1);
   CMSHggFormulaD1(const CMSHggFormulaD1& other, const char* name = 0);
-  virtual ~CMSHggFormulaD1() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaD1(*this, newname); }
+  ~CMSHggFormulaD1() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaD1(*this, newname); }
 
  protected:
   RooRealProxy p0_;
   RooRealProxy p1_;
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaD1,1)
+  ClassDefOverride(CMSHggFormulaD1,1)
 
 };
 
@@ -140,16 +140,16 @@ class CMSHggFormulaD2 : public RooAbsReal {
   CMSHggFormulaD2() {}
   CMSHggFormulaD2(const char* name, const char* title, RooAbsReal & p0, double const& p1);
   CMSHggFormulaD2(const CMSHggFormulaD2& other, const char* name = 0);
-  virtual ~CMSHggFormulaD2() {}
-  virtual TObject* clone(const char* newname) const { return new CMSHggFormulaD2(*this, newname); }
+  ~CMSHggFormulaD2() override {}
+  TObject* clone(const char* newname) const override { return new CMSHggFormulaD2(*this, newname); }
 
  protected:
   RooRealProxy p0_;
   double p1_;
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(CMSHggFormulaD2,1)
+  ClassDefOverride(CMSHggFormulaD2,1)
 
 };
 

--- a/interface/CMSHistErrorPropagator.h
+++ b/interface/CMSHistErrorPropagator.h
@@ -41,27 +41,27 @@ public:
 
   CMSHistErrorPropagator(CMSHistErrorPropagator const& other, const char* name = 0);
 
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new CMSHistErrorPropagator(*this, newname);
   }
 
-  virtual ~CMSHistErrorPropagator() {;}
+  ~CMSHistErrorPropagator() override {;}
 
   void applyErrorShifts(unsigned idx, FastHisto const& nominal, FastHisto & result);
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
   RooArgList * setupBinPars(double poissonThreshold);
 
   std::unique_ptr<RooArgSet> getSentryArgs() const;
 
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
-                      TString indent) const;
+                      TString indent) const override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
-                              const char* rangeName = 0) const;
+                              const char* rangeName = 0) const override;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 
   void setData(RooAbsData const& data) const;
 
@@ -111,7 +111,7 @@ public:
 
 
  private:
-  ClassDef(CMSHistErrorPropagator,1)
+  ClassDefOverride(CMSHistErrorPropagator,1)
 };
 
 #endif

--- a/interface/CMSHistFunc.h
+++ b/interface/CMSHistFunc.h
@@ -83,10 +83,10 @@ class CMSHistFunc : public RooAbsReal {
 
   CMSHistFunc(CMSHistFunc const& other, const char* name = 0);
 
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new CMSHistFunc(*this, newname);
   }
-  virtual ~CMSHistFunc();
+  ~CMSHistFunc() override;
 
   void addHorizontalMorph(RooAbsReal& hvar, TVectorD hpoints);
 
@@ -99,19 +99,19 @@ class CMSHistFunc : public RooAbsReal {
   void setShape(unsigned hindex, unsigned hpoint, unsigned vindex,
                 unsigned vpoint, TH1 const& hist);
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
   void updateCache() const;
 
   std::unique_ptr<RooArgSet> getSentryArgs() const;
 
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
-                      TString indent) const;
+                      TString indent) const override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
-                              const char* rangeName = 0) const;
+                              const char* rangeName = 0) const override;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 
   inline void setMorphStrategy(unsigned strategy) {
     morph_strategy_ = strategy;
@@ -219,7 +219,7 @@ class CMSHistFunc : public RooAbsReal {
 
   void applyRebin() const;
 
-  ClassDef(CMSHistFunc, 2)
+  ClassDefOverride(CMSHistFunc, 2)
 };
 
 

--- a/interface/CMSHistFuncWrapper.h
+++ b/interface/CMSHistFuncWrapper.h
@@ -24,20 +24,20 @@ class CMSHistFuncWrapper : public RooAbsReal {
 
   CMSHistFuncWrapper(CMSHistFuncWrapper const& other, const char* name = 0);
 
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new CMSHistFuncWrapper(*this, newname);
   }
-  virtual ~CMSHistFuncWrapper() {}
+  ~CMSHistFuncWrapper() override {}
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
-                      TString indent) const;
+                      TString indent) const override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
-                              const char* rangeName = 0) const;
+                              const char* rangeName = 0) const override;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 
   void updateCache() const;
 
@@ -55,7 +55,7 @@ class CMSHistFuncWrapper : public RooAbsReal {
   mutable SimpleCacheSentry sentry_; //!
 
  private:
-  ClassDef(CMSHistFuncWrapper, 1)
+  ClassDefOverride(CMSHistFuncWrapper, 1)
   mutable CMSHistFunc const* pfunc_;
   mutable CMSHistErrorPropagator * perr_;
   mutable bool initialized_; //! not to be serialized

--- a/interface/CMSHistSum.h
+++ b/interface/CMSHistSum.h
@@ -42,13 +42,13 @@ public:
 
   CMSHistSum(CMSHistSum const& other, const char* name = 0);
 
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new CMSHistSum(*this, newname);
   }
 
-  virtual ~CMSHistSum() {;}
+  ~CMSHistSum() override {;}
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
   std::map<std::string, Double_t> getProcessNorms() const;
 
@@ -57,12 +57,12 @@ public:
   std::unique_ptr<RooArgSet> getSentryArgs() const;
 
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose,
-                      TString indent) const;
+                      TString indent) const override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
-                              const char* rangeName = 0) const;
+                              const char* rangeName = 0) const override;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 
   void setData(RooAbsData const& data) const;
 
@@ -150,7 +150,7 @@ public:
 
 
  private:
-  ClassDef(CMSHistSum,2)
+  ClassDefOverride(CMSHistSum,2)
 };
 
 #endif

--- a/interface/CMSInterferenceFunc.h
+++ b/interface/CMSInterferenceFunc.h
@@ -25,9 +25,9 @@ class CMSInterferenceFunc : public CMSExternalMorph {
         const RooArgList& coefficients,
         const std::vector<std::vector<double>> binscaling
         );
-    virtual ~CMSInterferenceFunc();
+    ~CMSInterferenceFunc() override;
 
-    virtual TObject* clone(const char* newname) const override {
+    TObject* clone(const char* newname) const override {
       return new CMSInterferenceFunc(*this, newname);
     };
 

--- a/interface/CachingMultiPdf.h
+++ b/interface/CachingMultiPdf.h
@@ -12,11 +12,11 @@ namespace cacheutils {
     class CachingMultiPdf : public CachingPdfBase {
         public:
             CachingMultiPdf(const RooMultiPdf &pdf, const RooArgSet &obs) ;
-            ~CachingMultiPdf() ;
-            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-            const RooAbsReal *pdf() const { return pdf_; }
-            virtual void  setDataDirty() ;
-            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+            ~CachingMultiPdf() override ;
+            const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+            const RooAbsReal *pdf() const override { return pdf_; }
+            void  setDataDirty() override ;
+            void  setIncludeZeroWeights(bool includeZeroWeights) override ;
         protected:
             const RooMultiPdf * pdf_;
             boost::ptr_vector<CachingPdfBase>  cachingPdfs_;
@@ -25,11 +25,11 @@ namespace cacheutils {
     class CachingAddPdf : public CachingPdfBase {
         public:
             CachingAddPdf(const RooAddPdf &pdf, const RooArgSet &obs) ;
-            ~CachingAddPdf() ;
-            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-            const RooAbsReal *pdf() const { return pdf_; }
-            virtual void  setDataDirty() ;
-            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+            ~CachingAddPdf() override ;
+            const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+            const RooAbsReal *pdf() const override { return pdf_; }
+            void  setDataDirty() override ;
+            void  setIncludeZeroWeights(bool includeZeroWeights) override ;
         protected:
             const RooAddPdf * pdf_;
             std::vector<const RooAbsReal *> coeffs_;
@@ -40,11 +40,11 @@ namespace cacheutils {
     class CachingProduct : public CachingPdfBase {
         public:
             CachingProduct(const RooProduct &pdf, const RooArgSet &obs) ;
-            ~CachingProduct() ;
-            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-            const RooAbsReal *pdf() const { return pdf_; }
-            virtual void  setDataDirty() ;
-            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+            ~CachingProduct() override ;
+            const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+            const RooAbsReal *pdf() const override { return pdf_; }
+            void  setDataDirty() override ;
+            void  setIncludeZeroWeights(bool includeZeroWeights) override ;
         protected:
             const RooProduct * pdf_;
             boost::ptr_vector<CachingPdfBase>  cachingPdfs_;

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -122,7 +122,11 @@ class CachingAddNLL : public RooAbsReal {
         Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
         virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
-        virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const ;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
+        RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
+#else
+        bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
+#endif
         double  sumWeights() const { return sumWeights_; }
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
@@ -168,8 +172,11 @@ class CachingSimNLL  : public RooAbsReal {
         Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
         virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
-        virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const ;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
+        RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
+#else
         bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
+#endif
         void splitWithWeights(const RooAbsData &data, const RooAbsCategory& splitCat, Bool_t createEmptyDataSets) ;
         static void setNoDeepLogEvalError(bool noDeep) { noDeepLEE_ = noDeep; }
         void setZeroPoint() ; 

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -76,11 +76,11 @@ class CachingPdf : public CachingPdfBase {
     public:
         CachingPdf(RooAbsReal *pdf, const RooArgSet *obs) ;
         CachingPdf(const CachingPdf &other) ;
-        virtual ~CachingPdf() ;
-        virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-        const RooAbsReal *pdf() const { return pdf_; }
-        virtual void  setDataDirty() { lastData_ = 0; }
-        virtual void  setIncludeZeroWeights(bool includeZeroWeights) { includeZeroWeights_ = includeZeroWeights;  setDataDirty(); }
+        ~CachingPdf() override ;
+        const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+        const RooAbsReal *pdf() const override { return pdf_; }
+        void  setDataDirty() override { lastData_ = 0; }
+        void  setIncludeZeroWeights(bool includeZeroWeights) override { includeZeroWeights_ = includeZeroWeights;  setDataDirty(); }
     protected:
         const RooArgSet *obs_;
         RooAbsReal *pdfOriginal_;
@@ -102,10 +102,10 @@ class OptimizedCachingPdfT : public CachingPdf {
             CachingPdf(pdf,obs), vpdf_(0) {}
         OptimizedCachingPdfT(const OptimizedCachingPdfT &other) : 
             CachingPdf(other), vpdf_(0) {}
-        virtual ~OptimizedCachingPdfT() { delete vpdf_; }
+        ~OptimizedCachingPdfT() override { delete vpdf_; }
     protected:
-        virtual void realFill_(const RooAbsData &data, std::vector<Double_t> &values) ;
-        virtual void newData_(const RooAbsData &data) ;
+        void realFill_(const RooAbsData &data, std::vector<Double_t> &values) override ;
+        void newData_(const RooAbsData &data) override ;
         VPdfT *vpdf_;
 };
 
@@ -115,11 +115,11 @@ class CachingAddNLL : public RooAbsReal {
     public:
         CachingAddNLL(const char *name, const char *title, RooAbsPdf *pdf, RooAbsData *data, bool includeZeroWeights = false) ;
         CachingAddNLL(const CachingAddNLL &other, const char *name = 0) ;
-        virtual ~CachingAddNLL() ;
-        virtual CachingAddNLL *clone(const char *name = 0) const ;
-        virtual Double_t evaluate() const ;
-        virtual Bool_t isDerived() const { return kTRUE; }
-        virtual Double_t defaultErrorLevel() const { return 0.5; }
+        ~CachingAddNLL() override ;
+        CachingAddNLL *clone(const char *name = 0) const override ;
+        Double_t evaluate() const override ;
+        Bool_t isDerived() const override { return kTRUE; }
+        Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
         virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
         virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const ;
@@ -161,15 +161,15 @@ class CachingSimNLL  : public RooAbsReal {
     public:
         CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data, const RooArgSet *nuis=0) ;
         CachingSimNLL(const CachingSimNLL &other, const char *name = 0) ;
-        ~CachingSimNLL() ;
-        virtual CachingSimNLL *clone(const char *name = 0) const ;
-        virtual Double_t evaluate() const ;
-        virtual Bool_t isDerived() const { return kTRUE; }
-        virtual Double_t defaultErrorLevel() const { return 0.5; }
+        ~CachingSimNLL() override ;
+        CachingSimNLL *clone(const char *name = 0) const override ;
+        Double_t evaluate() const override ;
+        Bool_t isDerived() const override { return kTRUE; }
+        Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
         virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
         virtual RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const ;
-        virtual bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const;
+        bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
         void splitWithWeights(const RooAbsData &data, const RooAbsCategory& splitCat, Bool_t createEmptyDataSets) ;
         static void setNoDeepLogEvalError(bool noDeep) { noDeepLEE_ = noDeep; }
         void setZeroPoint() ; 
@@ -185,7 +185,7 @@ class CachingSimNLL  : public RooAbsReal {
         void setMaskNonDiscreteChannels(bool mask) ;
         friend class CachingAddNLL;
         // trap this call, since we don't care about propagating it to the sub-components
-        virtual void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) { }
+        void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) override { }
     private:
         void setup_();
         RooSimultaneous   *pdfOriginal_;

--- a/interface/ChannelCompatibilityCheck.h
+++ b/interface/ChannelCompatibilityCheck.h
@@ -13,11 +13,11 @@
 class ChannelCompatibilityCheck : public FitterAlgoBase {
 public:
   ChannelCompatibilityCheck() ;
-  virtual const std::string & name() const {
+  const std::string & name() const override {
     static const std::string name("ChannelCompatibilityCheck");
     return name;
   }
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 
 protected:
   std::string nameForLabel(const char *label) ;
@@ -31,7 +31,7 @@ protected:
   static std::vector<std::string> groups_;
   static std::map<TString,std::pair<double,double>> groupRanges_;
 
-  virtual bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
 };
 
 

--- a/interface/CombDataSetFactory.h
+++ b/interface/CombDataSetFactory.h
@@ -22,7 +22,7 @@ class CombDataSetFactory : public TObject {
    public:
       CombDataSetFactory() {}
       CombDataSetFactory(const RooArgSet &vars, RooCategory &cat) ;
-      ~CombDataSetFactory() ;
+      ~CombDataSetFactory() override ;
 
       void addSetBin(const char *label, RooDataHist *set);
       void addSetAny(const char *label, RooDataSet  *set);
@@ -31,7 +31,7 @@ class CombDataSetFactory : public TObject {
       RooDataHist *done(const char *name, const char *title) ;
       RooDataSet *doneUnbinned(const char *name, const char *title) ;
 
-      ClassDef(CombDataSetFactory,1) // Make RooDataHist
+      ClassDefOverride(CombDataSetFactory,1) // Make RooDataHist
 
     private:
         RooArgSet vars_;

--- a/interface/DebugProposal.h
+++ b/interface/DebugProposal.h
@@ -18,20 +18,20 @@ class DebugProposal : public RooStats::ProposalFunction {
       DebugProposal(RooStats::ProposalFunction *p, RooAbsPdf *pdf, RooAbsData *data, int tries) ;
 
       // Populate xPrime with a new proposed point
-      virtual void Propose(RooArgSet& xPrime, RooArgSet& x);
+      void Propose(RooArgSet& xPrime, RooArgSet& x) override;
 
       // Determine whether or not the proposal density is symmetric for
       // points x1 and x2 - that is, whether the probabilty of reaching x2
       // from x1 is equal to the probability of reaching x1 from x2
-      virtual Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) ;
+      Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) override ;
 
       // Return the probability of proposing the point x1 given the starting
       // point x2
-      virtual Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2);
+      Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2) override;
 
-      virtual ~DebugProposal() {}
+      ~DebugProposal() override {}
 
-      ClassDef(DebugProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
+      ClassDefOverride(DebugProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
 
     private:
         RooStats::ProposalFunction *prop_;

--- a/interface/FastTemplateFunc.h
+++ b/interface/FastTemplateFunc.h
@@ -16,7 +16,7 @@ public:
   FastTemplateFunc_t() : RooAbsReal(), obsList("obsList", "obsList", this){}
   FastTemplateFunc_t(const char *name, const char *title, RooArgList& inObsList) : RooAbsReal(name, title), obsList("obsList", "obsList", this){ setProxyList(obsList, inObsList); }
   FastTemplateFunc_t(const FastTemplateFunc_t& other, const char* name=0) : RooAbsReal(other, name), obsList("obsList", this, other.obsList){}
-  virtual inline ~FastTemplateFunc_t(){}
+  inline ~FastTemplateFunc_t() override{}
 
   void setProxyList(RooListProxy& proxyList, RooArgList& varList){
     for (RooAbsArg *var : varList) {
@@ -27,13 +27,13 @@ public:
     }
   }
 
-  virtual TObject* clone(const char* newname) const = 0;
-  virtual Double_t evaluate() const = 0;
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const = 0;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const = 0;
+  TObject* clone(const char* newname) const override = 0;
+  Double_t evaluate() const override = 0;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override = 0;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override = 0;
 
 private:
-  ClassDef(FastTemplateFunc_t, 1)
+  ClassDefOverride(FastTemplateFunc_t, 1)
 
 };
 typedef FastTemplateFunc_t<Float_t> FastTemplateFunc_f;
@@ -94,7 +94,7 @@ public:
   }
 
 private:
-  ClassDef(FastHistoFunc_t, 1)
+  ClassDefOverride(FastHistoFunc_t, 1)
 
 };
 typedef FastHistoFunc_t<Float_t> FastHistoFunc_f;
@@ -186,7 +186,7 @@ public:
   }
 
 private:
-  ClassDef(FastHisto2DFunc_t, 1)
+  ClassDefOverride(FastHisto2DFunc_t, 1)
 
 };
 typedef FastHisto2DFunc_t<Float_t> FastHisto2DFunc_f;
@@ -296,7 +296,7 @@ public:
   }
 
 private:
-  ClassDef(FastHisto3DFunc_t, 1)
+  ClassDefOverride(FastHisto3DFunc_t, 1)
 
 };
 typedef FastHisto3DFunc_t<Float_t> FastHisto3DFunc_f;

--- a/interface/FeldmanCousins.h
+++ b/interface/FeldmanCousins.h
@@ -13,10 +13,10 @@
 class FeldmanCousins : public LimitAlgo {
 public:
   FeldmanCousins() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 
-  virtual const std::string & name() const {
+  const std::string & name() const override {
     static const std::string name("FeldmanCousins");
     return name;
   }

--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -18,17 +18,17 @@
 class FitDiagnostics : public FitterAlgoBase {
 public:
   FitDiagnostics() ;
-  virtual const std::string & name() const {
+  const std::string & name() const override {
     static const std::string name("FitDiagnostics");
     return name;
   }
-  ~FitDiagnostics();
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
-  virtual void setToyNumber(const int) ;
-  virtual void setNToys(const int);
+  ~FitDiagnostics() override;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
+  void setToyNumber(const int) override ;
+  void setNToys(const int) override;
 
 protected:
-  virtual bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
 
   static std::string name_;
   static std::string massName_;
@@ -97,19 +97,19 @@ protected:
   class CovarianceReSampler : public NuisanceSampler {
     public:
         CovarianceReSampler(RooFitResult *res) : res_(res) {}
-        virtual void  generate(int ntoys) {}
-        virtual const RooAbsCollection & get(int) { return res_->randomizePars(); }
-        virtual const RooAbsCollection & centralValues() { return res_->floatParsFinal(); }
+        void  generate(int ntoys) override {}
+        const RooAbsCollection & get(int) override { return res_->randomizePars(); }
+        const RooAbsCollection & centralValues() override { return res_->floatParsFinal(); }
     protected:
         RooFitResult *res_;
   };
   class ToySampler : public NuisanceSampler, boost::noncopyable {
     public:
         ToySampler(RooAbsPdf *pdf, const RooArgSet *nuisances) ;    
-        virtual ~ToySampler() ;
-        virtual void  generate(int ntoys);
-        virtual const RooAbsCollection & get(int itoy);
-        virtual const RooAbsCollection & centralValues();
+        ~ToySampler() override ;
+        void  generate(int ntoys) override;
+        const RooAbsCollection & get(int itoy) override;
+        const RooAbsCollection & centralValues() override;
     private:
         RooAbsPdf  *pdf_;
         RooAbsData *data_;

--- a/interface/FitterAlgoBase.h
+++ b/interface/FitterAlgoBase.h
@@ -25,7 +25,7 @@ public:
   void applyOptionsBase(const boost::program_options::variables_map &vm) ;
 
   // configures the minimizer and then calls runSpecific
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
 
 protected:
   //static std::string minimizerAlgo_, 

--- a/interface/GaussExp.h
+++ b/interface/GaussExp.h
@@ -22,7 +22,7 @@ public:
 	      RooAbsReal& _p1,
 	      RooAbsReal& _p2);
   GaussExp(const GaussExp& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new GaussExp(*this,newname); }
+  TObject* clone(const char* newname) const override { return new GaussExp(*this,newname); }
   // inline virtual ~GaussExp() { }
 
 protected:
@@ -32,11 +32,11 @@ protected:
   RooRealProxy p1 ;
   RooRealProxy p2 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(GaussExp,1) // Your description goes here...
+  ClassDefOverride(GaussExp,1) // Your description goes here...
 };
  
 #endif

--- a/interface/GenerateOnly.h
+++ b/interface/GenerateOnly.h
@@ -15,12 +15,12 @@ class RooAbsPdf; class RooRealVar; class RooAbsData; class RooArgSet;
 class GenerateOnly : public LimitAlgo {
 public:
   GenerateOnly() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  const std::string & name() const override {
     static const std::string name("GenerateOnly");
     return name;
   }
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 };
 
 #endif

--- a/interface/GoodnessOfFit.h
+++ b/interface/GoodnessOfFit.h
@@ -16,12 +16,12 @@ class TDirectory;
 class GoodnessOfFit : public LimitAlgo {
 public:
   GoodnessOfFit() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  const std::string & name() const override {
     static const std::string name("GoodnessOfFit");
     return name;
   }
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 
   virtual bool runSaturatedModel(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   virtual bool runKSandAD(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint, bool kolmo);

--- a/interface/HGGRooPdfs.h
+++ b/interface/HGGRooPdfs.h
@@ -28,11 +28,11 @@ public:
   RooPower(const char *name, const char *title,
 		 RooAbsReal& _x, RooAbsReal& _c);
   RooPower(const RooPower& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooPower(*this,newname); }
-  inline virtual ~RooPower() { }
+  TObject* clone(const char* newname) const override { return new RooPower(*this,newname); }
+  inline ~RooPower() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   const RooAbsReal & base() const { return x.arg(); }
   const RooAbsReal & exponent() const { return c.arg(); }
 
@@ -40,10 +40,10 @@ protected:
   RooRealProxy x;
   RooRealProxy c;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
-  ClassDef(RooPower,1) // Exponential PDF
+  ClassDefOverride(RooPower,1) // Exponential PDF
 };
 
 #endif

--- a/interface/HWWLVJJRooPdfs.h
+++ b/interface/HWWLVJJRooPdfs.h
@@ -20,14 +20,14 @@ public:
   RooChebyshevPDF(const char *name, const char *title, RooAbsReal& var,
                   RooArgList& coefList);
   RooChebyshevPDF(const RooChebyshevPDF& other, const char *name=0);
-  virtual TObject* clone(const char *newname) const {
+  TObject* clone(const char *newname) const override {
     return new RooChebyshevPDF(*this, newname); }
 
-  virtual ~RooChebyshevPDF();
+  ~RooChebyshevPDF() override;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, 
-                              const char *rangeName = 0) const;
-  Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const;
+                              const char *rangeName = 0) const override;
+  Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const override;
 
   static Double_t ChebyshevP(Int_t order, Double_t v);
 
@@ -36,11 +36,11 @@ protected:
   RooRealProxy x;
   RooListProxy coefs;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
 
-  ClassDef(RooChebyshevPDF,1) //Chebyshev polynomial implementation.
+  ClassDefOverride(RooChebyshevPDF,1) //Chebyshev polynomial implementation.
 };
 
 
@@ -57,12 +57,12 @@ public:
 	    RooAbsReal& _width,
 	    int _onOff = 1);
   RooErfPdf(const RooErfPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooErfPdf(*this,newname); }
-  inline virtual ~RooErfPdf() { }
+  TObject* clone(const char* newname) const override { return new RooErfPdf(*this,newname); }
+  inline ~RooErfPdf() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
-  virtual void	printMultiline(std::ostream& os, Int_t contents, Bool_t verbose = kFALSE, TString indent = "") const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  void	printMultiline(std::ostream& os, Int_t contents, Bool_t verbose = kFALSE, TString indent = "") const override ;
 
 protected:
 
@@ -73,11 +73,11 @@ protected:
   RooRealProxy width ;
   int onOff;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooErfPdf,1) // Your description goes here...
+  ClassDefOverride(RooErfPdf,1) // Your description goes here...
 };
  
 /*
@@ -92,11 +92,11 @@ public:
 	      RooAbsReal& _c,
 	      RooAbsReal& _power);
   RooPowerExpPdf(const RooPowerExpPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooPowerExpPdf(*this,newname); }
-  inline virtual ~RooPowerExpPdf() { }
+  TObject* clone(const char* newname) const override { return new RooPowerExpPdf(*this,newname); }
+  inline ~RooPowerExpPdf() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -104,11 +104,11 @@ protected:
   RooRealProxy c ;
   RooRealProxy power ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooPowerExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooPowerExpPdf,1) // Your description goes here...
 };
  
 
@@ -125,12 +125,12 @@ public:
 	     RooAbsReal& _x,
 	     TH1D& _hist, bool _interpolate = false);
   RooTH1DPdf(const RooTH1DPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooTH1DPdf(*this,newname); }
-  inline virtual ~RooTH1DPdf() { }
+  TObject* clone(const char* newname) const override { return new RooTH1DPdf(*this,newname); }
+  inline ~RooTH1DPdf() override { }
 
   TH1D & getHist() { return hist ; }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -138,11 +138,11 @@ protected:
   mutable TH1D hist ;
   bool interpolate ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooTH1DPdf,1) // Your description goes here...
+  ClassDefOverride(RooTH1DPdf,1) // Your description goes here...
 };
  
 class RooPowerFunction : public RooAbsReal {
@@ -152,22 +152,22 @@ public:
               RooAbsReal& _x,
               RooAbsReal& _r);
   RooPowerFunction(const RooPowerFunction& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooPowerFunction(*this,newname); }
-  inline virtual ~RooPowerFunction() { }
+  TObject* clone(const char* newname) const override { return new RooPowerFunction(*this,newname); }
+  inline ~RooPowerFunction() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
   RooRealProxy x ;
   RooRealProxy r ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooPowerFunction,1) // Your description goes here...
+  ClassDefOverride(RooPowerFunction,1) // Your description goes here...
 };
 
 /*
@@ -181,22 +181,22 @@ public:
 	      RooAbsReal& _power) ;
   RooPowerLaw(const RooPowerLaw& other, const char * name = 0) ;
 
-  virtual TObject * clone(const char * newname) const { return new RooPowerLaw(*this, newname); }
+  TObject * clone(const char * newname) const override { return new RooPowerLaw(*this, newname); }
 
-  inline virtual ~RooPowerLaw() { }
+  inline ~RooPowerLaw() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& anVars, 
-  			      const char * rangeName = 0) const ;
-  Double_t analyticalIntegral(Int_t code, const char * rangeName = 0) const ;
+  			      const char * rangeName = 0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char * rangeName = 0) const override ;
 
 protected:
   RooRealProxy x;
   RooRealProxy power;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
-  ClassDef(RooPowerLaw, 1) // Power law PDF
+  ClassDefOverride(RooPowerLaw, 1) // Power law PDF
 };
  
 class RooExpPoly : public RooAbsPdf {
@@ -206,12 +206,12 @@ public:
 	      RooAbsReal& _x,
 	      RooArgList& _coefs);
   RooExpPoly(const RooExpPoly& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooExpPoly(*this,newname); }
-  inline virtual ~RooExpPoly() { }
+  TObject* clone(const char* newname) const override { return new RooExpPoly(*this,newname); }
+  inline ~RooExpPoly() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, 
-			      const char *rangeName = 0) const;
-  Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const;
+			      const char *rangeName = 0) const override;
+  Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const override;
 
   //Emuation of deprecated RooComplex (that used Double_t)
   typedef std::complex<Double_t> DoubleComplex_t;
@@ -222,11 +222,11 @@ protected:
   RooRealProxy x ;
   RooListProxy coefs ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooExpPoly,1) // Your description goes here...
+  ClassDefOverride(RooExpPoly,1) // Your description goes here...
 };
 
 #endif

--- a/interface/HWWLVJRooPdfs.h
+++ b/interface/HWWLVJRooPdfs.h
@@ -28,12 +28,12 @@ class RooErfExpPdf : public RooAbsPdf {
 
   RooErfExpPdf(const RooErfExpPdf& other, const char* name=0) ; // ctor
 
-  virtual TObject* clone(const char* newname) const { return new RooErfExpPdf(*this,newname); } // clone 
+  TObject* clone(const char* newname) const override { return new RooErfExpPdf(*this,newname); } // clone 
 
-  inline virtual ~RooErfExpPdf() { } // dtor
+  inline ~RooErfExpPdf() override { } // dtor
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ; // analytic integral
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ; // analytic integral
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -42,11 +42,11 @@ protected:
   RooRealProxy offset ;
   RooRealProxy width ;
   
-  Double_t evaluate() const ; // evaluate method 
+  Double_t evaluate() const override ; // evaluate method 
 
 private:
 
-  ClassDef(RooErfExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooErfExpPdf,1) // Your description goes here...
 };
 
 
@@ -68,9 +68,9 @@ class RooAlpha : public RooAbsPdf {
 
 	RooAlpha(const RooAlpha& other, const char* name=0) ;
 
-	virtual TObject* clone(const char* newname) const { return new RooAlpha(*this,newname); }
+	TObject* clone(const char* newname) const override { return new RooAlpha(*this,newname); }
 
-	inline virtual ~RooAlpha() { }
+	inline ~RooAlpha() override { }
 
         Double_t xmin;
         Double_t xmax;
@@ -85,11 +85,11 @@ class RooAlpha : public RooAbsPdf {
 	   RooRealProxy offseta;
 	   RooRealProxy widtha;
 
-	   Double_t evaluate() const ;
+	   Double_t evaluate() const override ;
 
  private:
 
-	  ClassDef(RooAlpha,1)
+	  ClassDefOverride(RooAlpha,1)
 };
 
 
@@ -106,9 +106,9 @@ class RooAlphaExp : public RooAbsPdf {
 
 		RooAlphaExp(const RooAlphaExp& other, const char* name=0) ;
 
-		virtual TObject* clone(const char* newname) const { return new RooAlphaExp(*this,newname); }
+		TObject* clone(const char* newname) const override { return new RooAlphaExp(*this,newname); }
 
-		inline virtual ~RooAlphaExp() { }
+		inline ~RooAlphaExp() override { }
 
         Double_t xmin;
         Double_t xmax;
@@ -118,11 +118,11 @@ class RooAlphaExp : public RooAbsPdf {
 		RooRealProxy x ;
 		RooRealProxy c;
 		RooRealProxy ca;
-		Double_t evaluate() const ;
+		Double_t evaluate() const override ;
 
 	private:
 
-		ClassDef(RooAlphaExp,1)
+		ClassDefOverride(RooAlphaExp,1)
 };
 
 
@@ -137,9 +137,9 @@ public:
 
   RooBWRunPdf(const RooBWRunPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooBWRunPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooBWRunPdf(*this,newname); }
 
-  inline virtual ~RooBWRunPdf() { }
+  inline ~RooBWRunPdf() override { }
 
 protected:
 
@@ -147,11 +147,11 @@ protected:
   RooRealProxy mean ;
   RooRealProxy width ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooBWRunPdf,1) // Your description goes here...
+  ClassDefOverride(RooBWRunPdf,1) // Your description goes here...
 };
 
 ////////////  Erf*Pow2 function 
@@ -170,9 +170,9 @@ public:
 
   RooErfPow2Pdf(const RooErfPow2Pdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooErfPow2Pdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooErfPow2Pdf(*this,newname); }
 
-  inline virtual ~RooErfPow2Pdf() { }
+  inline ~RooErfPow2Pdf() override { }
 
 protected:
 
@@ -182,11 +182,11 @@ protected:
   RooRealProxy offset ;
   RooRealProxy width ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooErfPow2Pdf,1) // Your description goes here...
+  ClassDefOverride(RooErfPow2Pdf,1) // Your description goes here...
 };
  
 
@@ -208,9 +208,9 @@ public:
 
   RooAlpha4ErfPow2Pdf(const RooAlpha4ErfPow2Pdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4ErfPow2Pdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4ErfPow2Pdf(*this,newname); }
 
-  inline virtual ~RooAlpha4ErfPow2Pdf() { }
+  inline ~RooAlpha4ErfPow2Pdf() override { }
 
 protected:
 
@@ -224,11 +224,11 @@ protected:
   RooRealProxy offseta ;
   RooRealProxy widtha ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4ErfPow2Pdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4ErfPow2Pdf,1) // Your description goes here...
 };
 
 
@@ -250,9 +250,9 @@ public:
 
   RooErfPowExpPdf(const RooErfPowExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooErfPowExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooErfPowExpPdf(*this,newname); }
 
-  inline virtual ~RooErfPowExpPdf() { }
+  inline ~RooErfPowExpPdf() override { }
 
 protected:
 
@@ -262,11 +262,11 @@ protected:
   RooRealProxy offset ;
   RooRealProxy width ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooErfPowExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooErfPowExpPdf,1) // Your description goes here...
 };
  
 
@@ -288,9 +288,9 @@ public:
 
   RooAlpha4ErfPowExpPdf(const RooAlpha4ErfPowExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4ErfPowExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4ErfPowExpPdf(*this,newname); }
 
-  inline virtual ~RooAlpha4ErfPowExpPdf() { }
+  inline ~RooAlpha4ErfPowExpPdf() override { }
 
 protected:
 
@@ -304,11 +304,11 @@ protected:
   RooRealProxy offseta ;
   RooRealProxy widtha ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4ErfPowExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4ErfPowExpPdf,1) // Your description goes here...
 };
 
 
@@ -327,9 +327,9 @@ public:
 
   RooGausExpPdf(const RooGausExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooGausExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooGausExpPdf(*this,newname); }
 
-  inline virtual ~RooGausExpPdf() { }
+  inline ~RooGausExpPdf() override { }
 
 protected:
 
@@ -338,11 +338,11 @@ protected:
   RooRealProxy mean ;
   RooRealProxy sigma ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooGausExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooGausExpPdf,1) // Your description goes here...
 };
 
 
@@ -362,9 +362,9 @@ public:
 
   RooAlpha4GausExpPdf(const RooAlpha4GausExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4GausExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4GausExpPdf(*this,newname); }
 
-  inline virtual ~RooAlpha4GausExpPdf() { }
+  inline ~RooAlpha4GausExpPdf() override { }
 
 protected:
 
@@ -376,11 +376,11 @@ protected:
   RooRealProxy meana ;
   RooRealProxy sigmaa ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4GausExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4GausExpPdf,1) // Your description goes here...
 };
 
 
@@ -400,9 +400,9 @@ public:
 
   RooErfPowPdf(const RooErfPowPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooErfPowPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooErfPowPdf(*this,newname); }
 
-  inline virtual ~RooErfPowPdf() { }
+  inline ~RooErfPowPdf() override { }
 
 protected:
 
@@ -411,11 +411,11 @@ protected:
   RooRealProxy offset ;
   RooRealProxy width ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooErfPowPdf,1) // Your description goes here...
+  ClassDefOverride(RooErfPowPdf,1) // Your description goes here...
 };
  
 
@@ -434,9 +434,9 @@ public:
 
   RooAlpha4ErfPowPdf(const RooAlpha4ErfPowPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4ErfPowPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4ErfPowPdf(*this,newname); }
 
-  inline virtual ~RooAlpha4ErfPowPdf() { }
+  inline ~RooAlpha4ErfPowPdf() override { }
 
 protected:
 
@@ -448,11 +448,11 @@ protected:
   RooRealProxy offseta ;
   RooRealProxy widtha ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4ErfPowPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4ErfPowPdf,1) // Your description goes here...
 };
 
 
@@ -468,9 +468,9 @@ public:
 
   RooPow2Pdf(const RooPow2Pdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooPow2Pdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooPow2Pdf(*this,newname); }
 
-  inline virtual ~RooPow2Pdf() { }
+  inline ~RooPow2Pdf() override { }
 
 protected:
 
@@ -478,11 +478,11 @@ protected:
   RooRealProxy p0 ;
   RooRealProxy p1 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooPow2Pdf,1) // Your description goes here...
+  ClassDefOverride(RooPow2Pdf,1) // Your description goes here...
 };
 
 ////// Pow Pdf 
@@ -495,20 +495,20 @@ public:
 
   RooPowPdf(const RooPowPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooPowPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooPowPdf(*this,newname); }
 
-  inline virtual ~RooPowPdf() { }
+  inline ~RooPowPdf() override { }
 
 protected:
 
   RooRealProxy x ;
   RooRealProxy p0 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooPowPdf,1) // Your description goes here...
+  ClassDefOverride(RooPowPdf,1) // Your description goes here...
 };
 
 
@@ -524,9 +524,9 @@ public:
 
   RooQCDPdf(const RooQCDPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooQCDPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooQCDPdf(*this,newname); }
 
-  inline virtual ~RooQCDPdf() { }
+  inline ~RooQCDPdf() override { }
 
 protected:
 
@@ -535,11 +535,11 @@ protected:
   RooRealProxy p1 ;
   RooRealProxy p2 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooQCDPdf,1) // Your description goes here...
+  ClassDefOverride(RooQCDPdf,1) // Your description goes here...
 };
 
 
@@ -555,9 +555,9 @@ public:
 
   RooUser1Pdf(const RooUser1Pdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooUser1Pdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooUser1Pdf(*this,newname); }
 
-  inline virtual ~RooUser1Pdf() { }
+  inline ~RooUser1Pdf() override { }
 
 protected:
 
@@ -565,11 +565,11 @@ protected:
   RooRealProxy p0 ;
   RooRealProxy p1 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooUser1Pdf,1) // Your description goes here...
+  ClassDefOverride(RooUser1Pdf,1) // Your description goes here...
 };
 
 
@@ -586,9 +586,9 @@ public:
 
   RooExpNPdf(const RooExpNPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooExpNPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooExpNPdf(*this,newname); }
 
-  inline virtual ~RooExpNPdf() { }
+  inline ~RooExpNPdf() override { }
 
 protected:
 
@@ -596,11 +596,11 @@ protected:
   RooRealProxy c ;
   RooRealProxy n ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooExpNPdf,1) // Your description goes here...
+  ClassDefOverride(RooExpNPdf,1) // Your description goes here...
 };
 
 //// Alpha function given by the ratio of two ExpN Pdf 
@@ -616,9 +616,9 @@ public:
 
   RooAlpha4ExpNPdf(const RooAlpha4ExpNPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4ExpNPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4ExpNPdf(*this,newname); }
 
-  inline virtual ~RooAlpha4ExpNPdf() { }
+  inline ~RooAlpha4ExpNPdf() override { }
 
 protected:
 
@@ -628,11 +628,11 @@ protected:
   RooRealProxy c1 ;
   RooRealProxy n1 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4ExpNPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4ExpNPdf,1) // Your description goes here...
 };
 
 
@@ -649,9 +649,9 @@ public:
 
   RooExpTailPdf(const RooExpTailPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooExpTailPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooExpTailPdf(*this,newname); }
 
-  inline virtual ~RooExpTailPdf() { }
+  inline ~RooExpTailPdf() override { }
 
 protected:
 
@@ -659,11 +659,11 @@ protected:
   RooRealProxy s ;
   RooRealProxy a ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooExpTailPdf,1) // Your description goes here...
+  ClassDefOverride(RooExpTailPdf,1) // Your description goes here...
 };
 
 ////// Alpha function given by the ratio of two levelled exp
@@ -679,9 +679,9 @@ public:
 
   RooAlpha4ExpTailPdf(const RooAlpha4ExpTailPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha4ExpTailPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha4ExpTailPdf(*this,newname); }
 
-  inline virtual ~RooAlpha4ExpTailPdf() { }
+  inline ~RooAlpha4ExpTailPdf() override { }
 
 protected:
 
@@ -691,11 +691,11 @@ protected:
   RooRealProxy s1 ;
   RooRealProxy a1 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha4ExpTailPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha4ExpTailPdf,1) // Your description goes here...
 };
 
 
@@ -713,9 +713,9 @@ public:
 
   Roo2ExpPdf(const Roo2ExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new Roo2ExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new Roo2ExpPdf(*this,newname); }
 
-  inline virtual ~Roo2ExpPdf() { }
+  inline ~Roo2ExpPdf() override { }
 
 protected:
 
@@ -724,11 +724,11 @@ protected:
   RooRealProxy c1 ;
   RooRealProxy frac ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(Roo2ExpPdf,1) // Your description goes here...
+  ClassDefOverride(Roo2ExpPdf,1) // Your description goes here...
 };
 
 ///// Alpha function given by the ratio of two double exp pdf 
@@ -746,9 +746,9 @@ public:
 
   RooAlpha42ExpPdf(const RooAlpha42ExpPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAlpha42ExpPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAlpha42ExpPdf(*this,newname); }
 
-  inline virtual ~RooAlpha42ExpPdf() { }
+  inline ~RooAlpha42ExpPdf() override { }
 
 protected:
 
@@ -760,11 +760,11 @@ protected:
   RooRealProxy c11 ;
   RooRealProxy frac1 ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAlpha42ExpPdf,1) // Your description goes here...
+  ClassDefOverride(RooAlpha42ExpPdf,1) // Your description goes here...
 };
 
 
@@ -779,13 +779,13 @@ public:
 
   RooAnaExpNPdf(const RooAnaExpNPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooAnaExpNPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooAnaExpNPdf(*this,newname); }
 
-  inline virtual ~RooAnaExpNPdf() { }
+  inline ~RooAnaExpNPdf() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -793,11 +793,11 @@ protected:
   RooRealProxy c ;
   RooRealProxy n ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooAnaExpNPdf,1) // Your description goes here...
+  ClassDefOverride(RooAnaExpNPdf,1) // Your description goes here...
 };
 
 ///// Double Crystal Ball function 
@@ -816,13 +816,13 @@ class RooDoubleCrystalBall : public RooAbsPdf {
 
   RooDoubleCrystalBall(const RooDoubleCrystalBall& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooDoubleCrystalBall(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooDoubleCrystalBall(*this,newname); }
 
-  inline virtual ~RooDoubleCrystalBall() { }
+  inline ~RooDoubleCrystalBall() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
 
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
  protected:
 
@@ -834,11 +834,11 @@ class RooDoubleCrystalBall : public RooAbsPdf {
   RooRealProxy alpha2;
   RooRealProxy n2;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
  private:
 
-  ClassDef(RooDoubleCrystalBall,1)
+  ClassDefOverride(RooDoubleCrystalBall,1)
 };
 
 

--- a/interface/HZGRooPdfs.h
+++ b/interface/HZGRooPdfs.h
@@ -29,11 +29,11 @@ public:
 		   const RooArgList& _coefList) ;
 
   RooStepBernstein(const RooStepBernstein& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooStepBernstein(*this, newname); }
-  inline virtual ~RooStepBernstein() { }
+  TObject* clone(const char* newname) const override { return new RooStepBernstein(*this, newname); }
+  inline ~RooStepBernstein() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 private:
 
@@ -41,9 +41,9 @@ private:
   RooRealProxy _stepThresh;
   RooListProxy _coefList ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooStepBernstein,1) // Bernstein polynomial PDF with step function
+  ClassDefOverride(RooStepBernstein,1) // Bernstein polynomial PDF with step function
 };
 
 class RooGaussStepBernstein : public RooAbsPdf {
@@ -57,12 +57,12 @@ public:
 
   RooGaussStepBernstein(const RooGaussStepBernstein& other,
 const char* name = 0);
-  virtual TObject* clone(const char* newname) const
+  TObject* clone(const char* newname) const override
   { return new RooGaussStepBernstein(*this, newname); }
-  inline virtual ~RooGaussStepBernstein() { }
+  inline ~RooGaussStepBernstein() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 private:
 
@@ -70,9 +70,9 @@ private:
   RooRealProxy _mean,_sigma,_stepVal;
   RooListProxy _coefList ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooGaussStepBernstein,1) // Bernstein polynomial PDF with step function convoluted with gaussian
+  ClassDefOverride(RooGaussStepBernstein,1) // Bernstein polynomial PDF with step function convoluted with gaussian
 };
 
 

--- a/interface/HZZ2L2QRooPdfs.h
+++ b/interface/HZZ2L2QRooPdfs.h
@@ -17,8 +17,8 @@ class RooCB : public RooAbsPdf {
         RooAbsReal& _theta
 	);
   RooCB(const RooCB& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCB(*this,newname); }
-  inline virtual ~RooCB() { }
+  TObject* clone(const char* newname) const override { return new RooCB(*this,newname); }
+  inline ~RooCB() override { }
 
  protected:
 
@@ -29,11 +29,11 @@ class RooCB : public RooAbsPdf {
   RooRealProxy n;
   RooRealProxy theta;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
  private:
 
-  ClassDef(RooCB,1)
+  ClassDefOverride(RooCB,1)
     };
 
  
@@ -60,10 +60,10 @@ public:
         RooAbsReal& _n2
   );
   RooDoubleCB(const RooDoubleCB& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooDoubleCB(*this,newname); }
-  inline virtual ~RooDoubleCB() { }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  TObject* clone(const char* newname) const override { return new RooDoubleCB(*this,newname); }
+  inline ~RooDoubleCB() override { }
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -76,11 +76,11 @@ protected:
   RooRealProxy alpha2;
   RooRealProxy n2;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooDoubleCB,2)
+  ClassDefOverride(RooDoubleCB,2)
 };
  
 class RooFermi : public RooAbsPdf {
@@ -92,8 +92,8 @@ public:
 	   RooAbsReal& _beta
 	   );
   RooFermi(const RooFermi& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFermi(*this,newname); }
-  inline virtual ~RooFermi() { }
+  TObject* clone(const char* newname) const override { return new RooFermi(*this,newname); }
+  inline ~RooFermi() override { }
 
 protected:
 
@@ -101,11 +101,11 @@ protected:
   RooRealProxy cutOff ;
   RooRealProxy beta ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooFermi,1) 
+  ClassDefOverride(RooFermi,1) 
 };
   
 class RooRelBW : public RooAbsPdf {
@@ -118,8 +118,8 @@ public:
 	   RooAbsReal& _n
 	   );
   RooRelBW(const RooRelBW& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooRelBW(*this,newname); }
-  inline virtual ~RooRelBW() { }
+  TObject* clone(const char* newname) const override { return new RooRelBW(*this,newname); }
+  inline ~RooRelBW() override { }
 
 protected:
 
@@ -128,11 +128,11 @@ protected:
   RooRealProxy width ;
   RooRealProxy n ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooRelBW,1)
+  ClassDefOverride(RooRelBW,1)
 };
  
 
@@ -147,12 +147,12 @@ public:
 	   );	
   
   Triangle(const Triangle& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { 
+  TObject* clone(const char* newname) const override { 
     return new Triangle(*this,newname); }
 
-  inline virtual ~Triangle() { }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  inline ~Triangle() override { }
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -161,11 +161,11 @@ protected:
   RooRealProxy turn;
   RooRealProxy stop;
   
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
   
-  ClassDef(Triangle,1)
+  ClassDefOverride(Triangle,1)
 };
 
 
@@ -182,8 +182,8 @@ class RooLevelledExp : public RooAbsPdf {
 		);
 
   RooLevelledExp(const RooLevelledExp& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooLevelledExp(*this,newname); }
-  inline virtual ~RooLevelledExp() { }
+  TObject* clone(const char* newname) const override { return new RooLevelledExp(*this,newname); }
+  inline ~RooLevelledExp() override { }
 
  protected:
 
@@ -195,11 +195,11 @@ class RooLevelledExp : public RooAbsPdf {
   RooRealProxy theta;
   
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
  private:
 
-  ClassDef(RooLevelledExp,1)
+  ClassDefOverride(RooLevelledExp,1)
     };
 
 

--- a/interface/HZZ4LRooPdfs.h
+++ b/interface/HZZ4LRooPdfs.h
@@ -52,8 +52,8 @@ public:
 			   RooAbsReal& _b3,
 			   RooAbsReal& _frac);
 	RooqqZZPdf(const RooqqZZPdf& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooqqZZPdf(*this,newname); }
-	inline virtual ~RooqqZZPdf() { }
+	TObject* clone(const char* newname) const override { return new RooqqZZPdf(*this,newname); }
+	inline ~RooqqZZPdf() override { }
 	
 protected:
 	
@@ -66,11 +66,11 @@ protected:
 	RooRealProxy b3 ;
 	RooRealProxy frac ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooqqZZPdf,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooqqZZPdf,1) // Your description goes here...                                                                                                   
 };
 
 
@@ -88,8 +88,8 @@ public:
 			   RooAbsReal& _b3,
 			   RooAbsReal& _frac);
 	RooggZZPdf(const RooggZZPdf& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooggZZPdf(*this,newname); }
-	inline virtual ~RooggZZPdf() { }
+	TObject* clone(const char* newname) const override { return new RooggZZPdf(*this,newname); }
+	inline ~RooggZZPdf() override { }
 	
 protected:
 	
@@ -102,11 +102,11 @@ protected:
 	RooRealProxy b3 ;
 	RooRealProxy frac ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooggZZPdf,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooggZZPdf,1) // Your description goes here...                                                                                                   
 };
 
 // ------- RooqqZZPdf_v2 -------
@@ -134,8 +134,8 @@ public:
 			   
 			   );
 	RooqqZZPdf_v2(const RooqqZZPdf_v2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooqqZZPdf_v2(*this,newname); }
-	inline virtual ~RooqqZZPdf_v2() { }
+	TObject* clone(const char* newname) const override { return new RooqqZZPdf_v2(*this,newname); }
+	inline ~RooqqZZPdf_v2() override { }
 	
 protected:
 	
@@ -156,11 +156,11 @@ protected:
 	RooRealProxy a13 ;
 	
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooqqZZPdf_v2,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooqqZZPdf_v2,1) // Your description goes here...                                                                                                   
 };
 
 
@@ -191,8 +191,8 @@ public:
 			   RooAbsReal& _a16
 			   );
 	RooVBFZZPdf(const RooVBFZZPdf& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooVBFZZPdf(*this,newname); }
-	inline virtual ~RooVBFZZPdf() { }
+	TObject* clone(const char* newname) const override { return new RooVBFZZPdf(*this,newname); }
+	inline ~RooVBFZZPdf() override { }
 	
 protected:
 	
@@ -216,11 +216,11 @@ protected:
 	RooRealProxy a16 ;
 	
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooVBFZZPdf,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooVBFZZPdf,1) // Your description goes here...                                                                                                   
 };
 
 
@@ -248,8 +248,8 @@ public:
 			   RooAbsReal& _a16
 			   );
 	RooVBFZZPdf_v2(const RooVBFZZPdf_v2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooVBFZZPdf_v2(*this,newname); }
-	inline virtual ~RooVBFZZPdf_v2() { }
+	TObject* clone(const char* newname) const override { return new RooVBFZZPdf_v2(*this,newname); }
+	inline ~RooVBFZZPdf_v2() override { }
 	
 protected:
 	
@@ -269,11 +269,11 @@ protected:
 	RooRealProxy a16 ;
 	
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooVBFZZPdf_v2,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooVBFZZPdf_v2,1) // Your description goes here...                                                                                                   
 };
 
 
@@ -297,8 +297,8 @@ public:
 			   
 			   );
 	RooggZZPdf_v2(const RooggZZPdf_v2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooggZZPdf_v2(*this,newname); }
-	inline virtual ~RooggZZPdf_v2() { }
+	TObject* clone(const char* newname) const override { return new RooggZZPdf_v2(*this,newname); }
+	inline ~RooggZZPdf_v2() override { }
 	
 protected:
 	
@@ -314,11 +314,11 @@ protected:
 	RooRealProxy a8 ;
 	RooRealProxy a9 ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooggZZPdf_v2,1) // Your description goes here...                                                                                                   
+	ClassDefOverride(RooggZZPdf_v2,1) // Your description goes here...                                                                                                   
 };
 
 class RooBetaFunc_v2 : public RooAbsPdf {
@@ -339,8 +339,8 @@ public:
 				   RooAbsReal& _f0
 				   );
 	RooBetaFunc_v2(const RooBetaFunc_v2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooBetaFunc_v2(*this,newname); }
-	inline virtual ~RooBetaFunc_v2() { }
+	TObject* clone(const char* newname) const override { return new RooBetaFunc_v2(*this,newname); }
+	inline ~RooBetaFunc_v2() override { }
 	
 protected:
 	
@@ -357,11 +357,11 @@ protected:
     RooRealProxy f;
 	RooRealProxy f0;
 	
-    Double_t evaluate() const ;
+    Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooBetaFunc_v2,1) 
+	ClassDefOverride(RooBetaFunc_v2,1) 
 };
 
 class Roo4lMasses2D_Bkg : public RooAbsPdf {
@@ -373,8 +373,8 @@ public:
 					  RooAbsReal& _channelVal	     
 					  );
 	Roo4lMasses2D_Bkg(const Roo4lMasses2D_Bkg& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new Roo4lMasses2D_Bkg(*this,newname); }
-	inline virtual ~Roo4lMasses2D_Bkg() { }
+	TObject* clone(const char* newname) const override { return new Roo4lMasses2D_Bkg(*this,newname); }
+	inline ~Roo4lMasses2D_Bkg() override { }
 	
 protected:
 	
@@ -382,11 +382,11 @@ protected:
     RooRealProxy mZZ;     
     RooRealProxy channelVal;     
 	
-    Double_t evaluate() const ;
+    Double_t evaluate() const override ;
     Double_t UnitStep(double arg) const;
 private:
 	
-	ClassDef(Roo4lMasses2D_Bkg,1) 
+	ClassDefOverride(Roo4lMasses2D_Bkg,1) 
 };
 
 //------------------------
@@ -400,8 +400,8 @@ public:
 					  RooAbsReal& _channelVal	     
 					  );
 	Roo4lMasses2D_BkgGGZZ(const Roo4lMasses2D_BkgGGZZ& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new Roo4lMasses2D_BkgGGZZ(*this,newname); }
-	inline virtual ~Roo4lMasses2D_BkgGGZZ() { }
+	TObject* clone(const char* newname) const override { return new Roo4lMasses2D_BkgGGZZ(*this,newname); }
+	inline ~Roo4lMasses2D_BkgGGZZ() override { }
 	
 protected:
 	
@@ -409,11 +409,11 @@ protected:
     RooRealProxy mZZ;     
     RooRealProxy channelVal;     
 	
-    Double_t evaluate() const ;
+    Double_t evaluate() const override ;
     Double_t UnitStep(double arg) const;
 private:
 	
-	ClassDef(Roo4lMasses2D_BkgGGZZ,1) 
+	ClassDefOverride(Roo4lMasses2D_BkgGGZZ,1) 
 };
 
 // --------------------------------------------------------------------
@@ -441,8 +441,8 @@ public:
 				  RooAbsReal& _CBn             
 				  );
 	Roo4lMasses2D(const Roo4lMasses2D& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new Roo4lMasses2D(*this,newname); }
-	inline virtual ~Roo4lMasses2D() { }
+	TObject* clone(const char* newname) const override { return new Roo4lMasses2D(*this,newname); }
+	inline ~Roo4lMasses2D() override { }
 	
 protected:
 	
@@ -458,11 +458,11 @@ protected:
     RooRealProxy CBalpha;            
     RooRealProxy CBn;             
 	
-    Double_t evaluate() const ;
+    Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(Roo4lMasses2D,1) 
+	ClassDefOverride(Roo4lMasses2D,1) 
 };
 
 // --------------------------------------
@@ -474,20 +474,20 @@ public:
 						   RooAbsReal& _m4l,
 						   RooAbsReal& _mH);
 	RooFourMuMassShapePdf2(const RooFourMuMassShapePdf2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooFourMuMassShapePdf2(*this,newname); }
-	inline virtual ~RooFourMuMassShapePdf2() { }
+	TObject* clone(const char* newname) const override { return new RooFourMuMassShapePdf2(*this,newname); }
+	inline ~RooFourMuMassShapePdf2() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	//void readFile() const ;
 	
 private:
 	
-	ClassDef(RooFourMuMassShapePdf2,2) // Your description goes here...                                                                                       
+	ClassDefOverride(RooFourMuMassShapePdf2,2) // Your description goes here...                                                                                       
 };
 
 
@@ -498,20 +498,20 @@ public:
 						  RooAbsReal& _m4l,
 						  RooAbsReal& _mH);
 	RooFourEMassShapePdf2(const RooFourEMassShapePdf2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooFourEMassShapePdf2(*this,newname); }
-	inline virtual ~RooFourEMassShapePdf2() { }
+	TObject* clone(const char* newname) const override { return new RooFourEMassShapePdf2(*this,newname); }
+	inline ~RooFourEMassShapePdf2() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	//void readFile() const ;
 	
 private:
 	
-	ClassDef(RooFourEMassShapePdf2,2) // Your description goes here...                                                                                        
+	ClassDefOverride(RooFourEMassShapePdf2,2) // Your description goes here...                                                                                        
 };
 
 
@@ -523,20 +523,20 @@ public:
 							  RooAbsReal& _m4l,
 							  RooAbsReal& _mH);
 	RooTwoETwoMuMassShapePdf2(const RooTwoETwoMuMassShapePdf2& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooTwoETwoMuMassShapePdf2(*this,newname); }
-	inline virtual ~RooTwoETwoMuMassShapePdf2() { }
+	TObject* clone(const char* newname) const override { return new RooTwoETwoMuMassShapePdf2(*this,newname); }
+	inline ~RooTwoETwoMuMassShapePdf2() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	//void readFile() const ;
 	
 private:	
 	
-	ClassDef(RooTwoETwoMuMassShapePdf2,2) // Your description goes here...                                                                                    
+	ClassDefOverride(RooTwoETwoMuMassShapePdf2,2) // Your description goes here...                                                                                    
 };
 
 
@@ -547,19 +547,19 @@ public:
 					 RooAbsReal& _m4l,
 					 RooAbsReal& _mH);
 	RooFourMuMassRes(const RooFourMuMassRes& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooFourMuMassRes(*this,newname); }
-	inline virtual ~RooFourMuMassRes() { }
+	TObject* clone(const char* newname) const override { return new RooFourMuMassRes(*this,newname); }
+	inline ~RooFourMuMassRes() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH  ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooFourMuMassRes,1) // Your description goes here...                                                                                             
+	ClassDefOverride(RooFourMuMassRes,1) // Your description goes here...                                                                                             
 };
 
 class RooFourEMassRes : public RooAbsPdf {
@@ -569,19 +569,19 @@ public:
 					RooAbsReal& _m4l,
 					RooAbsReal& _mH);
 	RooFourEMassRes(const RooFourEMassRes& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooFourEMassRes(*this,newname); }
-	inline virtual ~RooFourEMassRes() { }
+	TObject* clone(const char* newname) const override { return new RooFourEMassRes(*this,newname); }
+	inline ~RooFourEMassRes() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH  ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooFourEMassRes,1) // Your description goes here...                                                                                              
+	ClassDefOverride(RooFourEMassRes,1) // Your description goes here...                                                                                              
 };
 
 
@@ -592,8 +592,8 @@ public:
 						RooAbsReal& _m4l,
 						RooAbsReal& _mH);
 	RooTwoETwoMuMassRes(const RooTwoETwoMuMassRes& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooTwoETwoMuMassRes(*this,newname); }
-	inline virtual ~RooTwoETwoMuMassRes() { }
+	TObject* clone(const char* newname) const override { return new RooTwoETwoMuMassRes(*this,newname); }
+	inline ~RooTwoETwoMuMassRes() override { }
 	
 protected:
 	
@@ -601,11 +601,11 @@ protected:
 	RooRealProxy mH  ;
 	
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooTwoETwoMuMassRes,1) // Your description goes here...                                                                                          
+	ClassDefOverride(RooTwoETwoMuMassRes,1) // Your description goes here...                                                                                          
 };
 
 class RooRelBW1 : public RooAbsPdf {
@@ -616,8 +616,8 @@ public:
 			  RooAbsReal& _mean,
 			  RooAbsReal& _gamma);
 	RooRelBW1(const RooRelBW1& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBW1(*this,newname); }
-	inline virtual ~RooRelBW1() { }
+	TObject* clone(const char* newname) const override { return new RooRelBW1(*this,newname); }
+	inline ~RooRelBW1() override { }
 	
 protected:
 	
@@ -625,11 +625,11 @@ protected:
 	RooRealProxy mean ;
 	RooRealProxy gamma ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBW1,1) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBW1,1) // Your description goes here...                                                                                                    
 };
 
 //////////////////////////////////////////////
@@ -641,19 +641,19 @@ public:
 			  RooAbsReal& _m4l,
 			  RooAbsReal& _mH);
 	RooRelBWUF(const RooRelBWUF& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBWUF(*this,newname); }
-	inline virtual ~RooRelBWUF() { }
+	TObject* clone(const char* newname) const override { return new RooRelBWUF(*this,newname); }
+	inline ~RooRelBWUF() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBWUF,2) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBWUF,2) // Your description goes here...                                                                                                    
 };
 
 
@@ -666,19 +666,19 @@ public:
 			  RooAbsReal& _m4l,
 			  RooAbsReal& _mH);
 	RooRelBWUF_SM4(const RooRelBWUF_SM4& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBWUF_SM4(*this,newname); }
-	inline virtual ~RooRelBWUF_SM4() { }
+	TObject* clone(const char* newname) const override { return new RooRelBWUF_SM4(*this,newname); }
+	inline ~RooRelBWUF_SM4() override { }
 	
 protected:
 	
 	RooRealProxy m4l ;
 	RooRealProxy mH ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBWUF_SM4,2) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBWUF_SM4,2) // Your description goes here...                                                                                                    
 };
 
 
@@ -692,8 +692,8 @@ public:
 					RooAbsReal& _mH,
 					RooAbsReal& _width);
 	RooRelBWUFParamWidth(const RooRelBWUFParamWidth& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBWUFParamWidth(*this,newname); }
-	inline virtual ~RooRelBWUFParamWidth() { }
+	TObject* clone(const char* newname) const override { return new RooRelBWUFParamWidth(*this,newname); }
+	inline ~RooRelBWUFParamWidth() override { }
 	
 protected:
 	
@@ -701,11 +701,11 @@ protected:
 	RooRealProxy mH ;
 	RooRealProxy width;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBWUFParamWidth,2) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBWUFParamWidth,2) // Your description goes here...                                                                                                    
 };
 
 
@@ -719,8 +719,8 @@ public:
 			Double_t _widthSF=1.
 			);
 	RooRelBWUFParam(const RooRelBWUFParam& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBWUFParam(*this,newname); }
-	inline virtual ~RooRelBWUFParam() { }
+	TObject* clone(const char* newname) const override { return new RooRelBWUFParam(*this,newname); }
+	inline ~RooRelBWUFParam() override { }
 	
 protected:
 	
@@ -729,11 +729,11 @@ protected:
 	RooRealProxy scaleParam ;
 	Double_t widthSF ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBWUFParam,3) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBWUFParam,3) // Your description goes here...                                                                                                    
 };
 
 //////////////////////////////////////////////
@@ -746,8 +746,8 @@ public:
 					RooAbsReal& _mH,
 					RooAbsReal& _gamma);
 	RooRelBWHighMass(const RooRelBWHighMass& other, const char* name=0) ;
-	virtual TObject* clone(const char* newname) const { return new RooRelBWHighMass(*this,newname); }
-	inline virtual ~RooRelBWHighMass() { }
+	TObject* clone(const char* newname) const override { return new RooRelBWHighMass(*this,newname); }
+	inline ~RooRelBWHighMass() override { }
 	
 protected:
 	
@@ -755,11 +755,11 @@ protected:
 	RooRealProxy mH ;
 	RooRealProxy gamma ;
 	
-	Double_t evaluate() const ;
+	Double_t evaluate() const override ;
 	
 private:
 	
-	ClassDef(RooRelBWHighMass,2) // Your description goes here...                                                                                                    
+	ClassDefOverride(RooRelBWHighMass,2) // Your description goes here...                                                                                                    
 };
 
 ///////////////////////////////////////////////////
@@ -778,8 +778,8 @@ public:
 	          RooAbsReal& _fexp);
 
   RooTsallis(const RooTsallis& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooTsallis(*this,newname); }
-  inline virtual ~RooTsallis() { }
+  TObject* clone(const char* newname) const override { return new RooTsallis(*this,newname); }
+  inline ~RooTsallis() override { }
   /* Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
      Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;*/
 
@@ -794,11 +794,11 @@ protected:
   RooRealProxy T ;
   RooRealProxy fexp ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
- ClassDef(RooTsallis,1) // Your description goes here...
+ ClassDefOverride(RooTsallis,1) // Your description goes here...
 };
 
 
@@ -823,8 +823,8 @@ class RooaDoubleCBxBW : public RooAbsPdf {
         bool _computeActualCB
     );
   RooaDoubleCBxBW(const RooaDoubleCBxBW& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooaDoubleCBxBW(*this,newname); }
-  inline virtual ~RooaDoubleCBxBW() { }
+  TObject* clone(const char* newname) const override { return new RooaDoubleCBxBW(*this,newname); }
+  inline ~RooaDoubleCBxBW() override { }
 
  protected:
 
@@ -841,7 +841,7 @@ class RooaDoubleCBxBW : public RooAbsPdf {
   RooRealProxy thetaR;
   bool computeActualCB;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   Double_t evaluateDoubleCB() const ;
   Double_t evaluatePowerLaw(double lim, unsigned power, bool isLeft) const ;
   Double_t evaluateQuadratic(double lim1, double lim2, bool isLeft) const ;
@@ -849,7 +849,7 @@ class RooaDoubleCBxBW : public RooAbsPdf {
 
  private:
 
-  ClassDef(RooaDoubleCBxBW,1)
+  ClassDefOverride(RooaDoubleCBxBW,1)
     };
 
 
@@ -867,9 +867,9 @@ public:
 	      RooAbsReal& _WidthScl,
 	      Bool_t is8TeV);
   RooCPSHighMassGGH(const RooCPSHighMassGGH& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCPSHighMassGGH(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooCPSHighMassGGH(*this,newname); }
   Double_t Spline(Double_t xx) const;
-  inline virtual ~RooCPSHighMassGGH() {  }
+  inline ~RooCPSHighMassGGH() override {  }
 
 protected:
 
@@ -888,7 +888,7 @@ protected:
   Double_t a_r[7][5];
   Double_t a_beta[7][5];
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   void initMatrices() ;
   Double_t interpolateMatrix(const Double_t matrix[][5], const Double_t& x, const Double_t& y) const;
   Double_t getWidth(const Double_t& mass, const Double_t& cprime) const;
@@ -901,7 +901,7 @@ protected:
 
 private:
 
-  ClassDef(RooCPSHighMassGGH,5)
+  ClassDefOverride(RooCPSHighMassGGH,5)
 };
 
 
@@ -918,8 +918,8 @@ public:
 	      RooAbsReal& _IntStr,
 	      Bool_t is8TeV);
   RooBWHighMassGGH(const RooBWHighMassGGH& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooBWHighMassGGH(*this,newname); }
-  inline virtual ~RooBWHighMassGGH() {  }
+  TObject* clone(const char* newname) const override { return new RooBWHighMassGGH(*this,newname); }
+  inline ~RooBWHighMassGGH() override {  }
 
 protected:
 
@@ -937,7 +937,7 @@ protected:
   Double_t a_r[7][5];
   Double_t a_beta[7][5];
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   void initMatrices() ;
   Double_t interpolateMatrix(const Double_t matrix[][5], const Double_t& x, const Double_t& y) const;
   Double_t getWidth(const Double_t& mass, const Double_t& cprime) const;
@@ -952,7 +952,7 @@ protected:
 
 private:
 
-  ClassDef(RooBWHighMassGGH,4)
+  ClassDefOverride(RooBWHighMassGGH,4)
 };
 
 
@@ -967,9 +967,9 @@ public:
 	      RooAbsReal& _BRnew,
 	      Bool_t is8TeV);
   RooCPSHighMassGGHNoInterf(const RooCPSHighMassGGHNoInterf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCPSHighMassGGHNoInterf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooCPSHighMassGGHNoInterf(*this,newname); }
   Double_t Spline(Double_t xx) const;
-  inline virtual ~RooCPSHighMassGGHNoInterf() {  }
+  inline ~RooCPSHighMassGGHNoInterf() override {  }
 
 protected:
 
@@ -983,7 +983,7 @@ protected:
   Double_t a_width[7][5];
   Double_t a_delta[7][5];
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   void initMatrices() ;
   Double_t interpolateMatrix(const Double_t matrix[][5], const Double_t& x, const Double_t& y) const;
   Double_t getWidth(const Double_t& mass, const Double_t& cprime) const;
@@ -993,7 +993,7 @@ protected:
 
 private:
 
-  ClassDef(RooCPSHighMassGGHNoInterf,4)
+  ClassDefOverride(RooCPSHighMassGGHNoInterf,4)
 };
 
 
@@ -1012,9 +1012,9 @@ public:
 	      RooAbsReal& _WidthScl,
 	      Bool_t is8TeV);
   RooCPSHighMassVBF(const RooCPSHighMassVBF& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCPSHighMassVBF(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooCPSHighMassVBF(*this,newname); }
   Double_t Spline(Double_t xx) const;
-  inline virtual ~RooCPSHighMassVBF() {  }
+  inline ~RooCPSHighMassVBF() override {  }
 
 protected:
 
@@ -1033,7 +1033,7 @@ protected:
   Double_t a_r[7][5];
   Double_t a_beta[7][5];
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   void initMatrices() ;
   Double_t interpolateMatrix(const Double_t matrix[][5], const Double_t& x, const Double_t& y) const;
   Double_t getWidth(const Double_t& mass, const Double_t& cprime) const;
@@ -1046,7 +1046,7 @@ protected:
 
 private:
 
-  ClassDef(RooCPSHighMassVBF,4)
+  ClassDefOverride(RooCPSHighMassVBF,4)
 };
 
 
@@ -1061,9 +1061,9 @@ public:
 	      RooAbsReal& _BRnew,
 	      Bool_t is8TeV);
   RooCPSHighMassVBFNoInterf(const RooCPSHighMassVBFNoInterf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCPSHighMassVBFNoInterf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooCPSHighMassVBFNoInterf(*this,newname); }
   Double_t Spline(Double_t xx) const;
-  inline virtual ~RooCPSHighMassVBFNoInterf() {  }
+  inline ~RooCPSHighMassVBFNoInterf() override {  }
 
 protected:
 
@@ -1077,7 +1077,7 @@ protected:
   Double_t a_width[7][5];
   Double_t a_delta[7][5];
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   void initMatrices() ;
   Double_t interpolateMatrix(const Double_t matrix[][5], const Double_t& x, const Double_t& y) const;
   Double_t getWidth(const Double_t& mass, const Double_t& cprime) const;
@@ -1087,7 +1087,7 @@ protected:
 
 private:
 
-  ClassDef(RooCPSHighMassVBFNoInterf,4)
+  ClassDefOverride(RooCPSHighMassVBFNoInterf,4)
 };
 
 
@@ -1107,8 +1107,8 @@ public:
 	      RooAbsReal& _beta,
 	      RooAbsReal& _r);
   RooSigPlusInt(const RooSigPlusInt& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooSigPlusInt(*this,newname); }
-  inline virtual ~RooSigPlusInt() { }
+  TObject* clone(const char* newname) const override { return new RooSigPlusInt(*this,newname); }
+  inline ~RooSigPlusInt() override { }
   Double_t Spline(Double_t xx) const;
 
 protected:
@@ -1124,11 +1124,11 @@ protected:
   RooRealProxy beta ;
   RooRealProxy r ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooSigPlusInt,1) // Your description goes here...
+  ClassDefOverride(RooSigPlusInt,1) // Your description goes here...
 };
 
 

--- a/interface/HZZ4L_RooCTauPdf_1D.h
+++ b/interface/HZZ4L_RooCTauPdf_1D.h
@@ -27,7 +27,7 @@ protected:
 	RooRealProxy ctau;
 
 	RooListProxy _coefList;  //  List of histogram pdfs
-	Double_t evaluate() const;
+	Double_t evaluate() const override;
 public:
 	HZZ4L_RooCTauPdf_1D() {};
 	HZZ4L_RooCTauPdf_1D(
@@ -42,11 +42,11 @@ public:
 		);
 
 	HZZ4L_RooCTauPdf_1D(const HZZ4L_RooCTauPdf_1D& other, const char* name = 0);
-	virtual TObject* clone(const char* newname) const { return new HZZ4L_RooCTauPdf_1D(*this, newname); }
-	inline virtual ~HZZ4L_RooCTauPdf_1D() { /*delete[] Integral_T;*/ }
+	TObject* clone(const char* newname) const override { return new HZZ4L_RooCTauPdf_1D(*this, newname); }
+	inline ~HZZ4L_RooCTauPdf_1D() override { /*delete[] Integral_T;*/ }
 
-	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const;
-	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const override;
+	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 	const RooArgList& coefList() const { return _coefList; }
 
 	int nbins_ctau;
@@ -59,7 +59,7 @@ private:
 	Double_t interpolateBin() const;
 	Double_t interpolateIntegral() const;
 
-	ClassDef(HZZ4L_RooCTauPdf_1D, 1) // Your description goes here...
+	ClassDefOverride(HZZ4L_RooCTauPdf_1D, 1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooCTauPdf_1D_Expanded.h
+++ b/interface/HZZ4L_RooCTauPdf_1D_Expanded.h
@@ -28,7 +28,7 @@ protected:
 
   RooListProxy _funcList;  //  List of histogram pdfs
   RooListProxy _coefList;  //  List of pdf modifiers
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 public:
 	HZZ4L_RooCTauPdf_1D_Expanded() {};
 	HZZ4L_RooCTauPdf_1D_Expanded(
@@ -48,11 +48,11 @@ public:
     );
 
 	HZZ4L_RooCTauPdf_1D_Expanded(const HZZ4L_RooCTauPdf_1D_Expanded& other, const char* name = 0);
-	virtual TObject* clone(const char* newname) const { return new HZZ4L_RooCTauPdf_1D_Expanded(*this, newname); }
-	inline virtual ~HZZ4L_RooCTauPdf_1D_Expanded() { }
+	TObject* clone(const char* newname) const override { return new HZZ4L_RooCTauPdf_1D_Expanded(*this, newname); }
+	inline ~HZZ4L_RooCTauPdf_1D_Expanded() override { }
 
-	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const;
-	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const override;
+	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
   const RooArgList& funcList() const { return _funcList; }
   const RooArgList& coefList() const { return _coefList; }
 
@@ -73,7 +73,7 @@ private:
   Double_t interpolateBin() const;
 	Double_t interpolateIntegral() const;
 
-	ClassDef(HZZ4L_RooCTauPdf_1D_Expanded, 1) // Your description goes here...
+	ClassDefOverride(HZZ4L_RooCTauPdf_1D_Expanded, 1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooCTauPdf_2D.h
+++ b/interface/HZZ4L_RooCTauPdf_2D.h
@@ -28,7 +28,7 @@ protected:
 	RooRealProxy ctau;
 
 	RooListProxy _coefList;  //  List of histogram pdfs
-	Double_t evaluate() const;
+	Double_t evaluate() const override;
 public:
 	HZZ4L_RooCTauPdf_2D() {};
 	HZZ4L_RooCTauPdf_2D(
@@ -44,11 +44,11 @@ public:
 		);
 
 	HZZ4L_RooCTauPdf_2D(const HZZ4L_RooCTauPdf_2D& other, const char* name = 0);
-	virtual TObject* clone(const char* newname) const { return new HZZ4L_RooCTauPdf_2D(*this, newname); }
-	inline virtual ~HZZ4L_RooCTauPdf_2D() { delete[] Integral_T; }
+	TObject* clone(const char* newname) const override { return new HZZ4L_RooCTauPdf_2D(*this, newname); }
+	inline ~HZZ4L_RooCTauPdf_2D() override { delete[] Integral_T; }
 
-	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const;
-	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
+	Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = 0) const override;
+	Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
 	const RooArgList& coefList() const { return _coefList; }
 
 	int nbins_ctau;
@@ -61,7 +61,7 @@ private:
 	Double_t interpolateBin() const;
 	Double_t interpolateIntegral() const;
 
-	ClassDef(HZZ4L_RooCTauPdf_2D, 1) // Your description goes here...
+	ClassDefOverride(HZZ4L_RooCTauPdf_2D, 1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooSpinZeroPdf.h
+++ b/interface/HZZ4L_RooSpinZeroPdf.h
@@ -28,7 +28,7 @@ protected:
   RooRealProxy fai ;
   RooListProxy _coefList ;  //  List of funcficients
 //  TIterator* _coefIter ;    //! Iterator over funcficient lis
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 public:
   HZZ4L_RooSpinZeroPdf() {} ; 
   HZZ4L_RooSpinZeroPdf(const char *name, const char *title,
@@ -39,11 +39,11 @@ public:
 			const RooArgList& inCoefList);
 		    
   HZZ4L_RooSpinZeroPdf(const HZZ4L_RooSpinZeroPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf(*this,newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf() {}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf(*this,newname); }
+  inline ~HZZ4L_RooSpinZeroPdf() override {}
   
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   const RooArgList& coefList() const { return _coefList ; }
 
   double Integral_T1;
@@ -52,7 +52,7 @@ public:
 
 private:
 
-	ClassDef(HZZ4L_RooSpinZeroPdf,1) // Your description goes here...
+	ClassDefOverride(HZZ4L_RooSpinZeroPdf,1) // Your description goes here...
 
 };
  

--- a/interface/HZZ4L_RooSpinZeroPdf_1D.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_1D.h
@@ -28,7 +28,7 @@ protected:
 //  RooRealProxy ksmd ;
   RooRealProxy fai ;
   RooListProxy _coefList ;  //  List of funcficients
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 public:
   HZZ4L_RooSpinZeroPdf_1D() {} ; 
   HZZ4L_RooSpinZeroPdf_1D(const char *name, const char *title,
@@ -39,16 +39,16 @@ public:
 			const RooArgList& inCoefList);
 		    
   HZZ4L_RooSpinZeroPdf_1D(const HZZ4L_RooSpinZeroPdf_1D& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_1D(*this,newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_1D() {}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_1D(*this,newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_1D() override {}
   
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   const RooArgList& coefList() const { return _coefList ; }
 
 private:
 
-  ClassDef(HZZ4L_RooSpinZeroPdf_1D,1) // Your description goes here...
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_1D,1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooSpinZeroPdf_1D_fast.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_1D_fast.h
@@ -26,16 +26,16 @@ public:
     );
 
   HZZ4L_RooSpinZeroPdf_1D_fast(const HZZ4L_RooSpinZeroPdf_1D_fast& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_1D_fast(*this, newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_1D_fast(){}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_1D_fast(*this, newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_1D_fast() override{}
 
   Float_t interpolateFcn(Int_t code, const char* rangeName=0) const;
-  Double_t evaluate() const;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Double_t evaluate() const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 protected:
-  ClassDef(HZZ4L_RooSpinZeroPdf_1D_fast, 1)
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_1D_fast, 1)
 
 };
  

--- a/interface/HZZ4L_RooSpinZeroPdf_2D.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_2D.h
@@ -34,7 +34,7 @@ protected:
   RooRealProxy phi2;
   RooListProxy _coefList;  //  List of funcficients
   //  TIterator* _coefIter ;    //! Iterator over funcficient lis
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 public:
   HZZ4L_RooSpinZeroPdf_2D() {};
   HZZ4L_RooSpinZeroPdf_2D(const char *name, const char *title,
@@ -48,11 +48,11 @@ public:
     const RooArgList& inCoefList);
 
   HZZ4L_RooSpinZeroPdf_2D(const HZZ4L_RooSpinZeroPdf_2D& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_2D(*this, newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_2D() {}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_2D(*this, newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_2D() override {}
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
   const RooArgList& coefList() const { return _coefList; }
 
   double Integral_T1;
@@ -67,7 +67,7 @@ public:
 
 private:
 
-  ClassDef(HZZ4L_RooSpinZeroPdf_2D, 1) // Your description goes here...
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_2D, 1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooSpinZeroPdf_2D_fast.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_2D_fast.h
@@ -32,16 +32,16 @@ public:
     );
 
   HZZ4L_RooSpinZeroPdf_2D_fast(const HZZ4L_RooSpinZeroPdf_2D_fast& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_2D_fast(*this, newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_2D_fast(){}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_2D_fast(*this, newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_2D_fast() override{}
 
   Float_t interpolateFcn(Int_t code, const char* rangeName=0) const;
-  Double_t evaluate() const;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Double_t evaluate() const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 protected:
-  ClassDef(HZZ4L_RooSpinZeroPdf_2D_fast, 1)
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_2D_fast, 1)
 
 };
  

--- a/interface/HZZ4L_RooSpinZeroPdf_phase.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_phase.h
@@ -30,7 +30,7 @@ protected:
   RooRealProxy phi ;
   RooListProxy _coefList ;  //  List of funcficients
 //  TIterator* _coefIter ;    //! Iterator over funcficient lis
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 public:
   HZZ4L_RooSpinZeroPdf_phase() {} ; 
   HZZ4L_RooSpinZeroPdf_phase(const char *name, const char *title,
@@ -42,11 +42,11 @@ public:
 			const RooArgList& inCoefList);
 		    
   HZZ4L_RooSpinZeroPdf_phase(const HZZ4L_RooSpinZeroPdf_phase& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_phase(*this,newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_phase() {}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_phase(*this,newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_phase() override {}
   
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   const RooArgList& coefList() const { return _coefList ; }
 
   double Integral_T1;
@@ -56,7 +56,7 @@ public:
 
 private:
 
-  ClassDef(HZZ4L_RooSpinZeroPdf_phase,1) // Your description goes here...
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_phase,1) // Your description goes here...
 };
  
 #endif

--- a/interface/HZZ4L_RooSpinZeroPdf_phase_fast.h
+++ b/interface/HZZ4L_RooSpinZeroPdf_phase_fast.h
@@ -28,16 +28,16 @@ public:
     );
 
   HZZ4L_RooSpinZeroPdf_phase_fast(const HZZ4L_RooSpinZeroPdf_phase_fast& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new HZZ4L_RooSpinZeroPdf_phase_fast(*this, newname); }
-  inline virtual ~HZZ4L_RooSpinZeroPdf_phase_fast(){}
+  TObject* clone(const char* newname) const override { return new HZZ4L_RooSpinZeroPdf_phase_fast(*this, newname); }
+  inline ~HZZ4L_RooSpinZeroPdf_phase_fast() override{}
 
   Float_t interpolateFcn(Int_t code, const char* rangeName=0) const;
-  Double_t evaluate() const;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Double_t evaluate() const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 protected:
-  ClassDef(HZZ4L_RooSpinZeroPdf_phase_fast, 1)
+  ClassDefOverride(HZZ4L_RooSpinZeroPdf_phase_fast, 1)
 
 };
  

--- a/interface/HybridNew.h
+++ b/interface/HybridNew.h
@@ -22,15 +22,15 @@ class TDirectory;
 class HybridNew : public LimitAlgo {
 public:
   HybridNew() ; 
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
-  virtual void applyDefaultOptions() ; 
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
+  void applyDefaultOptions() override ; 
 
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
   virtual bool runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   virtual bool runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   virtual bool runSinglePoint(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
   virtual bool runTestStatistics(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  const std::string & name() const override {
     static const std::string name("HybridNew");
     return name;
   }

--- a/interface/MarkovChainMC.h
+++ b/interface/MarkovChainMC.h
@@ -16,9 +16,9 @@ namespace RooStats { class MarkovChain; }
 class MarkovChainMC : public LimitAlgo {
 public:
   MarkovChainMC() ;
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
-  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  const std::string & name() const override {
     static const std::string name("MarkovChainMC");
     return name;
   }

--- a/interface/MultiDimFit.h
+++ b/interface/MultiDimFit.h
@@ -17,16 +17,16 @@
 class MultiDimFit : public FitterAlgoBase {
 public:
   MultiDimFit() ;
-  virtual const std::string & name() const {
+  const std::string & name() const override {
     static const std::string name("MultiDimFit");
     return name;
   }
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 
   friend class RandStartPt;
 
 protected:
-  virtual bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
+  bool runSpecific(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
 
   enum Algo { None, Singles, Cross, Grid, RandomPoints, Contour2D, Stitch2D, FixedPoint, Impact };
   static Algo algo_;

--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -19,9 +19,9 @@ class ProcessNormalization : public RooAbsReal {
       ProcessNormalization(const char *name, const char *title, double nominal=1) ;
       ProcessNormalization(const char *name, const char *title, RooAbsReal &nominal) ;
       ProcessNormalization(const ProcessNormalization &other, const char *newname = 0) ;
-      ~ProcessNormalization() ;
+      ~ProcessNormalization() override ;
 
-      TObject * clone(const char *newname) const { return new ProcessNormalization(*this, newname); }
+      TObject * clone(const char *newname) const override { return new ProcessNormalization(*this, newname); }
 
       void setNominalValue(double nominal) { nominalValue_ = nominal; }
       void addLogNormal(double kappa, RooAbsReal &theta) ;
@@ -29,7 +29,7 @@ class ProcessNormalization : public RooAbsReal {
       void addOtherFactor(RooAbsReal &factor) ;
       void dump() const ;
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
         // ---- PERSISTENT ----
@@ -46,7 +46,7 @@ class ProcessNormalization : public RooAbsReal {
         // get the kappa for the appropriate x
         Double_t logKappaForX(double x, const std::pair<double,double> &logKappas ) const ;
 
-  ClassDef(ProcessNormalization,1) // Process normalization interpolator 
+  ClassDefOverride(ProcessNormalization,1) // Process normalization interpolator 
 };
 
 #endif

--- a/interface/ProfiledLikelihoodRatioTestStat.h
+++ b/interface/ProfiledLikelihoodRatioTestStat.h
@@ -19,9 +19,9 @@ class ProfiledLikelihoodRatioTestStat : public RooStats::TestStatistic {
             if (nuisances) nuisances_.addClone(*nuisances);
         }
 
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) ;
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override ;
 
-        virtual const TString GetVarName() const {
+        const TString GetVarName() const override {
             return TString::Format("-log(%s/%s)", pdfNull_->GetName(), pdfAlt_->GetName()); 
         }
 

--- a/interface/ProfiledLikelihoodRatioTestStatExt.h
+++ b/interface/ProfiledLikelihoodRatioTestStatExt.h
@@ -22,9 +22,9 @@ class ProfiledLikelihoodRatioTestStatOpt : public RooStats::TestStatistic {
                 const RooArgSet *nuisances, const RooArgSet & paramsNull = RooArgSet(), const RooArgSet & paramsAlt = RooArgSet(),
                 int verbosity=0) ;
  
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) ;
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override ;
 
-        virtual const TString GetVarName() const {
+        const TString GetVarName() const override {
             return TString::Format("-log(%s/%s)", pdfNull_->GetName(), pdfAlt_->GetName()); 
         }
 
@@ -55,10 +55,10 @@ class ProfiledLikelihoodTestStatOpt : public RooStats::TestStatistic {
                 const RooArgSet *nuisances, 
                 const RooArgSet & params, const RooArgSet & poi, const RooArgList &gobsParams, const RooArgList &gobs, int verbosity=0, OneSidedness oneSided = oneSidedDef) ; 
 
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) ;
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override ;
         virtual std::vector<Double_t> Evaluate(RooAbsData& data, RooArgSet& nullPOI, const std::vector<Double_t> &rVals) ;
 
-        virtual const TString GetVarName() const { return "- log (#lambda)"; }
+        const TString GetVarName() const override { return "- log (#lambda)"; }
 
         // Verbosity (default: 0)
         void setPrintLevel(Int_t level) { verbosity_ = level; }

--- a/interface/RooBernsteinFast.h
+++ b/interface/RooBernsteinFast.h
@@ -65,11 +65,11 @@ public:
     _xvector(other._xvector) {}
   
   
-  virtual TObject* clone(const char* newname) const { return new RooBernsteinFast(*this, newname); }
-  virtual ~RooBernsteinFast() { }
+  TObject* clone(const char* newname) const override { return new RooBernsteinFast(*this, newname); }
+  ~RooBernsteinFast() override { }
   
   
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override
     {
       
       // No analytical calculation available (yet) of integrals over subranges (as for standard RooBernstein)
@@ -82,7 +82,7 @@ public:
     }
     
     
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override
     {
 
       _bernvector[0] = 1.0;
@@ -111,7 +111,7 @@ protected:
   mutable VType _powvector;  //coefficients in power basis
   mutable VType _xvector;    //vector of powers of x variable
   
-  Double_t evaluate() const
+  Double_t evaluate() const override
     {
 
       _bernvector[0] = 1.0;
@@ -140,7 +140,7 @@ protected:
       
     }
 
-  ClassDef(RooBernsteinFast,1) // Polynomial PDF
+  ClassDefOverride(RooBernsteinFast,1) // Polynomial PDF
 };
 
 #endif

--- a/interface/RooCheapProduct.h
+++ b/interface/RooCheapProduct.h
@@ -9,16 +9,16 @@ class RooCheapProduct : public RooAbsReal {
         RooCheapProduct() {}
         RooCheapProduct(const char *name, const char *title, const RooArgList &terms, bool pruneConstants=false);
         RooCheapProduct(const RooCheapProduct& other, const char* name=0);
-        virtual ~RooCheapProduct() {}
-        virtual TObject *clone(const char *newname) const { return new RooCheapProduct(*this,newname); } 
+        ~RooCheapProduct() override {}
+        TObject *clone(const char *newname) const override { return new RooCheapProduct(*this,newname); } 
         const RooArgList & components() const { return terms_; }
     protected:
         RooListProxy terms_;
         std::vector<RooAbsReal *> vterms_; //! not to be serialized
         double offset_;
-        virtual Double_t evaluate() const ;
+        Double_t evaluate() const override ;
     private:
-        ClassDef(RooCheapProduct,1)
+        ClassDefOverride(RooCheapProduct,1)
 };
 
 #endif

--- a/interface/RooDoubleCBFast.h
+++ b/interface/RooDoubleCBFast.h
@@ -18,10 +18,10 @@ public:
               RooAbsReal& _n2
            );
   RooDoubleCBFast(const RooDoubleCBFast& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooDoubleCBFast(*this,newname); }
-  inline virtual ~RooDoubleCBFast() { }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  TObject* clone(const char* newname) const override { return new RooDoubleCBFast(*this,newname); }
+  inline ~RooDoubleCBFast() override { }
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -33,10 +33,10 @@ protected:
   RooRealProxy alpha2;
   RooRealProxy n2;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooDoubleCBFast,1)
+  ClassDefOverride(RooDoubleCBFast,1)
 };
 #endif

--- a/interface/RooEFTScalingFunction.h
+++ b/interface/RooEFTScalingFunction.h
@@ -15,8 +15,8 @@ class RooEFTScalingFunction : public RooAbsReal {
         RooEFTScalingFunction() {}
         RooEFTScalingFunction(const char *name, const char *title, const std::map<std::string,double> &coeffs, const RooArgList &terms);
         RooEFTScalingFunction(const RooEFTScalingFunction& other, const char* name=0);
-        virtual ~RooEFTScalingFunction() {}
-        virtual TObject *clone(const char *newname) const { return new RooEFTScalingFunction(*this,newname); } 
+        ~RooEFTScalingFunction() override {}
+        TObject *clone(const char *newname) const override { return new RooEFTScalingFunction(*this,newname); } 
         const std::map<std::string,double> & coeffs() const { return coeffs_; }
         const RooArgList & terms() const { return terms_; }
     protected:
@@ -24,9 +24,9 @@ class RooEFTScalingFunction : public RooAbsReal {
         RooListProxy terms_;
         std::map< std::vector<RooAbsReal *>, double> vcomponents_;
         double offset_;
-        virtual Double_t evaluate() const ;
+        Double_t evaluate() const override ;
     private:
-        ClassDef(RooEFTScalingFunction,1)
+        ClassDefOverride(RooEFTScalingFunction,1)
 };
 
 #endif

--- a/interface/RooMorphingPdf.h
+++ b/interface/RooMorphingPdf.h
@@ -75,19 +75,19 @@ class RooMorphingPdf : public RooAbsPdf {
   // Copy constructor
   RooMorphingPdf(const RooMorphingPdf& other, const char* name = 0);
   // Destructor
-  virtual ~RooMorphingPdf() {}
+  ~RooMorphingPdf() override {}
   // Clone method
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooMorphingPdf(*this, newname);
   }
   // void AddPoint(double point, FastVerticalInterpHistPdf & hist);
 
-  Bool_t selfNormalized() const { return kTRUE; }
+  Bool_t selfNormalized() const override { return kTRUE; }
 
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  public:
-  ClassDef(RooMorphingPdf, 1);
+  ClassDefOverride(RooMorphingPdf, 1);
 };
 
 #endif

--- a/interface/RooMultiPdf.h
+++ b/interface/RooMultiPdf.h
@@ -31,8 +31,8 @@ public:
   RooMultiPdf() {} ;
   RooMultiPdf(const char *name, const char *title, RooCategory &, const RooArgList& _c);
   RooMultiPdf(const RooMultiPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooMultiPdf(*this,newname); }
-  inline virtual ~RooMultiPdf() { }
+  TObject* clone(const char* newname) const override { return new RooMultiPdf(*this,newname); }
+  inline ~RooMultiPdf() override { }
 
 /*
   RooAbsReal* createNLL(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),  
@@ -59,9 +59,9 @@ arg8=RooCmdArg::none());
   void setCorrectionFactor(double penal);
   int getCurrentIndex() const ;
   RooAbsPdf *getPdf(int index) const ;
-  virtual Double_t getValV(const RooArgSet* nset) const ;
+  Double_t getValV(const RooArgSet* nset) const override ;
   /// needed since otherwise printValue calls evaluate(), which is taboo
-  virtual void printValue(ostream& os) const { getCurrentPdf()->printValue(os); }
+  void printValue(ostream& os) const override { getCurrentPdf()->printValue(os); }
 protected:
   RooListProxy c;
   RooListProxy corr;
@@ -74,12 +74,12 @@ protected:
   int nPdfs;
   mutable Int_t _oldIndex;
 
-  Double_t evaluate() const;
-  Double_t getLogVal(const RooArgSet *set = 0) const;
+  Double_t evaluate() const override;
+  Double_t getLogVal(const RooArgSet *set = 0) const override;
   //std::string createCorrectionString();	// should only do this once really
   double cFactor;
 
 private:
-  ClassDef(RooMultiPdf,1) // Multi PDF
+  ClassDefOverride(RooMultiPdf,1) // Multi PDF
 };
 #endif

--- a/interface/RooParametricHist.h
+++ b/interface/RooParametricHist.h
@@ -21,11 +21,11 @@ public:
   RooParametricHist() {} ;
   RooParametricHist (const char *name, const char *title, RooAbsReal& _x, RooArgList& _pars, const TH1 &_shape);
   RooParametricHist(const RooParametricHist& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooParametricHist(*this,newname); }
-  inline virtual ~RooParametricHist (){};
+  TObject* clone(const char* newname) const override { return new RooParametricHist(*this,newname); }
+  inline ~RooParametricHist () override{};
 
-  Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t, const char* rangeName=0) const override ;
 
   RooAbsArg  & getBinVar(const int i) const ;
   RooArgList & getAllBinVars() const ;
@@ -66,7 +66,7 @@ protected:
 
   double evaluatePartial() const ;
   double evaluateFull() const ;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   double getFullSum() const ;
 
   mutable double _cval;
@@ -79,7 +79,7 @@ protected:
   }
 
 private:
-   ClassDef(RooParametricHist, 2)
+   ClassDefOverride(RooParametricHist, 2)
 };
 
 #endif

--- a/interface/RooParametricHist2D.h
+++ b/interface/RooParametricHist2D.h
@@ -18,10 +18,10 @@ public:
   RooParametricHist2D (const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _y, RooArgList& _pars, const TH2 &_shape);
   
   RooParametricHist2D(const RooParametricHist2D& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooParametricHist2D(*this,newname); }
-  inline virtual ~RooParametricHist2D (){};
-  Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t, const char* rangeName=0) const ;   
+  TObject* clone(const char* newname) const override { return new RooParametricHist2D(*this,newname); }
+  inline ~RooParametricHist2D () override{};
+  Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t, const char* rangeName=0) const override ;   
   
   //RooAddition & getYieldVar(){return sum;};
   
@@ -42,13 +42,13 @@ protected:
   void initializeBins(const TH2&) const;
   //void initializeNorm();
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   double getFullSum() const ;
  
   mutable double cval;
   void update_cval(double r){cval=r;};
 private:
-   ClassDef(RooParametricHist2D, 1) 
+   ClassDefOverride(RooParametricHist2D, 1) 
 };
 
 #endif

--- a/interface/RooParametricShapeBinPdf.h
+++ b/interface/RooParametricShapeBinPdf.h
@@ -25,11 +25,11 @@ public:
    void setTH1Binning(const TH1& _Hnominal);
    RooAbsPdf* getPdf() const;
    RooAbsReal* getIntegral(int index) const;
-   virtual TObject* clone(const char* newname) const { return new RooParametricShapeBinPdf(*this,newname); }
-   inline virtual ~RooParametricShapeBinPdf() { }
+   TObject* clone(const char* newname) const override { return new RooParametricShapeBinPdf(*this,newname); }
+   inline ~RooParametricShapeBinPdf() override { }
 
-   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
    //accessors
    RooRealProxy const& getX() const { return x; }
@@ -48,22 +48,22 @@ protected:
    Double_t xMax;        // X max
    Double_t xMin;        // X min
 
-   Double_t evaluate() const;
+   Double_t evaluate() const override;
 private:
-   virtual RooPlot* plotOn(RooPlot* frame, 
+   RooPlot* plotOn(RooPlot* frame, 
               const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
               const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
               const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
               const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),
               const RooCmdArg& arg9=RooCmdArg::none(), const RooCmdArg& arg10=RooCmdArg::none()
-                 ) const {
+                 ) const override {
      return mypdf.arg().plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
      }
-     virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const {
+     RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override {
        return mypdf.arg().plotOn(frame,cmdList) ;
      }
      
-   ClassDef(RooParametricShapeBinPdf,2) // RooParametricShapeBinPdf function
+   ClassDefOverride(RooParametricShapeBinPdf,2) // RooParametricShapeBinPdf function
     
 };
 //---------------------------------------------------------------------------

--- a/interface/RooScaleLOSM.h
+++ b/interface/RooScaleLOSM.h
@@ -16,15 +16,15 @@ class RooScaleLOSM: public RooAbsReal
   public:
     RooScaleLOSM(){};
     RooScaleLOSM(const char *name, const char *title, RooAbsReal &mH);
-    ~RooScaleLOSM(){};
+    ~RooScaleLOSM() override{};
 
-    virtual TObject* clone(const char *newname) const = 0;
+    TObject* clone(const char *newname) const override = 0;
 
   protected:
     complexD f(double tau) const;
     inline complexD AmpSpinOneHalf(double tau) const;
     inline complexD AmpSpinOne(double tau) const;
-    virtual Double_t evaluate() const = 0;
+    Double_t evaluate() const override = 0;
 
     RooRealProxy mH_;
     static const double mt_, mW_;
@@ -34,7 +34,7 @@ class RooScaleLOSM: public RooAbsReal
 
   private:
 
-    ClassDef(RooScaleLOSM,1)
+    ClassDefOverride(RooScaleLOSM,1)
 };
 
 class RooScaleHGamGamLOSM: public RooScaleLOSM
@@ -43,17 +43,17 @@ class RooScaleHGamGamLOSM: public RooScaleLOSM
     RooScaleHGamGamLOSM(){};
     RooScaleHGamGamLOSM(const char *name, const char *title,
     		RooAbsReal &mH, RooAbsReal &ct, RooAbsReal &cW, RooAbsReal &mb, RooAbsReal &cb);
-    ~RooScaleHGamGamLOSM(){};
+    ~RooScaleHGamGamLOSM() override{};
 
-    TObject* clone(const char *newname) const;
+    TObject* clone(const char *newname) const override;
 
   protected:
-      Double_t evaluate() const;
+      Double_t evaluate() const override;
       RooRealProxy ct_, cW_, mb_, cb_;
 
   private:
 
-    ClassDef(RooScaleHGamGamLOSM,1)
+    ClassDefOverride(RooScaleHGamGamLOSM,1)
 };
 
 class RooScaleHGluGluLOSM: public RooScaleLOSM
@@ -62,17 +62,17 @@ class RooScaleHGluGluLOSM: public RooScaleLOSM
     RooScaleHGluGluLOSM(){};
     RooScaleHGluGluLOSM(const char *name, const char *title,
     		RooAbsReal &mH, RooAbsReal &ct, RooAbsReal &mb, RooAbsReal &cb);
-    ~RooScaleHGluGluLOSM(){};
+    ~RooScaleHGluGluLOSM() override{};
 
-    TObject* clone(const char *newname) const;
+    TObject* clone(const char *newname) const override;
 
   protected:
-      Double_t evaluate() const;
+      Double_t evaluate() const override;
       RooRealProxy ct_, mb_, cb_;
 
   private:
 
-    ClassDef(RooScaleHGluGluLOSM,1)
+    ClassDefOverride(RooScaleHGluGluLOSM,1)
 };
 
 class RooScaleHGamGamLOSMPlusX: public RooScaleHGamGamLOSM
@@ -81,17 +81,17 @@ class RooScaleHGamGamLOSMPlusX: public RooScaleHGamGamLOSM
     RooScaleHGamGamLOSMPlusX(){};
     RooScaleHGamGamLOSMPlusX(const char *name, const char *title,
     		RooAbsReal &mH, RooAbsReal &ct, RooAbsReal &cW, RooAbsReal &mb, RooAbsReal &cb, RooAbsReal &X);
-    ~RooScaleHGamGamLOSMPlusX(){};
+    ~RooScaleHGamGamLOSMPlusX() override{};
 
-    TObject* clone(const char *newname) const;
+    TObject* clone(const char *newname) const override;
 
   protected:
-      Double_t evaluate() const;
+      Double_t evaluate() const override;
       RooRealProxy X_;
 
   private:
 
-    ClassDef(RooScaleHGamGamLOSMPlusX,1)
+    ClassDefOverride(RooScaleHGamGamLOSMPlusX,1)
 };
 
 class RooScaleHGluGluLOSMPlusX: public RooScaleHGluGluLOSM
@@ -100,17 +100,17 @@ class RooScaleHGluGluLOSMPlusX: public RooScaleHGluGluLOSM
     RooScaleHGluGluLOSMPlusX(){};
     RooScaleHGluGluLOSMPlusX(const char *name, const char *title,
     		RooAbsReal &mH, RooAbsReal &ct, RooAbsReal &mb, RooAbsReal &cb, RooAbsReal &X);
-    ~RooScaleHGluGluLOSMPlusX(){};
+    ~RooScaleHGluGluLOSMPlusX() override{};
 
-    TObject* clone(const char *newname) const;
+    TObject* clone(const char *newname) const override;
 
   protected:
-      Double_t evaluate() const;
+      Double_t evaluate() const override;
       RooRealProxy X_;
 
   private:
 
-    ClassDef(RooScaleHGluGluLOSMPlusX,1)
+    ClassDefOverride(RooScaleHGluGluLOSMPlusX,1)
 };
 
 #endif

--- a/interface/RooSimultaneousOpt.h
+++ b/interface/RooSimultaneousOpt.h
@@ -30,7 +30,11 @@ public:
 
   ~RooSimultaneousOpt() override ;
 
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) ;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,30,0)
+  RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) override;
+#else
+  std::unique_ptr<RooAbsReal> createNLLImpl(RooAbsData& data, const RooLinkedList& cmdList) override;
+#endif
 
   const RooArgList & extraConstraints() const { return _extraConstraints; }
   const RooArgList & channelMasks() const { return _channelMasks; }

--- a/interface/RooSimultaneousOpt.h
+++ b/interface/RooSimultaneousOpt.h
@@ -26,9 +26,9 @@ public:
         _extraConstraints("extraConstraints", this, other._extraConstraints),
         _channelMasks("channelMasks", this, other._channelMasks)  {}
 
-  virtual RooSimultaneousOpt *clone(const char* name=0) const { return new RooSimultaneousOpt(*this, name); }
+  RooSimultaneousOpt *clone(const char* name=0) const override { return new RooSimultaneousOpt(*this, name); }
 
-  virtual ~RooSimultaneousOpt() ;
+  ~RooSimultaneousOpt() override ;
 
   virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) ;
 
@@ -39,7 +39,7 @@ public:
   void addExtraConstraints(const RooAbsCollection &pdfs) ;
   void addChannelMasks(const RooArgList &args);
 private:
-  ClassDef(RooSimultaneousOpt,3) // Variant of RooSimultaneous that can put together binned and unbinned stuff 
+  ClassDefOverride(RooSimultaneousOpt,3) // Variant of RooSimultaneous that can put together binned and unbinned stuff 
 
   RooListProxy _extraConstraints;  //  List of extra constraint terms
   RooListProxy _channelMasks;

--- a/interface/RooSpline1D.h
+++ b/interface/RooSpline1D.h
@@ -23,12 +23,12 @@ class RooSpline1D : public RooAbsReal {
       RooSpline1D(const char *name, const char *title, RooAbsReal &xvar, unsigned int npoints, const double *xvals, const double *yvals, const char *algo="CSPLINE") ;
       RooSpline1D(const char *name, const char *title, RooAbsReal &xar, unsigned int npoints, const float *xvals, const float *yvals, const char *algo="CSPLINE") ;
       RooSpline1D(const RooSpline1D &other, const char *newname=0) ;
-      ~RooSpline1D() ;
+      ~RooSpline1D() override ;
 
-      TObject * clone(const char *newname) const ;
+      TObject * clone(const char *newname) const override ;
 
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
         RooRealProxy xvar_;
@@ -38,7 +38,7 @@ class RooSpline1D : public RooAbsReal {
         mutable ROOT::Math::Interpolator *interp_; //! not to be serialized        
         void init() const ;
 
-  ClassDef(RooSpline1D,1) // Smooth interpolation	
+  ClassDefOverride(RooSpline1D,1) // Smooth interpolation	
 };
 
 #endif

--- a/interface/RooSplineND.h
+++ b/interface/RooSplineND.h
@@ -66,14 +66,14 @@ class RooSplineND : public RooAbsReal {
       RooSplineND(const char *name, const char *title, RooArgList &vars, TTree *tree, const char* fName="f", double eps=3., bool rescale=false, std::string cutstring="" ) ;
       RooSplineND(const RooSplineND& other, const char *name) ; 
       RooSplineND(const char *name, const char *title, const RooListProxy &vars, int ndim, int M, double eps, bool rescale, std::vector<double> &w, std::map<int,std::vector<double> > &map, std::map<int,std::pair<double,double> > & ,double,double) ;
-      ~RooSplineND() ;
+      ~RooSplineND() override ;
 
-      TObject * clone(const char *newname) const ;
+      TObject * clone(const char *newname) const override ;
 
       TGraph* getGraph(const char *xvar, double step) ;
 
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
         RooListProxy vars_;
@@ -98,7 +98,7 @@ class RooSplineND : public RooAbsReal {
 	mutable bool rescaleAxis;
 	
 
-  ClassDef(RooSplineND,1) 
+  ClassDefOverride(RooSplineND,1) 
 };
 
 #endif

--- a/interface/RooTaylorExpansion.h
+++ b/interface/RooTaylorExpansion.h
@@ -19,13 +19,13 @@ class RooTaylorExpansion : public RooAbsReal {
                      const std::vector<double>& terms);
 
   RooTaylorExpansion(const RooTaylorExpansion& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooTaylorExpansion(*this, newname);
   }
-  inline virtual ~RooTaylorExpansion() {}
+  inline ~RooTaylorExpansion() override {}
 
   void printMultiline(std::ostream& os, Int_t contents,
-                                   Bool_t verbose, TString indent) const;
+                                   Bool_t verbose, TString indent) const override;
 
  protected:
 
@@ -34,10 +34,10 @@ class RooTaylorExpansion : public RooAbsReal {
   std::vector<std::vector<int>> _trackers;
   std::vector<double> _terms;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(RooTaylorExpansion,
+  ClassDefOverride(RooTaylorExpansion,
            1)  // Multivariate Gaussian PDF with correlations
 };
 

--- a/interface/SequentialMinimizer.h
+++ b/interface/SequentialMinimizer.h
@@ -111,53 +111,53 @@ namespace cmsmath {
             SequentialMinimizer(const char *name=0) : ROOT::Math::Minimizer() {}
 
             /// reset for consecutive minimizations - implement if needed 
-            virtual void Clear() ;
+            void Clear() override ;
 
             /// set the function to minimize
-            virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func) ; 
+            void SetFunction(const ROOT::Math::IMultiGenFunction & func) override ; 
 
             /// set free variable 
-            virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) ; 
+            bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override ; 
 
             /// set upper/lower limited variable (override if minimizer supports them )
-            virtual bool SetLimitedVariable(unsigned int ivar, const std::string & name, double val, double  step, double  lower, double  upper) ; 
+            bool SetLimitedVariable(unsigned int ivar, const std::string & name, double val, double  step, double  lower, double  upper) override ; 
 
             /// set fixed variable (override if minimizer supports them )
-            virtual bool SetFixedVariable(unsigned int ivar, const std::string & name, double val) ; 
+            bool SetFixedVariable(unsigned int ivar, const std::string & name, double val) override ; 
 
             /// method to perform the minimization
-            virtual  bool Minimize() ; 
+             bool Minimize() override ; 
 
             /// return minimum function value
-            virtual double MinValue() const { return minValue_;  }
+            double MinValue() const override { return minValue_;  }
 
             /// return expected distance reached from the minimum
-            virtual double Edm() const { return edm_; }
+            double Edm() const override { return edm_; }
 
             /// return  pointer to X values at the minimum 
-            virtual const double *  X() const { return & func_->x[0]; }
+            const double *  X() const override { return & func_->x[0]; }
 
             /// return pointer to gradient values at the minimum 
-            virtual const double *  MinGradient() const { return 0; }  
+            const double *  MinGradient() const override { return 0; }  
 
             /// number of function calls to reach the minimum 
-            virtual unsigned int NCalls() const { return func_->nCalls; }    
+            unsigned int NCalls() const override { return func_->nCalls; }    
 
             /// this is <= Function().NDim() which is the total 
             /// number of variables (free+ constrained ones) 
-            virtual unsigned int NDim() const { return nDim_; }
+            unsigned int NDim() const override { return nDim_; }
 
             /// number of free variables (real dimension of the problem) 
             /// this is <= Function().NDim() which is the total 
-            virtual unsigned int NFree() const { return nFree_;   }
+            unsigned int NFree() const override { return nFree_;   }
 
             /// minimizer provides error and error matrix
-            virtual bool ProvidesError() const { return false; } 
+            bool ProvidesError() const override { return false; } 
 
             /// return errors at the minimum 
-            virtual const double * Errors() const { return 0; }
+            const double * Errors() const override { return 0; }
 
-            virtual double CovMatrix(unsigned int i, unsigned int j) const { return 0; }
+            double CovMatrix(unsigned int i, unsigned int j) const override { return 0; }
 
             // these have to be public for ROOT to handle
             enum State { Cleared, Ready, Active, Done, Fixed, Unknown };

--- a/interface/Significance.h
+++ b/interface/Significance.h
@@ -15,12 +15,12 @@ class RooAbsPdf; class RooRealVar; class RooAbsData; class RooArgSet;
 class Significance : public LimitAlgo {
 public:
   Significance() ;
-  virtual bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint);
-  virtual const std::string & name() const {
+  bool run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) override;
+  const std::string & name() const override {
     static const std::string name("Significance");
     return name;
   }
-  virtual void applyOptions(const boost::program_options::variables_map &vm) ;
+  void applyOptions(const boost::program_options::variables_map &vm) override ;
 
   /// Setup Minimizer configuration on creation, reset the previous one on destruction.
   class MinimizerSentry {

--- a/interface/SimpleCacheSentry.h
+++ b/interface/SimpleCacheSentry.h
@@ -22,21 +22,21 @@ class SimpleCacheSentry : public RooAbsArg {
         bool empty() const { return _deps.getSize() == 0; }
         void reset() { clearValueDirty(); } 
         // base class methods to be implemented
-        virtual TObject* clone(const char* newname) const { return new SimpleCacheSentry(*this, newname); }
-        virtual RooAbsArg *createFundamental(const char* newname=0) const { return 0; }
-        virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) { return false; }
-        virtual void writeToStream(std::ostream& os, Bool_t compact) const { }
-        virtual Bool_t operator==(const RooAbsArg& other) const { return this == &other; }
-        virtual void syncCache(const RooArgSet* nset=0) {}
-        virtual void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) {}
-        virtual void attachToTree(TTree& t, Int_t bufSize=32000) {}
-        virtual void attachToVStore(RooVectorDataStore& vstore) {}
-        virtual void setTreeBranchStatus(TTree& t, Bool_t active) {}
-        virtual void fillTreeBranch(TTree& t) {}
-        virtual Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const;
+        TObject* clone(const char* newname) const override { return new SimpleCacheSentry(*this, newname); }
+        RooAbsArg *createFundamental(const char* newname=0) const override { return 0; }
+        Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override { return false; }
+        void writeToStream(std::ostream& os, Bool_t compact) const override { }
+        Bool_t operator==(const RooAbsArg& other) const override { return this == &other; }
+        void syncCache(const RooArgSet* nset=0) override {}
+        void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) override {}
+        void attachToTree(TTree& t, Int_t bufSize=32000) override {}
+        void attachToVStore(RooVectorDataStore& vstore) override {}
+        void setTreeBranchStatus(TTree& t, Bool_t active) override {}
+        void fillTreeBranch(TTree& t) override {}
+        Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const override;
     private:
         RooSetProxy _deps;
-        ClassDef(SimpleCacheSentry,1) 
+        ClassDefOverride(SimpleCacheSentry,1) 
 };
 
 #endif

--- a/interface/SimpleConstraintGroup.h
+++ b/interface/SimpleConstraintGroup.h
@@ -16,11 +16,11 @@ class SimpleConstraintGroup : public RooAbsReal {
         void clearZeroPoint() ;
         void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
  
-        TObject * clone(const char *newname) const { return new SimpleConstraintGroup(*this, newname); }
+        TObject * clone(const char *newname) const override { return new SimpleConstraintGroup(*this, newname); }
 
         unsigned int size() const { return _gaus.size() + _pois.size(); }
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
         RooSetProxy _deps;
@@ -28,7 +28,7 @@ class SimpleConstraintGroup : public RooAbsReal {
         std::vector<const SimplePoissonConstraint *> _pois;
         std::vector<double> _gaus0, _pois0;
 
-        ClassDef(SimpleConstraintGroup,1) // group of constraints
+        ClassDefOverride(SimpleConstraintGroup,1) // group of constraints
 };
 
 #endif

--- a/interface/SimpleGaussianConstraint.h
+++ b/interface/SimpleGaussianConstraint.h
@@ -13,8 +13,8 @@ class SimpleGaussianConstraint : public RooGaussian {
             RooGaussian(other, name) { init(); }
         SimpleGaussianConstraint(const RooGaussian &g) : RooGaussian(g, "") { init(); }
 
-        virtual TObject* clone(const char* newname) const { return new SimpleGaussianConstraint(*this,newname); }
-        inline virtual ~SimpleGaussianConstraint() { }
+        TObject* clone(const char* newname) const override { return new SimpleGaussianConstraint(*this,newname); }
+        inline ~SimpleGaussianConstraint() override { }
 
         const RooAbsReal & getX() const { return x.arg(); }
 
@@ -34,7 +34,7 @@ class SimpleGaussianConstraint : public RooGaussian {
         double scale_;
         void init() ;
 
-        ClassDef(SimpleGaussianConstraint,1) // Gaussian PDF with fast log
+        ClassDefOverride(SimpleGaussianConstraint,1) // Gaussian PDF with fast log
 };
 
 #endif

--- a/interface/SimplePoissonConstraint.h
+++ b/interface/SimplePoissonConstraint.h
@@ -14,8 +14,8 @@ class SimplePoissonConstraint : public RooPoisson {
             RooPoisson(other, name) { init(); }
         SimplePoissonConstraint(const RooPoisson &g) : RooPoisson(g, "") { init(); }
 
-        virtual TObject* clone(const char* newname) const { return new SimplePoissonConstraint(*this,newname); }
-        inline virtual ~SimplePoissonConstraint() { }
+        TObject* clone(const char* newname) const override { return new SimplePoissonConstraint(*this,newname); }
+        inline ~SimplePoissonConstraint() override { }
 
         const RooAbsReal & getMean() const { return mean.arg(); }
 
@@ -45,7 +45,7 @@ class SimplePoissonConstraint : public RooPoisson {
         double logGamma_;
         void init() ;
 
-        ClassDef(SimplePoissonConstraint,1) // Poisson PDF with fast log
+        ClassDefOverride(SimplePoissonConstraint,1) // Poisson PDF with fast log
 };
 
 #endif

--- a/interface/SimpleProdPdf.h
+++ b/interface/SimpleProdPdf.h
@@ -15,25 +15,25 @@ class SimpleProdPdf : public RooAbsPdf {
   SimpleProdPdf(const char* name, const char* title, RooArgList& pdfList,
                 std::vector<int> const& pdfSettings);
   SimpleProdPdf(const SimpleProdPdf& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new SimpleProdPdf(*this, newname); }
-  inline virtual ~SimpleProdPdf() {}
+  TObject* clone(const char* newname) const override { return new SimpleProdPdf(*this, newname); }
+  inline ~SimpleProdPdf() override {}
 
   RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset,
-                             const RooNumIntConfig* cfg, const char* rangeName) const;
+                             const RooNumIntConfig* cfg, const char* rangeName) const override;
 
   const RooArgList& pdfList() const { return _pdfList; }
-  void printMetaArgs(std::ostream& os) const;
+  void printMetaArgs(std::ostream& os) const override;
 
   // Copied from RooProdPdf - needed to get the correct toy/Asimov binning
-  std::list<Double_t>* binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override;
 
  protected:
   RooListProxy _pdfList;
   std::vector<int> _pdfSettings;  // 0 = normal, 1 = conditional
-  virtual Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
-  ClassDef(SimpleProdPdf, 1)
+  ClassDefOverride(SimpleProdPdf, 1)
 };
 
 #endif

--- a/interface/SimpleTaylorExpansion1D.h
+++ b/interface/SimpleTaylorExpansion1D.h
@@ -23,12 +23,12 @@ class SimpleTaylorExpansion1D : public RooAbsReal {
       SimpleTaylorExpansion1D(const char *name, const char *title, RooAbsReal & func, RooRealVar & xvar, double dx, int order=2) ;
       SimpleTaylorExpansion1D(const SimpleTaylorExpansion1D &other, const char *newname=0) ;
 
-      ~SimpleTaylorExpansion1D() ;
+      ~SimpleTaylorExpansion1D() override ;
 
-      TObject * clone(const char *newname) const ;
+      TObject * clone(const char *newname) const override ;
 
     protected:
-        Double_t evaluate() const;
+        Double_t evaluate() const override;
 
     private:
 
@@ -36,7 +36,7 @@ class SimpleTaylorExpansion1D : public RooAbsReal {
         double x0_, ci_[MaxOrder+1];
 
 
-  ClassDef(SimpleTaylorExpansion1D,1) // Simple Taylor Expansion in 1D 
+  ClassDefOverride(SimpleTaylorExpansion1D,1) // Simple Taylor Expansion in 1D 
 };
 
 #endif

--- a/interface/SimplerLikelihoodRatioTestStat.h
+++ b/interface/SimplerLikelihoodRatioTestStat.h
@@ -19,7 +19,7 @@ class SimplerLikelihoodRatioTestStat : public RooStats::TestStatistic {
             snapAlt_.addClone(paramsAlt);
         }
 
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) 
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override 
         {
             if (data.numEntries() != 1) throw std::invalid_argument("HybridNew::TestSimpleStatistics: dataset doesn't have exactly 1 entry.");
             const RooArgSet *entry = data.get(0);
@@ -35,7 +35,7 @@ class SimplerLikelihoodRatioTestStat : public RooStats::TestStatistic {
             return -log(nullNLL/altNLL);
         }
 
-        virtual const TString GetVarName() const {
+        const TString GetVarName() const override {
             return TString::Format("-log(%s/%s)", pdfNull_->GetName(), pdfAlt_->GetName()); 
         }
 

--- a/interface/SimplerLikelihoodRatioTestStatExt.h
+++ b/interface/SimplerLikelihoodRatioTestStatExt.h
@@ -40,11 +40,11 @@ class SimplerLikelihoodRatioTestStatOpt : public RooStats::TestStatistic {
         ///   factorize: if set to true, the constraint terms not depending on the observables will be removed 
         SimplerLikelihoodRatioTestStatOpt(const RooArgSet &obs, RooAbsPdf &pdfNull, RooAbsPdf &pdfAlt, const RooArgSet & paramsNull = RooArgSet(), const RooArgSet & paramsAlt = RooArgSet(), bool factorize=true) ;
 
-        virtual ~SimplerLikelihoodRatioTestStatOpt() ;
+        ~SimplerLikelihoodRatioTestStatOpt() override ;
 
-        virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) ;
+        Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override ;
 
-        virtual const TString GetVarName() const {
+        const TString GetVarName() const override {
             return TString::Format("-log(%s/%s)", pdfNull_->GetName(), pdfAlt_->GetName()); 
         }
     private:

--- a/interface/TH1Keys.h
+++ b/interface/TH1Keys.h
@@ -14,41 +14,41 @@ class TH1Keys : public TH1 {
        TH1Keys(const char *name,const char *title,Int_t nbinsx,const Float_t  *xbins, TString options = "a", Double_t rho = 1.5) ;
        TH1Keys(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins, TString options = "a", Double_t rho = 1.5) ;
        TH1Keys(const TH1Keys &other);
-       virtual ~TH1Keys();
+       ~TH1Keys() override;
 
        TH1 * GetHisto() { if (!isCacheGood_) FillH1(); return cache_; }
        const TH1 * GetHisto() const { if (!isCacheGood_) FillH1(); return cache_; }
 
-       virtual Int_t    Fill(Double_t x) { return Fill(x,1.0); }
-       virtual Int_t    Fill(Double_t x, Double_t w);
-       virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
+       Int_t    Fill(Double_t x) override { return Fill(x,1.0); }
+       Int_t    Fill(Double_t x, Double_t w) override;
+       void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1) override;
 #if ROOT_VERSION_CODE <  ROOT_VERSION(5,34,00)
        virtual void     Add(const TH1 *h1, Double_t c1=1);
        virtual void     Add(const TH1 *h, const TH1 *h2, Double_t c1=1, Double_t c2=1) { dont("Add with two arguments"); } 
 #else
-       virtual Bool_t   Add(const TH1 *h1, Double_t c1=1);
-       virtual Bool_t   Add(const TH1 *h, const TH1 *h2, Double_t c1=1, Double_t c2=1) { dont("Add with two arguments"); return false;} 
+       Bool_t   Add(const TH1 *h1, Double_t c1=1) override;
+       Bool_t   Add(const TH1 *h, const TH1 *h2, Double_t c1=1, Double_t c2=1) override { dont("Add with two arguments"); return false;} 
 #endif
-       virtual void     AddBinContent(Int_t bin) { AddBinContent(bin, 1.0); }
-       virtual void     AddBinContent(Int_t bin, Double_t w) { dont("AddBinContent"); }
-       virtual void     Copy(TObject &hnew) const { dont("Copy"); }
+       void     AddBinContent(Int_t bin) override { AddBinContent(bin, 1.0); }
+       void     AddBinContent(Int_t bin, Double_t w) override { dont("AddBinContent"); }
+       void     Copy(TObject &hnew) const override { dont("Copy"); }
 
        virtual TH1     *DrawCopy(Option_t *option="") const { dont("DrawCopy"); return 0; }
 
-       virtual Double_t GetBinContent(Int_t bin) const { return GetHisto()->GetBinContent(bin); }
-       virtual Double_t GetBinContent(Int_t bin, Int_t) const { return GetHisto()->GetBinContent(bin); }
-       virtual Double_t GetBinContent(Int_t bin, Int_t, Int_t) const {return GetHisto()->GetBinContent(bin); }
+       Double_t GetBinContent(Int_t bin) const override { return GetHisto()->GetBinContent(bin); }
+       Double_t GetBinContent(Int_t bin, Int_t) const override { return GetHisto()->GetBinContent(bin); }
+       Double_t GetBinContent(Int_t bin, Int_t, Int_t) const override {return GetHisto()->GetBinContent(bin); }
 
-       virtual Double_t GetEntries() const { return dataset_->numEntries(); }
+       Double_t GetEntries() const override { return dataset_->numEntries(); }
 
-       virtual void     Reset(Option_t *option="") ; 
-       virtual void     SetBinContent(Int_t bin, Double_t content) { dont("SetBinContent"); }
-       virtual void     SetBinContent(Int_t bin, Int_t, Double_t content)        { SetBinContent(bin,content); }
-       virtual void     SetBinContent(Int_t bin, Int_t, Int_t, Double_t content) { SetBinContent(bin,content); }
-       virtual void     SetBinsLength(Int_t n=-1) { dont("SetBinLength"); }
-       virtual void     Scale(Double_t c1=1, Option_t *option="");
+       void     Reset(Option_t *option="") override ; 
+       void     SetBinContent(Int_t bin, Double_t content) override { dont("SetBinContent"); }
+       void     SetBinContent(Int_t bin, Int_t, Double_t content) override        { SetBinContent(bin,content); }
+       void     SetBinContent(Int_t bin, Int_t, Int_t, Double_t content) override { SetBinContent(bin,content); }
+       void     SetBinsLength(Int_t n=-1) override { dont("SetBinLength"); }
+       void     Scale(Double_t c1=1, Option_t *option="") override;
 
-       ClassDef(TH1Keys,1)  //
+       ClassDefOverride(TH1Keys,1)  //
 
     private:
         Double_t    min_, max_;

--- a/interface/TestProposal.h
+++ b/interface/TestProposal.h
@@ -29,20 +29,20 @@ class TestProposal : public RooStats::ProposalFunction {
       } 
 
       // Populate xPrime with a new proposed point
-      virtual void Propose(RooArgSet& xPrime, RooArgSet& x);
+      void Propose(RooArgSet& xPrime, RooArgSet& x) override;
 
       // Determine whether or not the proposal density is symmetric for
       // points x1 and x2 - that is, whether the probabilty of reaching x2
       // from x1 is equal to the probability of reaching x1 from x2
-      virtual Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) ;
+      Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) override ;
 
       // Return the probability of proposing the point x1 given the starting
       // point x2
-      virtual Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2);
+      Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2) override;
 
-      virtual ~TestProposal() {}
+      ~TestProposal() override {}
 
-      ClassDef(TestProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
+      ClassDefOverride(TestProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
     
     private:
       double divisor_, poiDivisor_;

--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -62,11 +62,11 @@ class ToyMCSamplerOpt : public RooStats::ToyMCSampler{
         ToyMCSamplerOpt(const RooStats::ToyMCSampler &base) ;
         ToyMCSamplerOpt(const ToyMCSamplerOpt &other) ;
 #endif
-        ~ToyMCSamplerOpt() ;
-        virtual void SetPdf(RooAbsPdf& pdf) ;
+        ~ToyMCSamplerOpt() override ;
+        void SetPdf(RooAbsPdf& pdf) override ;
         void setGlobalObsPdf(RooAbsPdf *pdf) { globalObsPdf_ = pdf; }
-        virtual RooAbsData* GenerateToyData(RooArgSet& /*nullPOI*/, double& weight) const ;
-        virtual RooDataSet* GetSamplingDistributionsSingleWorker(RooArgSet& paramPointIn) ;
+        RooAbsData* GenerateToyData(RooArgSet& /*nullPOI*/, double& weight) const override ;
+        RooDataSet* GetSamplingDistributionsSingleWorker(RooArgSet& paramPointIn) override ;
     private:
         RooAbsData* GenerateToyDataWithImportanceSampling(RooArgSet& /*nullPOI*/, double& weight) const ;
 

--- a/interface/VBFHZZ4L_RooSpinZeroPdf.h
+++ b/interface/VBFHZZ4L_RooSpinZeroPdf.h
@@ -32,7 +32,7 @@ protected:
   RooRealProxy a1, ai;
   RooListProxy _coefList ;  //  List of funcficients
 //  TIterator* _coefIter ;    //! Iterator over funcficient lis
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 public:
   VBFHZZ4L_RooSpinZeroPdf() {} ;
   VBFHZZ4L_RooSpinZeroPdf(const char *name, const char *title,
@@ -44,11 +44,11 @@ public:
                        const RooArgList& inCoefList);
 
   VBFHZZ4L_RooSpinZeroPdf(const VBFHZZ4L_RooSpinZeroPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new VBFHZZ4L_RooSpinZeroPdf(*this,newname); }
-  inline virtual ~VBFHZZ4L_RooSpinZeroPdf() {}
+  TObject* clone(const char* newname) const override { return new VBFHZZ4L_RooSpinZeroPdf(*this,newname); }
+  inline ~VBFHZZ4L_RooSpinZeroPdf() override {}
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   const RooArgList& coefList() const { return _coefList ; }
 
   double Integral_T1;
@@ -59,7 +59,7 @@ public:
 
 private:
 
-        ClassDef(VBFHZZ4L_RooSpinZeroPdf,1) // Your description goes here...
+        ClassDefOverride(VBFHZZ4L_RooSpinZeroPdf,1) // Your description goes here...
 
 };
 

--- a/interface/VBFHZZ4L_RooSpinZeroPdf_fast.h
+++ b/interface/VBFHZZ4L_RooSpinZeroPdf_fast.h
@@ -28,16 +28,16 @@ public:
     );
 
   VBFHZZ4L_RooSpinZeroPdf_fast(const VBFHZZ4L_RooSpinZeroPdf_fast& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new VBFHZZ4L_RooSpinZeroPdf_fast(*this, newname); }
-  inline virtual ~VBFHZZ4L_RooSpinZeroPdf_fast(){}
+  TObject* clone(const char* newname) const override { return new VBFHZZ4L_RooSpinZeroPdf_fast(*this, newname); }
+  inline ~VBFHZZ4L_RooSpinZeroPdf_fast() override{}
 
   Float_t interpolateFcn(Int_t code, const char* rangeName=0) const;
-  Double_t evaluate() const;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Double_t evaluate() const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 protected:
-  ClassDef(VBFHZZ4L_RooSpinZeroPdf_fast, 1)
+  ClassDefOverride(VBFHZZ4L_RooSpinZeroPdf_fast, 1)
 
 };
  

--- a/interface/VVHZZ4L_RooSpinZeroPdf_1D_fast.h
+++ b/interface/VVHZZ4L_RooSpinZeroPdf_1D_fast.h
@@ -26,16 +26,16 @@ public:
     );
 
   VVHZZ4L_RooSpinZeroPdf_1D_fast(const VVHZZ4L_RooSpinZeroPdf_1D_fast& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new VVHZZ4L_RooSpinZeroPdf_1D_fast(*this, newname); }
-  inline virtual ~VVHZZ4L_RooSpinZeroPdf_1D_fast(){}
+  TObject* clone(const char* newname) const override { return new VVHZZ4L_RooSpinZeroPdf_1D_fast(*this, newname); }
+  inline ~VVHZZ4L_RooSpinZeroPdf_1D_fast() override{}
 
   Float_t interpolateFcn(Int_t code, const char* rangeName=0) const;
-  Double_t evaluate() const;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Double_t evaluate() const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 protected:
-  ClassDef(VVHZZ4L_RooSpinZeroPdf_1D_fast, 1)
+  ClassDefOverride(VVHZZ4L_RooSpinZeroPdf_1D_fast, 1)
 
 };
  

--- a/interface/VectorizedHistFactoryPdfs.h
+++ b/interface/VectorizedHistFactoryPdfs.h
@@ -10,11 +10,11 @@ namespace cacheutils {
     class VectorizedHistFunc : public CachingPdfBase {
         public:
             VectorizedHistFunc(const RooHistFunc &pdf, bool includeZeroWeights=false) ;
-            virtual ~VectorizedHistFunc() {}
-            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-            virtual const RooAbsReal *pdf() const { return pdf_; };
-            virtual void  setDataDirty() { data_ = 0; }
-            virtual void  setIncludeZeroWeights(bool includeZeroWeights) { includeZeroWeights_ = includeZeroWeights; }
+            ~VectorizedHistFunc() override {}
+            const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+            const RooAbsReal *pdf() const override { return pdf_; };
+            void  setDataDirty() override { data_ = 0; }
+            void  setIncludeZeroWeights(bool includeZeroWeights) override { includeZeroWeights_ = includeZeroWeights; }
         private:
             const RooHistFunc * pdf_;
             const RooAbsData * data_;
@@ -34,11 +34,11 @@ namespace cacheutils {
     class CachingPiecewiseInterpolation : public CachingPdfBase {
         public:
             CachingPiecewiseInterpolation(const PiecewiseInterpolation &pdf, const RooArgSet &obs) ;
-            ~CachingPiecewiseInterpolation() ;
-            virtual const std::vector<Double_t> & eval(const RooAbsData &data) ;
-            const RooAbsReal *pdf() const { return pdf_; }
-            virtual void  setDataDirty() ;
-            virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
+            ~CachingPiecewiseInterpolation() override ;
+            const std::vector<Double_t> & eval(const RooAbsData &data) override ;
+            const RooAbsReal *pdf() const override { return pdf_; }
+            void  setDataDirty() override ;
+            void  setIncludeZeroWeights(bool includeZeroWeights) override ;
         protected:
             const PiecewiseInterpolation * pdf_;
             std::vector<const RooAbsReal *> coeffs_;

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -23,12 +23,12 @@ public:
   VerticalInterpHistPdf() ;
   VerticalInterpHistPdf(const char *name, const char *title, const RooRealVar &x, const RooArgList& funcList, const RooArgList& coefList, Double_t smoothRegion=1., Int_t smoothAlgo=1) ;
   VerticalInterpHistPdf(const VerticalInterpHistPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new VerticalInterpHistPdf(*this,newname) ; }
-  virtual ~VerticalInterpHistPdf() ;
+  TObject* clone(const char* newname) const override { return new VerticalInterpHistPdf(*this,newname) ; }
+  ~VerticalInterpHistPdf() override ;
 
-  Bool_t selfNormalized() const { return kTRUE; }
+  Bool_t selfNormalized() const override { return kTRUE; }
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
@@ -51,7 +51,7 @@ protected:
   mutable int  *_cacheSingleGood; //! not to be serialized
 private:
 
-  ClassDef(VerticalInterpHistPdf,1) // 
+  ClassDefOverride(VerticalInterpHistPdf,1) // 
 
 protected:
   void setupCaches() const ;
@@ -71,12 +71,12 @@ public:
   FastVerticalInterpHistPdfBase() ;
   FastVerticalInterpHistPdfBase(const char *name, const char *title, const RooArgSet &obs, const RooArgList& funcList, const RooArgList& coefList, Double_t smoothRegion=1., Int_t smoothAlgo=1) ;
   FastVerticalInterpHistPdfBase(const FastVerticalInterpHistPdfBase& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const = 0; 
-  virtual ~FastVerticalInterpHistPdfBase() ;
+  TObject* clone(const char* newname) const override = 0; 
+  ~FastVerticalInterpHistPdfBase() override ;
 
-  Bool_t selfNormalized() const { return kTRUE; }
+  Bool_t selfNormalized() const override { return kTRUE; }
 
-  Double_t evaluate() const = 0;
+  Double_t evaluate() const override = 0;
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
@@ -116,7 +116,7 @@ protected:
   }
 
 private:
-  ClassDef(FastVerticalInterpHistPdfBase,2) // 
+  ClassDefOverride(FastVerticalInterpHistPdfBase,2) // 
 };
 
 
@@ -133,10 +133,10 @@ public:
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
-  virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf(*this,newname) ; }
-  virtual ~FastVerticalInterpHistPdf() {}
+  TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf(*this,newname) ; }
+  ~FastVerticalInterpHistPdf() override {}
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   Bool_t hasCache()     const { return _cache.size() > 0; }
   Bool_t isCacheReady() const { return _cache.size() > 0 && _init; }
@@ -158,7 +158,7 @@ protected:
   void syncComponents(int dimension) const ;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf,1) // 
 };
 
 class FastVerticalInterpHistPdfV {
@@ -192,14 +192,14 @@ public:
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x), _y("y",this,other._y), _conditional(other._conditional),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
-  virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf2D(*this,newname) ; }
-  virtual ~FastVerticalInterpHistPdf2D() {}
+  TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2D(*this,newname) ; }
+  ~FastVerticalInterpHistPdf2D() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }
   Bool_t conditional() const { return _conditional; }
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   Bool_t hasCache()     const { return _cache.size() > 0; }
   Bool_t isCacheReady() const { return _cache.size() > 0 && _init; }
@@ -222,7 +222,7 @@ protected:
   void syncComponents(int dimension) const ;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf2D,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf2D,1) // 
 };
 
 
@@ -233,12 +233,12 @@ public:
   FastVerticalInterpHistPdf2Base(const char *name, const char *title, const RooArgSet &obs, const TList & funcList, const RooArgList& coefList, Double_t smoothRegion=1., Int_t smoothAlgo=1) ;
   FastVerticalInterpHistPdf2Base(const FastVerticalInterpHistPdf2Base& other, const char* name=0) ;
   explicit FastVerticalInterpHistPdf2Base(const FastVerticalInterpHistPdfBase& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const = 0; 
-  virtual ~FastVerticalInterpHistPdf2Base() ;
+  TObject* clone(const char* newname) const override = 0; 
+  ~FastVerticalInterpHistPdf2Base() override ;
 
-  Bool_t selfNormalized() const { return kTRUE; }
+  Bool_t selfNormalized() const override { return kTRUE; }
 
-  Double_t evaluate() const = 0;
+  Double_t evaluate() const override = 0;
 
   const RooArgList& coefList() const { return _coefList ; }
 
@@ -282,10 +282,10 @@ protected:
 
   // initialize the morphParams and the sentry. to be called by the daughter class, sets also _initBase to true
   void initBase() const ; 
-  virtual Bool_t  importWorkspaceHook(RooWorkspace& ws);
+  Bool_t  importWorkspaceHook(RooWorkspace& ws) override;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf2Base,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf2Base,1) // 
 };
 
 
@@ -301,11 +301,11 @@ public:
     _x("x",this,other._x),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   explicit FastVerticalInterpHistPdf2(const FastVerticalInterpHistPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf2(*this,newname) ; }
-  virtual ~FastVerticalInterpHistPdf2() {}
+  TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2(*this,newname) ; }
+  ~FastVerticalInterpHistPdf2() override {}
 
-  virtual void setActiveBins(unsigned int bins) ;
-  Double_t evaluate() const ;
+  void setActiveBins(unsigned int bins) override ;
+  Double_t evaluate() const override ;
 
   FastHisto const& cache() const { return _cache; }
 
@@ -325,7 +325,7 @@ protected:
   void initComponent(int which, TObject *hi, TObject *lo) ;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf2,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf2,1) // 
 };
 class FastVerticalInterpHistPdf2V {
     public: 
@@ -355,17 +355,17 @@ public:
     _x("x",this,other._x), _y("y",this,other._y), _conditional(other._conditional),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   explicit FastVerticalInterpHistPdf2D2(const FastVerticalInterpHistPdf2D& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf2D2(*this,newname) ; }
-  virtual ~FastVerticalInterpHistPdf2D2() {}
+  TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2D2(*this,newname) ; }
+  ~FastVerticalInterpHistPdf2D2() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }
   Bool_t conditional() const { return _conditional; }
 
-  Int_t getMaxVal(const RooArgSet& vars) const ;
-  Double_t maxVal(Int_t code) const ;
+  Int_t getMaxVal(const RooArgSet& vars) const override ;
+  Double_t maxVal(Int_t code) const override ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 protected:
   RooRealProxy _x, _y;
   bool _conditional;
@@ -382,7 +382,7 @@ protected:
   void initComponent(int which, TObject *hi, TObject *lo) ;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf2D2,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf2D2,1) // 
 };
 
 
@@ -403,15 +403,15 @@ public:
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x), _y("y",this,other._y), _z("z",this,other._z), _conditional(other._conditional),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
-  virtual TObject* clone(const char* newname) const { return new FastVerticalInterpHistPdf3D(*this,newname) ; }
-  virtual ~FastVerticalInterpHistPdf3D() {}
+  TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf3D(*this,newname) ; }
+  ~FastVerticalInterpHistPdf3D() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }
   const RooRealVar & z() const { return dynamic_cast<const RooRealVar &>(_z.arg()); }
   Bool_t conditional() const { return _conditional; }
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   Bool_t hasCache()     const { return _cache.size() > 0; }
   Bool_t isCacheReady() const { return _cache.size() > 0 && _init; }
@@ -434,7 +434,7 @@ protected:
   void syncComponents(int dimension) const ;
 
 private:
-  ClassDef(FastVerticalInterpHistPdf3D,1) // 
+  ClassDefOverride(FastVerticalInterpHistPdf3D,1) // 
 };
 
 

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -15,15 +15,15 @@ public:
   VerticalInterpPdf() ;
   VerticalInterpPdf(const char *name, const char *title, const RooArgList& funcList, const RooArgList& coefList, Double_t quadraticRegion=0., Int_t quadraticAlgo=0) ;
   VerticalInterpPdf(const VerticalInterpPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new VerticalInterpPdf(*this,newname) ; }
-  virtual ~VerticalInterpPdf() ;
+  TObject* clone(const char* newname) const override { return new VerticalInterpPdf(*this,newname) ; }
+  ~VerticalInterpPdf() override ;
 
-  Double_t evaluate() const ;
-  virtual Bool_t checkObservables(const RooArgSet* nset) const ;	
+  Double_t evaluate() const override ;
+  Bool_t checkObservables(const RooArgSet* nset) const override ;	
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
@@ -35,8 +35,8 @@ protected:
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem()  {} ;
-    virtual ~CacheElem() {} ; 
-    virtual RooArgList containedArgs(Action) { RooArgList ret(_funcIntList) ; ret.add(_funcNormList) ; return ret ; }
+    ~CacheElem() override {} ; 
+    RooArgList containedArgs(Action) override { RooArgList ret(_funcIntList) ; ret.add(_funcNormList) ; return ret ; }
     RooArgList _funcIntList ;
     RooArgList _funcNormList ;
   } ;
@@ -55,7 +55,7 @@ protected:
   bool isConditionalProdPdf(RooAbsReal *pdf) const;
   RooAbsReal* makeConditionalProdPdfIntegral(RooAbsPdf* pdf, RooArgSet const& analVars) const;
 
-  ClassDef(VerticalInterpPdf,3) // PDF constructed from a sum of (non-pdf) functions
+  ClassDefOverride(VerticalInterpPdf,3) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -842,6 +842,10 @@ cacheutils::CachingAddNLL::getObservables(const RooArgSet* depList, Bool_t value
     return new RooArgSet();
 }
 
+// ROOT 6.26 changed the signature of getParameters to avoid heap allocation,
+// and especially returning an owning pointer that people tend to forget to
+// delete.
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
 RooArgSet* 
 cacheutils::CachingAddNLL::getParameters(const RooArgSet* depList, Bool_t stripDisconnected) const 
 {
@@ -849,6 +853,16 @@ cacheutils::CachingAddNLL::getParameters(const RooArgSet* depList, Bool_t stripD
     ret->add(catParams_);
     return ret;
 }
+#else
+bool cacheutils::CachingAddNLL::getParameters(const RooArgSet* depList,
+                                              RooArgSet& outputSet,
+                                              bool stripDisconnected) const
+{
+    outputSet.add(params_);
+    outputSet.add(catParams_);
+    return true;
+}
+#endif
 
 
 cacheutils::CachingSimNLL::CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data, const RooArgSet *nuis) :
@@ -1270,6 +1284,10 @@ cacheutils::CachingSimNLL::getObservables(const RooArgSet* depList, Bool_t value
     return new RooArgSet();
 }
 
+// ROOT 6.26 changed the signature of getParameters to avoid heap allocation,
+// and especially returning an owning pointer that people tend to forget to
+// delete.
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
 RooArgSet* 
 cacheutils::CachingSimNLL::getParameters(const RooArgSet* depList, Bool_t stripDisconnected) const 
 {
@@ -1284,14 +1302,22 @@ cacheutils::CachingSimNLL::getParameters(const RooArgSet* depList, Bool_t stripD
     if (hideConstants_) RooStats::RemoveConstantParameters(ret);
     return ret;
 }
-
+#else
 bool cacheutils::CachingSimNLL::getParameters(const RooArgSet* depList,
-                                                              RooArgSet& outputSet,
-                                                              bool stripDisconnected) const {
-  RooArgSet tempList = *getParameters(depList);
-  outputSet.add(tempList);
-  return true;
+                                              RooArgSet& outputSet,
+                                              bool stripDisconnected) const
+{
+    if (internalMasks_.empty()) {
+        outputSet.add(params_);
+        if (!hideRooCategories_) outputSet.add(catParams_);
+    } else {
+        outputSet.add(activeParameters_);
+        if (!hideRooCategories_) outputSet.add(activeCatParameters_);
+    }
+    if (hideConstants_) RooStats::RemoveConstantParameters(&outputSet);
+    return true;
 }
+#endif
 
 void cacheutils::CachingSimNLL::setMaskConstraints(bool flag) {
     double nllBefore = evaluate();

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -45,12 +45,12 @@ namespace cacheutils {
                 RooAbsReal(other, name),
                 list_("deps",this,other.list_),
                 terms_(other.terms_) {} 
-            ~ReminderSum() {}
-            virtual TObject* clone(const char* newname) const { return new ReminderSum(*this,newname); }
+            ~ReminderSum() override {}
+            TObject* clone(const char* newname) const override { return new ReminderSum(*this,newname); }
         private:
             RooListProxy list_;
             std::vector<const RooAbsReal *> terms_;
-            Double_t evaluate() const;
+            Double_t evaluate() const override;
     };
 }
 

--- a/src/RooSimultaneousOpt.cc
+++ b/src/RooSimultaneousOpt.cc
@@ -2,15 +2,24 @@
 #include "../interface/CachingNLL.h"
 #include <RooCmdConfig.h>
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,30,0)
 RooAbsReal* 
 RooSimultaneousOpt::createNLL(RooAbsData& data, const RooLinkedList& cmdList) 
+#else
+std::unique_ptr<RooAbsReal>
+RooSimultaneousOpt::createNLLImpl(RooAbsData& data, const RooLinkedList& cmdList) 
+#endif
 {
     RooCmdConfig pc(Form("RooSimultaneousOpt::createNLL(%s)",GetName())) ;
     pc.defineSet("cPars","Constrain",0,0);
     RooArgSet *cPars = pc.getSet("cPars");
-    cacheutils::CachingSimNLL *nll =  new cacheutils::CachingSimNLL(this, &data, cPars);
+    auto nll =  std::make_unique<cacheutils::CachingSimNLL>(this, &data, cPars);
     nll->setChannelMasks(this->channelMasks());
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,30,0)
+    return nll.release();
+#else
     return nll;
+#endif
 }
 
 RooSimultaneousOpt::~RooSimultaneousOpt()

--- a/src/SequentialMinimizer.cc
+++ b/src/SequentialMinimizer.cc
@@ -465,10 +465,10 @@ namespace cmsmath {
         public:
            SubspaceMultiGenFunction(const ROOT::Math::IMultiGenFunction *f, int nDim, const int *idx, double *xi) :
                 f_(f), nDim_(nDim), idx_(idx), x_(xi) {}
-           virtual SubspaceMultiGenFunction * Clone() const { return new SubspaceMultiGenFunction(*this); }
-           virtual unsigned int NDim() const { return nDim_; }
+           SubspaceMultiGenFunction * Clone() const override { return new SubspaceMultiGenFunction(*this); }
+           unsigned int NDim() const override { return nDim_; }
         private:
-           virtual double DoEval(const double * x) const {
+           double DoEval(const double * x) const override {
                 for (int i = 0; i < nDim_; ++i) x_[idx_[i]] = x[i];
                 return (*f_)(x_);
            }


### PR DESCRIPTION
To avoid future mistakes when overriding functions, this commit suggests to use the `override` keyword as suggested by clang-tidy.

How this commit was produced:

1. Compile with CMake, exporting the compile commands as described here: https://stackoverflow.com/questions/20059670/how-to-use-cmake-export-compile-commands

2. Build

3. Run this in the build directory: ``` run-clang-tidy -header-filter="interface/.*" -config-file=../.clang-tidy -export-fixes fixes.yaml . -j20 ```

4. Copy the `fixes.yaml` back to the main repo and apply fixes with: ``` clang-apply-replacements . ```