### PR TITLE
Fix for CMSSW 14_0_0 / ROOT 6.30 compilation

### DIFF
--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -15,6 +15,7 @@
 #include <TGraphErrors.h>
 #include <TStopwatch.h>
 #include <TRandom3.h>
+#include <TTree.h>
 #include "RooRealVar.h"
 #include "RooArgSet.h"
 #include "RooAbsPdf.h"


### PR DESCRIPTION
What I needed to do to compile in 14x