### PR TITLE
Fix bugs in shapeN + CMSHistFunc/Sum

### DIFF
--- a/src/CMSHistFunc.cc
+++ b/src/CMSHistFunc.cc
@@ -607,6 +607,7 @@ void CMSHistFunc::updateCache() const {
       cache_.CopyValues(mcache_[idx].step2);
       if (vtype_ == VerticalSetting::LogQuadLinear) {
         cache_.Exp();
+        cache_.Scale(mcache_[idx].step1.Integral() / mcache_[idx].step2.Integral());
       }
       cache_.CropUnderflows();
       if (enable_fast_vertical_) fast_vertical_ = true;

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -283,9 +283,9 @@ void CMSHistSum::updateMorphs() const {
           compcache_[ip][ibin] *= extdata[ibin];
         }
       }
-    }
-    if (vtype_[ip] == CMSHistFunc::VerticalSetting::LogQuadLinear) {
-      compcache_[ip].Log();
+      if (vtype_[ip] == CMSHistFunc::VerticalSetting::LogQuadLinear) {
+        compcache_[ip].Log();
+      }
     }
   }
   int n_morphs = vmorphpars_.size();
@@ -362,6 +362,7 @@ void CMSHistSum::updateCache() const {
       staging_ = compcache_[i];
       if (vtype_[i] == CMSHistFunc::VerticalSetting::LogQuadLinear) {
         staging_.Exp();
+        staging_.Scale(storage_[process_fields_[i]].Integral() / staging_.Integral());
       }
       staging_.CropUnderflows();
       vectorized::mul_add(valsum_.size(), coeffvals_[i], &(staging_[0]), &valsum_[0]);


### PR DESCRIPTION
 - Fixes major bug when using `--X-rtd FAST_VERTICAL_MORPH` in conjunction with CMSHistSum where the `log` value of the templates were applied in every evaluate, not just the first time
 - Fix minor bug in CMSHistFunc and CMSHistSum which now explicitly fixes the normalization after shapeN interpolation to the nominal