### PR TITLE
 Adding getProcessNorms() to CMSHistErrorPropagator

### DIFF
--- a/interface/CMSHistErrorPropagator.h
+++ b/interface/CMSHistErrorPropagator.h
@@ -72,6 +72,8 @@ public:
   RooArgList wrapperList() const;
   RooArgList const& coefList() const { return coeffs_; }
   RooArgList const& funcList() const { return funcs_; }
+  
+  std::map<std::string, Double_t> getProcessNorms() const;
 
   friend class CMSHistV<CMSHistErrorPropagator>;
 

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -576,9 +576,11 @@ std::map<std::string, Double_t> CMSHistErrorPropagator::getProcessNorms() const 
         }
         if (!normProd) {
           RooAbsReal* integral = shape->createIntegral(*myobs);
-          normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
-          normProd->addOwnedComponents(*integral);
-          coeff->addOwnedComponents(*normProd);
+      	  RooArgList normProdInputs;
+      	  normProdInputs.add(*integral);
+      	  normProdInputs.add(*coeff);
+          normProd = new RooProduct(normProdName, "", normProdInputs);
+          normProd->addOwnedComponents(normProdInputs);
         }
         vals_[normProdName.Data()] = normProd->getVal();
       }

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -549,5 +549,40 @@ RooArgList CMSHistErrorPropagator::wrapperList() const {
   return result;
 }
 
+std::map<std::string, Double_t> CMSHistErrorPropagator::getProcessNorms() const {
+
+      std::map<std::string, Double_t> vals_;
+      RooArgList clist(coefList());
+      RooArgList plist(funcList());
+      /*if (plist.getSize() == 1) {
+         CMSHistErrorPropagator *err = dynamic_cast<CMSHistErrorPropagator*>(plist.at(0));
+         if (err) {
+           clist.removeAll();
+           plist.removeAll();
+           clist.add(err->coefList());
+           plist.add(err->wrapperList());
+         }
+      }
+      */
+      for (int i = 0, n = clist.getSize(); i < n; ++i) {
+        RooAbsReal *coeff = (RooAbsReal *) clist.at(i);
+        std::string coeffName = coeff->GetName();
+        RooAbsReal* shape = (RooAbsReal*)plist.at(i);
+        std::unique_ptr<RooArgSet> myobs(shape->getObservables(*x_));
+        TString normProdName = TString::Format("%s", coeff->GetName());
+        RooAbsReal * normProd = nullptr;
+        if (coeff->ownedComponents()) {
+          normProd = dynamic_cast<RooAbsReal*>(coeff->ownedComponents()->find(normProdName));
+        }
+        if (!normProd) {
+          RooAbsReal* integral = shape->createIntegral(*myobs);
+          normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
+          normProd->addOwnedComponents(*integral);
+          coeff->addOwnedComponents(*normProd);
+        }
+        vals_[normProdName.Data()] = normProd->getVal();
+      }
+      return vals_;
+}
 #undef HFVERBOSE
 

--- a/test/printWorkspaceNormalisations.py
+++ b/test/printWorkspaceNormalisations.py
@@ -49,14 +49,14 @@ parser.add_option(
     type="float",
     help="Only print values if yield is less than this threshold.",
 )
