### PR TITLE
Scale rates via datacard parser

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -92,6 +92,12 @@ parser.add_option(
     action="store_true",
     help="Drop regularization terms that would not be correctly combined.",
 )
+parser.add_option(
+    "--scale-rate",
+    metavar="'[BIN/]PROCES=NUMBER[,...]'",
+    dest="scaleRates",
+    help="Scale the rate of processes in comma-separated list with syntax '[<bin>/]<process>=<number>'. Accepts regexp, e.g. '.*/ggH_[78]TeV=0.5'",
+)
 
 (options, args) = parser.parse_args()
 options.bin = True  # fake that is a binary output, so that we parse shape lines


### PR DESCRIPTION
This PR allows users to scale rates in datacard parser via command line for `combineCards.py` or `text2workspace.py`.

I ran into a use case where I want to combine cards with signal pdfs normalized to 1 pb to set limits on the cross section in units of pb. When combined, the signal yields/rates need to be reweighed by their relative fraction of the total cross section. With this PR, one can do
```bash
combineCards.py datacard_wh.txt datacard_zh.txt --scale-rate='wh_.*=0.6,zh_.*=0.4'
```
where `0.6 = 1.37/(1.37+0.88)` and `0.4 = 0.88/(1.37+0.88)` for 𝜎(WH) = 1.37 pb and  𝜎(ZH) = 0.88 pb.

The implementation allows to use regular expression by default, and specify the bin, e.g.
```bash
--scale-rate='ch[12]/wh.*=0.6,ch[12]/wz.*=0.4'
```
Mathematical expressions native to python are possible thanks to implementation with `eval()`, e.g.
```bash
--scale-rate='wh.*=1.37/(1.37+0.88),zh.*=1-1.37/(1.37+0.88)'
```

Hope this can be useful to others? I think it should work for simple datacards without shapes and just the rates, or datacards with PDFs, but not histograms (see [documentation](https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/part2/settinguptheanalysis/#rates-for-shape-analyses))?