### PR TITLE
Avoid problems with `FastVerticalInterpHistPdf2Base` initialization

### DIFF
--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -772,14 +772,9 @@ FastVerticalInterpHistPdf2Base::FastVerticalInterpHistPdf2Base(const FastVertica
   _coefList("coefList", this, other._coefList),
   _smoothRegion(other._smoothRegion),
   _smoothAlgo(other._smoothAlgo),
-  _initBase(other._initBase),
+  _initBase(false),
   _morphs(other._morphs), _morphParams(other._morphParams)
 {
-    if (_initBase) {
-        // Morph params are already set, but we must set the sentry
-        _sentry.addVars(_coefList);
-        _sentry.setValueDirty(); 
-    }
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
The `_sentry` is already filled when calling `evaluate()`, so no need to do that in the copy constructor:
https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/main/src/VerticalInterpHistPdf.cc#L895

Doing so can actually leading to redundant calls to `_sentry.addVars(_coefList)`, resulting in the problem reported here:
https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/940#issuecomment-2064076625
```
[#0] ERROR:InputArguments -- RooArgSet::checkForDup: ERROR argument with name CMS_vhbb_stats_TT_ZmmLoose7TeV is already in this set
```

FYI @kcormi 