-parser.add_option(
-    "",
-    "--use-cms-histsum",
-    dest="use_cms_histsum",
-    default=False,
-    action="store_true",
-    help="Set to true if workspace built with --use-cms-histsum option.",
-)
+#parser.add_option(
+#    "",
+#    "--use-cms-histsum",
+#    dest="use_cms_histsum",
+#    default=False,
+#    action="store_true",
+#    help="Set to true if workspace built with --use-cms-histsum option.",
+#)
 parser.add_option(
     "",
     "--procFilter",
@@ -169,17 +169,23 @@ for i in range(all_norms.getSize()):
     else:
         chan_procs[chan] = [[proc, norm, 0, 0]]
 
+use_cms_histsum = False 
+
+all_props = ws.allFunctions().selectByName("prop_bin*")
+if all_props.getSize()>0: use_cms_histsum=True
+
 # Look for cases where chan stored as CMSHistSum, set flag
-if options.use_cms_histsum:
+if use_cms_histsum:
     chan_CMSHistSum_norms = {}
-    all_props = ws.allFunctions().selectByName("prop_bin*")
+    #all_props = ws.allFunctions().selectByName("prop_bin*")
     for chan in chan_procs.keys():
         prop_it = all_props.createIterator()
         for i in range(all_props.getSize()):
             prop = prop_it.Next()
             prop_name = prop.GetName()
             if chan == prop_name.split("_bin")[-1]:
-                if type(prop) == ROOT.CMSHistSum:
+                types = [ROOT.CMSHistSum, ROOT.CMSHistErrorPropagator]
+                if type(prop) in types :
                     chan_CMSHistSum_norms[chan] = dict(prop.getProcessNorms())
 
 
@@ -243,7 +249,7 @@ if options.format == "html":
                 continue
             print("<hr>")
             print("Top-level normalization for process {proc0} -> {proc1_name}<br>".format(proc0=proc[0], proc1_name=proc[1].GetName()))
-            if options.use_cms_histsum:
+            if use_cms_histsum:
                 if chan in chan_CMSHistSum_norms:
                     default_val = chan_CMSHistSum_norms[chan][proc[1].GetName()]
                 else:
@@ -253,7 +259,7 @@ if options.format == "html":
             default_norms[chan][proc[1].GetName()] = default_val
 
             if options.printValueOnly:
-                print("default value = {default_val}<br>".format(default_val=default_val))
+                print("default value = {default_val:.5f}<br>".format(default_val=default_val))
             else:
                 if proc[2]:
                     proc_norm_var = ws.function("n_exp_bin%s_proc_%s" % (chan, proc[0]))
@@ -289,7 +295,7 @@ if options.format == "html":
                         print(" ... is a constant (RooRealVar)")
                         printEndExpand()
 
-            print("  default value = ", default_val, "<br>")
+            print("  default value = %.5f "%default_val, "<br>")
             print("</tr>")
 
     print(
@@ -320,7 +326,7 @@ if options.format == "text":
             print("---------------------------------------------------------------------------")
             print("  Top-level normalization for process %s -> %s" % (proc[0], proc[1].GetName()))
             print("---------------------------------------------------------------------------")
-            if options.use_cms_histsum:
+            if use_cms_histsum:
                 if chan in chan_CMSHistSum_norms:
                     default_val = chan_CMSHistSum_norms[chan][proc[1].GetName()]
                 else:
@@ -330,7 +336,7 @@ if options.format == "text":
             default_norms[chan][proc[1].GetName()] = default_val
 
             if options.printValueOnly:
-                print("  default value = ", default_val)
+                print("  default value = %.5f "%default_val)
             # if options.printValueOnly: print " --xcp %s:%s "%(chan,proc[0]),
             else:
                 if proc[2]:
@@ -354,7 +360,7 @@ if options.format == "text":
                         proc[1].Print()
                         print(" ... is a constant (RooRealVar)")
                 print("  -------------------------------------------------------------------------")
-                print("  default value = ", default_val)
+                print("  default value = %.5f "%default_val)
 
 # Save norms to json file
 if options.output_json != "":

--- a/test/printWorkspaceNormalisations.py
+++ b/test/printWorkspaceNormalisations.py
@@ -49,14 +49,14 @@ parser.add_option(
     type="float",
     help="Only print values if yield is less than this threshold.",
 )
-#parser.add_option(
+# parser.add_option(
 #    "",
 #    "--use-cms-histsum",
 #    dest="use_cms_histsum",
 #    default=False,
 #    action="store_true",
 #    help="Set to true if workspace built with --use-cms-histsum option.",
-#)
+# )
 parser.add_option(
     "",
     "--procFilter",
@@ -169,15 +169,16 @@ for i in range(all_norms.getSize()):
     else:
         chan_procs[chan] = [[proc, norm, 0, 0]]
 
-use_cms_histsum = False 
+use_cms_histsum = False
 
 all_props = ws.allFunctions().selectByName("prop_bin*")
-if all_props.getSize()>0: use_cms_histsum=True
+if all_props.getSize() > 0:
+    use_cms_histsum = True
 
 # Look for cases where chan stored as CMSHistSum, set flag
 if use_cms_histsum:
     chan_CMSHistSum_norms = {}
-    #all_props = ws.allFunctions().selectByName("prop_bin*")
+    # all_props = ws.allFunctions().selectByName("prop_bin*")
     for chan in chan_procs.keys():
         prop_it = all_props.createIterator()
         for i in range(all_props.getSize()):
@@ -185,7 +186,7 @@ if use_cms_histsum:
             prop_name = prop.GetName()
             if chan == prop_name.split("_bin")[-1]:
                 types = [ROOT.CMSHistSum, ROOT.CMSHistErrorPropagator]
-                if type(prop) in types :
+                if type(prop) in types:
                     chan_CMSHistSum_norms[chan] = dict(prop.getProcessNorms())
 
 
@@ -295,7 +296,7 @@ if options.format == "html":
                         print(" ... is a constant (RooRealVar)")
                         printEndExpand()
 
-            print("  default value = %.5f "%default_val, "<br>")
+            print("  default value = %.5f " % default_val, "<br>")
             print("</tr>")
 
     print(
@@ -336,7 +337,7 @@ if options.format == "text":
             default_norms[chan][proc[1].GetName()] = default_val
 
             if options.printValueOnly:
-                print("  default value = %.5f "%default_val)
+                print("  default value = %.5f " % default_val)
             # if options.printValueOnly: print " --xcp %s:%s "%(chan,proc[0]),
             else:
                 if proc[2]:
@@ -360,7 +361,7 @@ if options.format == "text":
                         proc[1].Print()
                         print(" ... is a constant (RooRealVar)")
                 print("  -------------------------------------------------------------------------")
-                print("  default value = %.5f "%default_val)
+                print("  default value = %.5f " % default_val)
 
 # Save norms to json file
 if options.output_json != "":


### PR DESCRIPTION
Added function to CMSHistErrorPropagator to return process norm name and values. This is now used in the `test/printWorkspaceNormalisations.py` script so that it works when using autoMCStats (no longer just reports 1 for the normalisation value)

Currently there are not a lot of warnings when compiling. Attached warnings below 

```
In member function 'add',
    inlined from 'processArg' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:138:46,
    inlined from 'processArgs' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:135:35,
    inlined from '__ct ' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:55:16,
    inlined from 'getProcessNorms' at src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:55:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooCollectionProxy.h:114:40: warning: array subscript 'struct RooCollectionProxy[0]' is partly outside array bounds of 'struct RooArgList[1]' [-Warray-bounds]
  114 |       return add(var, _defValueServer, _defShapeServer, silent);
      |                                        ^
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc: In member function 'getProcessNorms':
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:83: note: object '<anonymous>' of size 128
  579 |           normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
      |                                                                                   ^
In member function 'add',
    inlined from 'processArg' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:138:46,
    inlined from 'processArgs' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:135:35,
    inlined from '__ct ' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:55:16,
    inlined from 'getProcessNorms' at src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:55:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooCollectionProxy.h:114:23: warning: array subscript 'struct RooCollectionProxy[0]' is partly outside array bounds of 'struct RooArgList[1]' [-Warray-bounds]
  114 |       return add(var, _defValueServer, _defShapeServer, silent);
      |                       ^
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc: In member function 'getProcessNorms':
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:83: note: object '<anonymous>' of size 128
  579 |           normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
      |                                                                                   ^
In member function 'add',
    inlined from 'processArg' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:144:8,
    inlined from 'processArgs' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:135:35,
    inlined from '__ct ' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:55:16,
    inlined from 'getProcessNorms' at src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:55:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooCollectionProxy.h:114:40: warning: array subscript 'struct RooCollectionProxy[0]' is partly outside array bounds of 'struct RooArgList[1]' [-Warray-bounds]
  114 |       return add(var, _defValueServer, _defShapeServer, silent);
      |                                        ^
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc: In member function 'getProcessNorms':
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:83: note: object '<anonymous>' of size 128
  579 |           normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
      |                                                                                   ^
In member function 'add',
    inlined from 'processArg' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:144:8,
    inlined from 'processArgs' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:135:35,
    inlined from '__ct ' at /cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooArgList.h:55:16,
    inlined from 'getProcessNorms' at src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:55:
/cvmfs/cms.cern.ch/el9_amd64_gcc12/lcg/root/6.30.07-8b1a11e1ef0e074fdfd44e162b27e71c/include/RooCollectionProxy.h:114:23: warning: array subscript 'struct RooCollectionProxy[0]' is partly outside array bounds of 'struct RooArgList[1]' [-Warray-bounds]
  114 |       return add(var, _defValueServer, _defShapeServer, silent);
      |                       ^
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc: In member function 'getProcessNorms':
src/HiggsAnalysis/CombinedLimit/src/CMSHistErrorPropagator.cc:579:83: note: object '<anonymous>' of size 128
  579 |           normProd = new RooProduct(normProdName, "", RooArgList(*integral, *coeff));
      |                                                                                   ^

``` 