### PR TITLE
Add public getters to useful information in combine classes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+ColumnLimit: 120
+NamespaceIndentation: All
+SortIncludes: false
+IndentWidth: 2
+AccessModifierOffset: -2
+PenaltyBreakComment: 30
+PenaltyExcessCharacter: 100
+AlignAfterOpenBracket: Align
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+ReflowComments: false
+BinPackArguments: false
+BinPackParameters: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-site
 *.pyc
+*.wscode.*
+.python/
+build/
+install/
+site

--- a/interface/AsymPow.h
+++ b/interface/AsymPow.h
@@ -26,9 +26,11 @@ class AsymPow : public RooAbsReal {
       AsymPow(const char *name, const char *title, RooAbsReal &kappaLow, RooAbsReal &kappaHigh, RooAbsReal &theta) ;
       AsymPow(const AsymPow &other, const char *newname=0) ;
 
-      ~AsymPow() override ;
+      TObject * clone(const char *newname) const override { return new AsymPow(*this, newname); }
 
-      TObject * clone(const char *newname) const override ;
+      RooAbsReal const &kappaLow() const { return kappaLow_.arg(); }
+      RooAbsReal const &kappaHigh() const { return kappaHigh_.arg(); }
+      RooAbsReal const &theta() const { return theta_.arg(); }
 
     protected:
         Double_t evaluate() const override;

--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -19,7 +19,6 @@ class ProcessNormalization : public RooAbsReal {
       ProcessNormalization(const char *name, const char *title, double nominal=1) ;
       ProcessNormalization(const char *name, const char *title, RooAbsReal &nominal) ;
       ProcessNormalization(const ProcessNormalization &other, const char *newname = 0) ;
-      ~ProcessNormalization() override ;
 
       TObject * clone(const char *newname) const override { return new ProcessNormalization(*this, newname); }
 
@@ -28,6 +27,13 @@ class ProcessNormalization : public RooAbsReal {
       void addAsymmLogNormal(double kappaLo, double kappaHi, RooAbsReal &theta) ;
       void addOtherFactor(RooAbsReal &factor) ;
       void dump() const ;
+
+      double nominalValue() const { return nominalValue_; }
+      std::vector<double> const &logKappa() const { return logKappa_; }
+      RooArgList const &thetaList() const { return thetaList_; }
+      std::vector<std::pair<double, double>> const &logAsymmKappa() const { return logAsymmKappa_; }
+      RooArgList const &asymmThetaList() const { return asymmThetaList_; }
+      RooArgList const &otherFactorList() const { return otherFactorList_; }
 
     protected:
         Double_t evaluate() const override;

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -34,7 +34,12 @@ public:
   const RooArgList& coefList() const { return _coefList ; }
 
   const RooRealProxy &x() const { return _x; }
+
+  double smoothRegion() const { return _smoothRegion; }
+  int smoothAlgo() const { return _smoothAlgo; }
+
   friend class FastVerticalInterpHistPdf;
+
 protected:
   RooRealProxy   _x;
   RooListProxy _funcList ;   //  List of component FUNCs
@@ -84,6 +89,11 @@ public:
   /// Must be public, for serialization
   struct Morph { FastTemplate sum; FastTemplate diff; };
 
+  std::vector<Morph> const &morphs() const { return _morphs; }
+
+  double smoothRegion() const { return _smoothRegion; }
+  int smoothAlgo() const { return _smoothAlgo; }
+
   friend class FastVerticalInterpHistPdf2Base;
 protected:
   RooRealProxy   _x;
@@ -127,21 +137,22 @@ public:
   FastVerticalInterpHistPdf() : FastVerticalInterpHistPdfBase() {}
   FastVerticalInterpHistPdf(const char *name, const char *title, const RooRealVar &x, const RooArgList& funcList, const RooArgList& coefList, Double_t smoothRegion=1., Int_t smoothAlgo=1) :
     FastVerticalInterpHistPdfBase(name,title,RooArgSet(x),funcList,coefList,smoothRegion,smoothAlgo),
-    _x("x","Independent variable",this,const_cast<RooRealVar&>(x)),
-    _cache(), _cacheNominal(), _cacheNominalLog()  {}
+    _x("x","Independent variable",this,const_cast<RooRealVar&>(x)) {}
   FastVerticalInterpHistPdf(const FastVerticalInterpHistPdf& other, const char* name=0) :
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf(*this,newname) ; }
-  ~FastVerticalInterpHistPdf() override {}
 
   Double_t evaluate() const override ;
 
   Bool_t hasCache()     const { return _cache.size() > 0; }
   Bool_t isCacheReady() const { return _cache.size() > 0 && _init; }
+  FastHisto const &cacheNominal() const { return _cacheNominal; }
+
   friend class FastVerticalInterpHistPdfV;
   friend class FastVerticalInterpHistPdf2;
+
 protected:
   RooRealProxy   _x;
 
@@ -186,14 +197,12 @@ public:
     FastVerticalInterpHistPdfBase(name,title,RooArgSet(x,y),funcList,coefList,smoothRegion,smoothAlgo),
     _x("x","Independent variable",this,const_cast<RooRealVar&>(x)),
     _y("y","Independent variable",this,const_cast<RooRealVar&>(y)),
-    _conditional(conditional),
-    _cache(), _cacheNominal(), _cacheNominalLog()  {}
+    _conditional(conditional) {}
   FastVerticalInterpHistPdf2D(const FastVerticalInterpHistPdf2D& other, const char* name=0) :
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x), _y("y",this,other._y), _conditional(other._conditional),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2D(*this,newname) ; }
-  ~FastVerticalInterpHistPdf2D() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }
@@ -203,6 +212,8 @@ public:
 
   Bool_t hasCache()     const { return _cache.size() > 0; }
   Bool_t isCacheReady() const { return _cache.size() > 0 && _init; }
