### PR TITLE
Fix #987, incorrect dependency in conda_env.yml

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -9,6 +9,6 @@ dependencies:
   - gsl
   - tbb
   - vdt
-  - boost
+  - boost-cpp
   - pcre
   - eigen


### PR DESCRIPTION
Dear All. This PR fixes #987. There should be boost-cpp in cond_env.yml, not boost. After changing boost to boost-cpp, the compilation with conda was successful.