### PR TITLE
Use RooDataSet constructor that takes `RooFit::WeightVar` argument

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -1224,7 +1224,7 @@ class ShapeBuilder(ModelBuilder):
                     _cache[name] = rdh
                 else:
                     obs.add(self.out.var("CMS_fakeWeight"))
-                    rds = ROOT.RooDataSet(name, name, obs, "CMS_fakeWeight")
+                    rds = ROOT.RooDataSet(name, name, obs, ROOT.RooFit.WeightVar("CMS_fakeWeight"))
                     obs.setRealValue("CMS_fakeWeight", self.DC.obs[channel])
                     rds.add(obs, self.DC.obs[channel])
                     _cache[name] = rds


### PR DESCRIPTION
The constructor that just takes a string is deprecated and will be removed in ROOT 6.34.