+
+  FastHisto2D const &cacheNominal() const { return _cacheNominal; }
 
   friend class FastVerticalInterpHistPdf2D2;
 protected:
@@ -245,8 +256,15 @@ public:
   virtual void setActiveBins(unsigned int bins) {}
 
   bool cacheIsGood() const { return _sentry.good() && _initBase; }
+
+  double smoothRegion() const { return _smoothRegion; }
+  int smoothAlgo() const { return _smoothAlgo; }
+
   /// Must be public, for serialization
   typedef FastVerticalInterpHistPdfBase::Morph Morph;
+
+  std::vector<Morph> const &morphs() const { return _morphs; }
+
 protected:
   RooListProxy _coefList ;  //  List of coefficients
   Double_t     _smoothRegion;
@@ -302,7 +320,6 @@ public:
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   explicit FastVerticalInterpHistPdf2(const FastVerticalInterpHistPdf& other, const char* name=0) ;
   TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2(*this,newname) ; }
-  ~FastVerticalInterpHistPdf2() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
 
@@ -310,6 +327,8 @@ public:
   Double_t evaluate() const override ;
 
   FastHisto const& cache() const { return _cache; }
+
+  FastHisto const &cacheNominal() const { return _cacheNominal; }
 
   friend class FastVerticalInterpHistPdf2V;
 protected:
@@ -358,7 +377,6 @@ public:
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   explicit FastVerticalInterpHistPdf2D2(const FastVerticalInterpHistPdf2D& other, const char* name=0) ;
   TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf2D2(*this,newname) ; }
-  ~FastVerticalInterpHistPdf2D2() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }
@@ -368,6 +386,8 @@ public:
   Double_t maxVal(Int_t code) const override ;
 
   Double_t evaluate() const override ;
+
+  FastHisto2D const &cacheNominal() const { return _cacheNominal; }
 
 protected:
   RooRealProxy _x, _y;
@@ -400,14 +420,12 @@ public:
     _x("x","Independent variable",this,const_cast<RooRealVar&>(x)),
     _y("y","Independent variable",this,const_cast<RooRealVar&>(y)),
     _z("z","Independent variable",this,const_cast<RooRealVar&>(z)),
-    _conditional(conditional),
-    _cache(), _cacheNominal(), _cacheNominalLog()  {}
+    _conditional(conditional) {}
   FastVerticalInterpHistPdf3D(const FastVerticalInterpHistPdf3D& other, const char* name=0) :
     FastVerticalInterpHistPdfBase(other, name),
     _x("x",this,other._x), _y("y",this,other._y), _z("z",this,other._z), _conditional(other._conditional),
     _cache(other._cache), _cacheNominal(other._cacheNominal), _cacheNominalLog(other._cacheNominalLog)  {}
   TObject* clone(const char* newname) const override { return new FastVerticalInterpHistPdf3D(*this,newname) ; }
-  ~FastVerticalInterpHistPdf3D() override {}
 
   const RooRealVar & x() const { return dynamic_cast<const RooRealVar &>(_x.arg()); }
   const RooRealVar & y() const { return dynamic_cast<const RooRealVar &>(_y.arg()); }

--- a/src/AsymPow.cc
+++ b/src/AsymPow.cc
@@ -20,13 +20,6 @@ AsymPow::AsymPow(const AsymPow &other, const char *newname) :
     theta_("theta",this,other.theta_)
     { }
 
-AsymPow::~AsymPow() {}
-
-TObject *AsymPow::clone(const char *newname) const 
-{
-    return new AsymPow(*this,newname);
-}
-
 Double_t AsymPow::evaluate() const {
    return RooFit::Detail::MathFuncs::asymPow(theta_, kappaLow_, kappaHigh_);
 }

--- a/src/ProcessNormalization.cc
+++ b/src/ProcessNormalization.cc
@@ -15,14 +15,10 @@ ProcessNormalization::ProcessNormalization(const char *name, const char *title, 
 { 
 }
 
-ProcessNormalization::ProcessNormalization(const char *name, const char *title, RooAbsReal &nominal) :
-        RooAbsReal(name,title),
-        nominalValue_(1.0),
-        thetaList_("thetaList", "List of nuisances for symmetric kappas", this), 
-        asymmThetaList_("asymmThetaList", "List of nuisances for asymmetric kappas", this), 
-        otherFactorList_("otherFactorList", "Other multiplicative terms", this)
-{ 
-    otherFactorList_.add(nominal);
+ProcessNormalization::ProcessNormalization(const char *name, const char *title, RooAbsReal &nominal)
+  : ProcessNormalization{name, title, 1.0}
+{
+   otherFactorList_.add(nominal);
 }
 
 ProcessNormalization::ProcessNormalization(const ProcessNormalization &other, const char *newname) :
@@ -35,8 +31,6 @@ ProcessNormalization::ProcessNormalization(const ProcessNormalization &other, co
         otherFactorList_("otherFactorList", this, other.otherFactorList_)
 {
 }
-
-ProcessNormalization::~ProcessNormalization() {}
 
 void ProcessNormalization::addLogNormal(double kappa, RooAbsReal &theta) {
     if (kappa != 0.0 && kappa != 1.0) {


### PR DESCRIPTION
This will help for example in the serialization to JSON or the C++ code generation for automatic differentiation.

Also, duplicate the `.clang-format` file from CMSSW to make the correct style available outside the CMSSW environment, and update the `.gitignore` file.