### PR TITLE
fix seg fault with FitDiagnostics plots

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -610,7 +610,6 @@ utils::makePlots(const RooAbsPdf &pdf, const RooAbsData &data, const char *signa
 	      if (rebinFactor>1) ds->plotOn(ret.back(), RooFit::DataError(RooAbsData::Poisson));
 	      else ds->plotOn(ret.back(), RooFit::DataError(RooAbsData::Poisson),RooFit::Binning(""));
 	    }
-            delete ds;
         }
         delete datasets;
     } else if (pdf.canBeExtended()) {


### PR DESCRIPTION
The most recent version seems to segfault when running the `--plots` option of FitDiagnostics. This appears to be due to explicitly deleting the nodes of this `TList` while iterating over them, and then the TList trying to delete them later when it is deleted. Though I'm not sure what change is making this only cause a problem now.

Sometimes rather than a segmentation fault, this just produced error printouts of the type:

```
Error in <TList::Clear>: A list is accessing an object (0x82808d0) already deleted (list name = TList)
```