### PR TITLE
Avoid using interfaces that are deprecated in ROOT 6.32

### DIFF
--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -663,7 +663,7 @@ cacheutils::CachingAddNLL::evaluate() const
         //         *its += coeff * (*itv); // sum (n_i * pdf_i)
         //    }
         // vectorize to make it faster
-        vectorized::mul_add(pdfvals.size(), coeff, &pdfvals[0], &partialSum_[0]);
+        vectorized::mul_add(pdfvals.size(), coeff, pdfvals.data(), partialSum_.data());
     }
     // if all basic integrals evaluated ok, use them
     if (allBasicIntegralsOk) basicIntegrals_ = 2;
@@ -705,7 +705,7 @@ cacheutils::CachingAddNLL::evaluate() const
     //      for ( its = bgs, itw = bgw ; its != eds ; ++its, ++itw ) {
     //         ret -= (*itw) * log( ((*its) / sumCoeff) );
     //      }
-    ret -= vectorized::nll_reduce(partialSum_.size(), &partialSum_[0], &weights_[0], sumCoeff, &workingArea_[0]);
+    ret -= vectorized::nll_reduce(partialSum_.size(), partialSum_.data(), weights_.data(), sumCoeff, workingArea_.data());
     // std::cout << "AddNLL for " << pdf_->GetName() << ": " << ret << std::endl;
     // and add extended term: expected - observed*log(expected);
     static bool expEventsNoNorm = runtimedef::get("ADDNLL_ROOREALSUM_NONORM");

--- a/src/HMuMuRooPdfs.cc
+++ b/src/HMuMuRooPdfs.cc
@@ -58,16 +58,13 @@ RooModZPdf::RooModZPdf(const char *name, const char *title, RooAbsReal& _x, RooA
   w{"w", "w", this},
   bernCoef("coefficients", "List of Bernstein coefficients", this)
 {
-  TIterator* coefIter = _coef.createIterator() ;
-  RooAbsArg* coef ;
-  while((coef = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg* coef : _coef) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       std::cout << "RooBernstein::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName() << " is not of type RooAbsReal" << std::endl ;
       R__ASSERT(0) ;
     }
     bernCoef.add(*coef);
   }
-  delete coefIter ;
 }
 
 RooModZPdf::RooModZPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a, RooAbsReal& _b, RooAbsReal& _c, const RooArgList& _coef):
@@ -80,16 +77,13 @@ RooModZPdf::RooModZPdf(const char *name, const char *title, RooAbsReal& _x, RooA
   w{"w", "w", this},
   bernCoef("coefficients", "List of Bernstein coefficients", this)
 {
-  TIterator* coefIter = _coef.createIterator() ;
-  RooAbsArg* coef ;
-  while((coef = (RooAbsArg*)coefIter->Next())) {
+  for (RooAbsArg* coef : _coef) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
       std::cout << "RooBernstein::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName() << " is not of type RooAbsReal" << std::endl ;
       R__ASSERT(0) ;
     }
     bernCoef.add(*coef);
   }
-  delete coefIter ;
 }
 
 RooModZPdf::RooModZPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a, RooAbsReal& _b, RooAbsReal& _c, RooAbsReal& _m):
@@ -152,13 +146,12 @@ double RooModZPdf::evaluate() const {
   if (degree <= 0) return val;
   
   double xv = (x - xmin) / (xmax - xmin);
-  RooFIter iter = bernCoef.fwdIterator();
   double bernval = 1.;
   double coefsum = 0.;
   double coef    = 0.;
 
   for (Int_t i = 0; i < degree; i++) {
-    coef = ((RooAbsReal *)iter.next())->getVal();
+    coef = static_cast<RooAbsReal &>(bernCoef[i]).getVal();
     coefsum -= coef;
     bernval += (degree+1.) * TMath::Binomial(degree, i) * pow(xv, degree-i) * pow(1.-xv, i) * coef;
   }

--- a/src/TH1Keys.cc
+++ b/src/TH1Keys.cc
@@ -31,7 +31,7 @@ TH1Keys::TH1Keys(const char *name,const char *title,Int_t nbinsx,Double_t xlow,D
     RooArgSet vars;
     vars.add(*x_);
     vars.add(*w_);
-    dataset_ = new RooDataSet(name, title, vars, "w");
+    dataset_ = new RooDataSet(name, title, vars, RooFit::WeightVar("w"));
 
     cache_->SetDirectory(0);
     fDimension = 1;
@@ -54,7 +54,7 @@ TH1Keys::TH1Keys(const char *name,const char *title,Int_t nbinsx,const Float_t  
     RooArgSet vars;
     vars.add(*x_);
     vars.add(*w_);
-    dataset_ = new RooDataSet(name, title, vars, "w");
+    dataset_ = new RooDataSet(name, title, vars, RooFit::WeightVar("w"));
 
     cache_->SetDirectory(0);
     fDimension = 1;
@@ -79,7 +79,7 @@ TH1Keys::TH1Keys(const char *name,const char *title,Int_t nbinsx,const Double_t 
     RooArgSet vars;
     vars.add(*x_);
     vars.add(*w_);
-    dataset_ = new RooDataSet(name, title, vars, "w");
+    dataset_ = new RooDataSet(name, title, vars, RooFit::WeightVar("w"));
 
     cache_->SetDirectory(0);
     fDimension = 1;
@@ -103,7 +103,7 @@ TH1Keys::TH1Keys(const TH1Keys &other)  :
     RooArgSet vars;
     vars.add(*x_);
     vars.add(*w_);
-    dataset_ = new RooDataSet(other.GetName(), other.GetTitle(), vars, "w");
+    dataset_ = new RooDataSet(other.GetName(), other.GetTitle(), vars, RooFit::WeightVar("w"));
 
     other.Copy(*this);
     fDimension = 1;


### PR DESCRIPTION
More details in the commit descriptions. Follows up on previous commits.