### PR TITLE
Remove default requirements from DataFrameWrapper

### DIFF
--- a/python/DataFrameWrapper.py
+++ b/python/DataFrameWrapper.py
@@ -70,16 +70,18 @@ class DataFrameWrapper(object):
         if not hasattr(self, "df"):
             raise AttributeError("Dataframe has not been loaded")
 
-        #index_labels, column_labels = object_name.split(",")
-        # Not necessary to include ":nominal,sum_w:sum_ww in every line 
+        # index_labels, column_labels = object_name.split(",")
+        # Not necessary to include ":nominal,sum_w:sum_ww in every line
         # check if its not there and if so, add these default names of columns
         try:
             index_labels, column_labels = object_name.split(",")
-        except:
-            index_labels  = object_name
+        except ValueError:
+            index_labels = object_name
             column_labels = ""
-        if len(column_labels)==0: column_labels="sum_w:sum_ww"
-        if len(index_labels.split(":")) < 3 : index_labels+=":nominal"
+        if len(column_labels) == 0:
+            column_labels = "sum_w:sum_ww"
+        if len(index_labels.split(":")) < 3:
+            index_labels += ":nominal"
 
         # Try to cast index_labels into self.df.index dtypes. Users can only
         # input index_labels as a string, but the dataframe might have other

--- a/test/printWorkspaceNormalisations.py
+++ b/test/printWorkspaceNormalisations.py
@@ -269,7 +269,7 @@ if options.format == "html":
                         print("... is a product, which contains {proc_norm_var_name}<br>".format(proc_norm_var_name=proc_norm_var.GetName()))
                         printExpand(proc_norm_var.GetName())
                         proc_norm_var.Print()
-                        printExpand()
+                        printEndExpand()
                 else:
                     if proc[3]:
                         if proc[1].Class().GetName() == ROOT.ProcessNormalization().Class().GetName():


### PR DESCRIPTION
In DataFrameWrapper, can assume that if shape lines don't include `:nominal,sum_w:sum_ww` extension, then we can just add them internally. 

This avoids users having to write boilerplate in datacards making these more similar to TH1 type.

Not changes to tutorial datacard.