### PR TITLE
ROOT v6.30 support: add a fix for unlimited parameters 

### DIFF
--- a/interface/utils.h
+++ b/interface/utils.h
@@ -112,7 +112,7 @@ namespace utils {
     void setModelParameters( const std::string & setPhysicsModelParameterExpression, const RooArgSet & params);
     // Set range of physics model parameters
     void setModelParameterRanges( const std::string & setPhysicsModelParameterRangeExpression, const RooArgSet & params);
-
+    void check_inf_parameters(const RooArgSet & params);
     bool isParameterAtBoundary( const RooRealVar &);
     bool anyParameterAtBoundaries( const RooArgSet &, int verbosity);
 

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -481,6 +481,9 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       // Possible that MH value was re-set above, so make sure mass is set to the correct value and not over-ridden later.
       if (w->var("MH")) mass_ = w->var("MH")->getVal();
     }
+    // look for parameters ranged [-1e+30, 1e+30], corresponding to the old definition of unlimited parameters, 
+    // since ROOT v6.30 have to removeRange() to keep them unlimited
+    utils::check_inf_parameters(w->allVars());
 
   } else {
     std::cerr << "HLF not validated" << std::endl;
@@ -524,6 +527,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     if (setPhysicsModelParameterExpression_ != "") {
 	    utils::setModelParameters( setPhysicsModelParameterExpression_, w->allVars());
     }
+    utils::check_inf_parameters(w->allVars());
   }
   gSystem->cd(pwd);
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -885,6 +885,20 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
   }
 }
 
+
+void utils::check_inf_parameters(const RooArgSet & params) {
+
+    double infinity_root626 = 1.0e30; 
+    for (RooAbsArg *arg : params) {    
+        RooRealVar *p = dynamic_cast<RooRealVar *>(arg);
+        if (p->getRange().first <= -infinity_root626 || p->getRange().second >= +infinity_root626){
+            std::cout << "Found a parameter named "<< p->GetName() 
+                      << " infinite in ROOT versions < 6.30, going to removeRange()" << endl;
+            p->removeRange();
+        }
+    }
+}
+
 void utils::createSnapshotFromString( const std::string expression, const RooArgSet &allvars, RooArgSet &output, const char *context) {
     if (expression.find("=") == std::string::npos) {
         if (allvars.getSize() != 1) throw std::invalid_argument(std::string("Error: the argument to ")+context+" is a single value, but there are multiple variables to choose from");


### PR DESCRIPTION
To account for the new definition [std::numeric_limits<double>::infinity()](https://github.com/root-project/root/blob/v6-30-00-patches/roofit/roofitcore/inc/RooNumber.h#L25) of RooNumber::infinity() since ROOT version v6.30  incompatible with the old definition [Double_t RooNumber::_Infinity= 1.0e30](https://github.com/root-project/root/blob/v6-26-00-patches/roofit/roofitcore/src/RooNumber.cxx#L41) 