### PR TITLE
Fix pull calculation protection

### DIFF
--- a/python/calculate_pulls.py
+++ b/python/calculate_pulls.py
@@ -31,7 +31,8 @@ def compat(x, x0, sx, sx0):
 
 def diffPull(x, x0, sx, sx0):
     # as defined in http://physics.rockefeller.edu/luc/technical_reports/cdf5776_pulls.pdf
-    if abs(sx * sx - sx0 * sx0) < 0.001:
+    # The following protection checks the relative size of the constraint wrt the input uncertainty
+    if abs((sx * sx - sx0 * sx0)/(sx0 * sx0)) < 0.001:
         return [0, 999]
     elif sx > sx0:
         return [0, 999]

--- a/python/calculate_pulls.py
+++ b/python/calculate_pulls.py
@@ -32,7 +32,7 @@ def compat(x, x0, sx, sx0):
 def diffPull(x, x0, sx, sx0):
     # as defined in http://physics.rockefeller.edu/luc/technical_reports/cdf5776_pulls.pdf
     # The following protection checks the relative size of the constraint wrt the input uncertainty
-    if abs((sx * sx - sx0 * sx0)/(sx0 * sx0)) < 0.001:
+    if abs((sx * sx - sx0 * sx0) / (sx0 * sx0)) < 0.001:
         return [0, 999]
     elif sx > sx0:
         return [0, 999]


### PR DESCRIPTION
The protection for negligible constraints in the pull calculation used to check for an absolute difference in pre- and post-fit constraint. For most uncertainties this works fine, but if you introduce a param with a value much smaller than 1 the criterion is probably too strict.

This changes the protection to apply if the constraint relative to the input uncertainty is less than sqrt(0.001).