### PR TITLE
Add global flag to set NLL evaluation backend

### DIFF
--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -67,6 +67,9 @@ public:
 
   /// Add a branch to the output tree (for advanced use or debugging only)
   static void addBranch(const char *name, void *address, const char *leaflist) ;
+
+  static  std::string nllBackend_;
+
 private:
   bool mklimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr) ;
  
@@ -127,7 +130,6 @@ private:
   static std::string  trackParametersNameString_;
   static std::string  trackErrorsNameString_;
   static std::string  textToWorkspaceString_;
-
 };
 
 #endif

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -95,6 +95,7 @@ std::string defineBackgroundOnlyModelParameterExpression_ = "";
 std::string Combine::trackParametersNameString_="";
 std::string Combine::trackErrorsNameString_="";
 std::string Combine::textToWorkspaceString_="";
+std::string Combine::nllBackend_ = "combine";
 
 std::vector<std::pair<RooAbsReal*,float> > Combine::trackedParametersMap_;
 std::vector<std::pair<RooRealVar*,float> > Combine::trackedErrorsMap_;

--- a/src/RooSimultaneousOpt.cc
+++ b/src/RooSimultaneousOpt.cc
@@ -1,5 +1,7 @@
 #include "../interface/RooSimultaneousOpt.h"
 #include "../interface/CachingNLL.h"
+#include "../interface/Combine.h"
+
 #include <RooCmdConfig.h>
 
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,30,0)
@@ -10,6 +12,17 @@ std::unique_ptr<RooAbsReal>
 RooSimultaneousOpt::createNLLImpl(RooAbsData& data, const RooLinkedList& cmdList) 
 #endif
 {
+    // Alternative evaluation backends are only supported from ROOT 6.30.
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,30,0)
+    if (Combine::nllBackend_ != "combine") {
+        RooLinkedList cmdListCopy{cmdList};
+        // Set the RooFit::EvalBackend() of RooFit to what the
+        // Combine::nllBackend_ is set.
+        RooCmdArg evalBackendArg{RooFit::EvalBackend(Combine::nllBackend_)};
+        cmdListCopy.Add(&evalBackendArg);
+        return RooSimultaneous::createNLLImpl(data, cmdListCopy);
+    }
+#endif
     RooCmdConfig pc(Form("RooSimultaneousOpt::createNLL(%s)",GetName())) ;
     pc.defineSet("cPars","Constrain",0,0);
     RooArgSet *cPars = pc.getSet("cPars");


### PR DESCRIPTION
  * In case the value is `"combine"`, it will use combines caching NLL classes

  * In any other case, it will RooFits default `createNLL()`, setting the RooFit::EvalBackend to the value on the global flag. See: https://root.cern.ch/doc/master/classRooAbsPdf.html#a24b1afec4fd149e08967eac4285800de