### PR TITLE
Update CI workflows 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
           # python 3.10 root 6.26
           - python: "3.10"
             root: "6.26.4"
-          # python 3.10 root 6.32
-          - python: "3.10"
-            root: "6.32" # version 6.30.07 where the conflicting classes were removed from root is not available, so compiling with 6.32.00 where this issue is resolved
+          # python 3.10 root 6.32 (not available yet)
+          #- python: "3.10"
+          #  root: "6.32" # version 6.30.07 where the conflicting classes were removed from root is not available, so compiling with 6.32.00 where this issue is resolved
 
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.8"]
+        python: ["3.9"]
         root: ["6.22.08"]  #closest to CMSSW_11_3_4 where we have 6.22.09
         include:
           # to deprecate (11_2_X py2)
@@ -38,7 +38,7 @@ jobs:
             root: "6.26.4"
           # python 3.10 root 6.32
           - python: "3.10"
-            root: "6.32.00" # version 6.30.07 where the conflicting classes were removed from root is not available, so compiling with 6.32.00 where this issue is resolved
+            root: "6.32" # version 6.30.07 where the conflicting classes were removed from root is not available, so compiling with 6.32.00 where this issue is resolved
 
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         python: ["3.8"]
-        root: ["6.22"]
+        root: ["6.22.08"]  #closest to CMSSW_11_3_4 where we have 6.22.09
         include:
           # to deprecate (11_2_X py2)
           - python: "2.7.18"
-            root: "6.22.08" #closest to CMSSW_11_3_4 where we have 6.22.09
+            root: "6.22.0" 
           # python 3.10 root 6.26
           - python: "3.10"
             root: "6.26.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.9"]
-        root: ["6.22.08"]  #closest to CMSSW_11_3_4 where we have 6.22.09
+        python: ["3.8"]
+        root: ["6.22"]  
         include:
           # to deprecate (11_2_X py2)
           - python: "2.7.18"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
           # to deprecate (11_2_X py2)
           - python: "2.7.18"
             root: "6.22.0"
-          # python 3.9 root 6.24 (12_3_X)
-          - python: "3.9"
-            root: "6.24"
           # python 3.10 root 6.26
           - python: "3.10"
             root: "6.26.4"
+          - python: "3.10"
+            root: "6.30.07"
+
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,13 @@ jobs:
         include:
           # to deprecate (11_2_X py2)
           - python: "2.7.18"
-            root: "6.22.0"
+            root: "6.22.08" #closest to CMSSW_11_3_4 where we have 6.22.09
           # python 3.10 root 6.26
           - python: "3.10"
             root: "6.26.4"
+          # python 3.10 root 6.32
           - python: "3.10"
-            root: "6.30.07"
+            root: "6.32.00" # version 6.30.07 where the conflicting classes were removed from root is not available, so compiling with 6.32.00 where this issue is resolved
 
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -15,13 +15,13 @@ jobs:
         IMAGE: ["cmscloud/al9-cms"]
         CMSSW_VERSION: ["CMSSW_14_1_0_pre4"] # ROOT v6.30/07
         SCRAM_ARCH: ["el9_amd64_gcc12"]
-      include:
-        - IMAGE: "cmscloud/cc7-cms"
-          CMSSW_VERSION: "CMSSW_11_3_4" # ROOT v6.22
-          SCRAM_ARCH: "slc7_amd64_gcc900"
-        - IMAGE: "cmscloud/al9-cms"
-          CMSSW_VERSION: "CMSSW_14_0_0_pre1" # ROOT v6.26/11
-          SCRAM_ARCH: "el9_amd64_gcc12"
+        include:
+          - IMAGE: "cmscloud/cc7-cms"
+            CMSSW_VERSION: "CMSSW_11_3_4" # ROOT v6.22
+            SCRAM_ARCH: "slc7_amd64_gcc900"
+          - IMAGE: "cmscloud/al9-cms"
+            CMSSW_VERSION: "CMSSW_14_0_0_pre1" # ROOT v6.26/11
+            SCRAM_ARCH: "el9_amd64_gcc12"
 
     name: Test with ${{ matrix.CMSSW_VERSION }}
     steps:

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IMAGE: cmscloud/al9-cms
-        CMSSW_VERSION: CMSSW_14_1_0_pre4 # ROOT v6.30/07
-        SCRAM_ARCH: el9_amd64_gcc12
+        IMAGE: ["cmscloud/al9-cms"]
+        CMSSW_VERSION: ["CMSSW_14_1_0_pre4"] # ROOT v6.30/07
+        SCRAM_ARCH: ["el9_amd64_gcc12"]
       include:
