### PR TITLE
Fix Quadratic Scaling (docstring and allow pickle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
         python: ["3.8"]
         root: ["6.22"]  
         include:
-          # to deprecate (11_2_X py2)
-          - python: "2.7.18"
-            root: "6.22.0" 
           # python 3.10 root 6.26
           - python: "3.10"
             root: "6.26.4"

--- a/python/QuadraticScaling.py
+++ b/python/QuadraticScaling.py
@@ -19,7 +19,7 @@ class Quadratic(PhysicsModel):
     >>> np.save('scales.npy', scales)
 
     Example for running:
-    text2workspace.py ttV.txt -P HiggsAnalysis.CombinedLimit.EFT:quad --PO scaling=scales.npy --PO process=ttZ --PO process=ttW --PO coefficient=cuW -o cuW.root
+    text2workspace.py ttV.txt -P HiggsAnalysis.CombinedLimit.QuadraticScaling:quad --PO scaling=scales.npy --PO process=ttZ --PO process=ttW --PO coefficient=cuW -o cuW.root
     combine -M MultiDimFit cuW.root --setParameterRanges=-4,4
     """
 
@@ -37,7 +37,7 @@ class Quadratic(PhysicsModel):
                 self.scaling = value
 
     def setup(self):
-        scaling = np.load(self.scaling)[()]
+        scaling = np.load(self.scaling, allow_pickle=True)[()]
         for process in self.processes:
             self.modelBuilder.out.var(process)
             name = "r_{0}_{1}".format(process, self.coefficient)


### PR DESCRIPTION
Fix the docstring (EFT->QuadraticScaling, is the filename) and also allow_pickle=True for reading dicts from np gz for the quadratic model.