-        - IMAGE: cmscloud/cc7-cms
-          CMSSW_VERSION: CMSSW_11_3_4 # ROOT v6.22
-          SCRAM_ARCH: slc7_amd64_gcc900
-        - IMAGE: cmscloud/al9-cms
-          CMSSW_VERSION: CMSSW_14_0_0_pre1 # ROOT v6.26/11
-          SCRAM_ARCH: el9_amd64_gcc12
+        - IMAGE: "cmscloud/cc7-cms"
+          CMSSW_VERSION: "CMSSW_11_3_4" # ROOT v6.22
+          SCRAM_ARCH: "slc7_amd64_gcc900"
+        - IMAGE: "cmscloud/al9-cms"
+          CMSSW_VERSION: "CMSSW_14_0_0_pre1" # ROOT v6.26/11
+          SCRAM_ARCH: "el9_amd64_gcc12"
 
     name: Test with ${{ matrix.CMSSW_VERSION }}
     steps:

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -1,10 +1,5 @@
 name: CI with CVMFS
 
-env:
-  IMAGE: cmscloud/cc7-cms
-  CMSSW_VERSION: CMSSW_11_3_4
-  SCRAM_ARCH: slc7_amd64_gcc900
-
 on:
   workflow_dispatch:
   pull_request:
@@ -15,7 +10,20 @@ on:
 jobs:
   test_workflow:
     runs-on: ubuntu-latest
-    name: Test with CMSSW
+    strategy:
+      matrix:
+        IMAGE: cmscloud/al9-cms
+        CMSSW_VERSION: CMSSW_14_1_0_pre4 # ROOT v6.30/07
+        SCRAM_ARCH: el9_amd64_gcc12
+      include:
+        - IMAGE: cmscloud/cc7-cms
+          CMSSW_VERSION: CMSSW_11_3_4 # ROOT v6.22
+          SCRAM_ARCH: slc7_amd64_gcc900
+        - IMAGE: cmscloud/al9-cms
+          CMSSW_VERSION: CMSSW_14_0_0_pre1 # ROOT v6.26/11
+          SCRAM_ARCH: el9_amd64_gcc12
+
+    name: Test with ${{ matrix.CMSSW_VERSION }}
     steps:
       # checkout the files of this repository
       - uses: actions/checkout@v4
@@ -24,9 +32,9 @@ jobs:
           cvmfs_repositories: 'cms.cern.ch'
       - uses: rhaschke/docker-run-action@v5
         with:
-          image: ${{ env.IMAGE }}
+          image: ${{ matrix.IMAGE }}
           shell: bash
-          options: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit -w /home/cmsusr -e CMSSW_VERSION=${{ env.CMSSW_VERSION }} -e SCRAM_ARCH=${{ env.SCRAM_ARCH }}
+          options: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
           run: | 
             ls /work/CombinedLimit
             ls /cvmfs/cms.cern.ch | grep common
@@ -39,6 +47,7 @@ jobs:
             cp -r /work/CombinedLimit HiggsAnalysis/
             scramv1 b -j$(nproc)
             echo ${PATH}
+            root --version
             combine --help
             combine HiggsAnalysis/CombinedLimit/data/tutorials/CAT23001/datacard-2-template-analysis.txt -M HybridNew --LHCmode LHC-limits --rMax 2.0 --clsAcc 0.01
             combine HiggsAnalysis/CombinedLimit/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt -M HybridNew --LHCmode LHC-significance -T 100 --mass 125


### PR DESCRIPTION
1. Add matrix strategy to cvmfs job including compilation with CMSSW_14_1_0_pre4 (ROOT v6.30/07), CMSSW_11_3_4 (ROOT v6.22) and CMSSW_14_0_0_pre1 (ROOT v6.26/11)
2. Update the main ci workflow, remove the 6.24 build (there is no corresponding combine release), build with root v6.32 will be added once the release is available for installation 