### PR TITLE
More standard implementation of RooMultiPdf

### DIFF
--- a/interface/RooMultiPdf.h
+++ b/interface/RooMultiPdf.h
@@ -24,9 +24,8 @@ public:
   void setCorrectionFactor(double penal) { cFactor = penal; }
   inline int getCurrentIndex() const { return static_cast<int>(x); }
   inline RooAbsPdf *getPdf(int index) const { return static_cast<RooAbsPdf*>(c.at(index)); }
-  Double_t getValV(const RooArgSet* nset) const override ;
-  /// needed since otherwise printValue calls evaluate(), which is taboo
-  void printValue(std::ostream& os) const override { getCurrentPdf()->printValue(os); }
+  // Always normalized because each pdf is normalized
+  bool selfNormalized() const override { return true; }
 protected:
   RooListProxy c;
   RooListProxy corr;

--- a/interface/RooMultiPdf.h
+++ b/interface/RooMultiPdf.h
@@ -1,83 +1,44 @@
 #ifndef ROO_MULTIPDF
 #define ROO_MULTIPDF
 
-#include "RooAbsArg.h"
 #include "RooAbsPdf.h"
-#include "RooAbsReal.h"
-#include "RooRealProxy.h"
-#include "RooRealVar.h"
-#include "RooArgList.h"
-#include "RooAbsCategory.h"
 #include "RooCategory.h"
 #include "RooCategoryProxy.h"
-#include "RooArgProxy.h"
-#include "RooAbsProxy.h"
-#include "RooFormulaVar.h"
-#include "RooLinkedList.h"
-#include "RooConstVar.h"
-
-
 #include "RooListProxy.h"
 
 #include <iostream>
-#include <vector>
-
-
-using namespace std;
 
 class RooMultiPdf : public RooAbsPdf {
 public:
-  enum PenatlyScheme{PVAL, AIC};
-  RooMultiPdf() {} ;
+  enum PenaltyScheme{PVAL, AIC};
+  RooMultiPdf() {}
   RooMultiPdf(const char *name, const char *title, RooCategory &, const RooArgList& _c);
-  RooMultiPdf(const RooMultiPdf& other, const char* name=0);
+  RooMultiPdf(const RooMultiPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooMultiPdf(*this,newname); }
-  inline ~RooMultiPdf() override { }
 
-/*
-  RooAbsReal* createNLL(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),  
-                                const RooCmdArg& arg3=RooCmdArg::none(),
-const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg&
-arg5=RooCmdArg::none(),  
-                                 const RooCmdArg& arg6=RooCmdArg::none(),
-const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg&
-arg8=RooCmdArg::none());
-
-  RooAbsReal* createNLL(RooAbsData &data,const RooLinkedList&);
-*/
-
-//}
-/*
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
-*/
-  bool checkIndexDirty() const;
-  double getCorrection() const;
-  RooAbsPdf *getCurrentPdf() const;
-  int getNumPdfs() const {return nPdfs;};
-  void setCorrectionFactor(PenatlyScheme penal);
-  void setCorrectionFactor(double penal);
-  int getCurrentIndex() const ;
-  RooAbsPdf *getPdf(int index) const ;
+  inline bool checkIndexDirty() const { return _oldIndex != x; }
+  inline double getCorrection() const { return cFactor * static_cast<RooAbsReal*>(corr.at(x))->getVal(); }
+  inline RooAbsPdf *getCurrentPdf() const { return getPdf(getCurrentIndex()); }
+  int getNumPdfs() const { return c.size(); }
+  void setCorrectionFactor(PenaltyScheme penal) { cFactor = penal == AIC ? 1.0 : 0.5; }
+  void setCorrectionFactor(double penal) { cFactor = penal; }
+  inline int getCurrentIndex() const { return static_cast<int>(x); }
+  inline RooAbsPdf *getPdf(int index) const { return static_cast<RooAbsPdf*>(c.at(index)); }
   Double_t getValV(const RooArgSet* nset) const override ;
   /// needed since otherwise printValue calls evaluate(), which is taboo
-  void printValue(ostream& os) const override { getCurrentPdf()->printValue(os); }
+  void printValue(std::ostream& os) const override { getCurrentPdf()->printValue(os); }
 protected:
   RooListProxy c;
   RooListProxy corr;
   RooCategoryProxy x;
-  //RooFormulaVar *cval;
- // RooRealProxy nllcorr;
-//  RooAbsCatgeory *fIndex_r;
 
   int fIndex; // sigh, there should be a better way than this
-  int nPdfs;
+  int nPdfs; // not used, kept so we didn't have to change the class layout for IO
   mutable Int_t _oldIndex;
 
   Double_t evaluate() const override;
-  Double_t getLogVal(const RooArgSet *set = 0) const override;
-  //std::string createCorrectionString();	// should only do this once really
-  double cFactor;
+  Double_t getLogVal(const RooArgSet *set = nullptr) const override;
+  double cFactor = 0.5; // correction to 2*NLL by default is -> 2*0.5 per param
 
 private:
   ClassDefOverride(RooMultiPdf,1) // Multi PDF

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -672,7 +672,7 @@ cacheutils::CachingAddNLL::evaluate() const
     double ret = constantZeroPoint_;
     if (runtimedef::get("REMOVE_CONSTANT_ZERO_POINT") ) ret = 0; 
     for (its = bgs; its != eds ; ++its) {
-        if (!isnormal(*its) || *its <= 0) {
+        if (!std::isnormal(*its) || *its <= 0) {
             if ((weights_[its-bgs] == 0) && (*its == 0)) {
                 // this special case we don't care, as zero is fine and it will be multiplied by zero afterwards,
                 // we just need to protect it for the logarithm
@@ -1091,7 +1091,7 @@ cacheutils::CachingSimNLL::evaluate() const
         std::vector<double>::const_iterator itz = constrainZeroPoints_.begin();
         for (std::vector<RooAbsPdf *>::const_iterator it = constrainPdfs_.begin(), ed = constrainPdfs_.end(); it != ed; ++it, ++itz) { 
             double pdfval = (*it)->getVal(nuis_);
-            if (!isnormal(pdfval) || pdfval <= 0) {
+            if (!std::isnormal(pdfval) || pdfval <= 0) {
                 //std::cout << "WARNING: underflow constraint pdf " << (*it)->GetName() << ", value = " << pdfval << std::endl;
     		    CombineLogger::instance().log("CachingNLL.cc",__LINE__,std::string(Form("underflow (pdf evaluates to <=0) of constraint pdf %s, value = %g ",(*it)->GetName(), pdfval)),__func__);
                 if (gentleNegativePenalty_) { ret += 25; continue; }
@@ -1208,7 +1208,7 @@ void cacheutils::CachingSimNLL::setZeroPoint() {
     std::vector<double>::iterator itz = constrainZeroPoints_.begin();
     for (std::vector<RooAbsPdf *>::const_iterator it = constrainPdfs_.begin(), ed = constrainPdfs_.end(); it != ed; ++it, ++itz) {
         double pdfval = (*it)->getVal(nuis_);
-        if (isnormal(pdfval) || pdfval > 0) *itz = -log(pdfval);
+        if (std::isnormal(pdfval) || pdfval > 0) *itz = -log(pdfval);
     }
     itz = constrainZeroPointsFast_.begin();
     for (std::vector<SimpleGaussianConstraint*>::const_iterator it = constrainPdfsFast_.begin(), ed = constrainPdfsFast_.end(); it != ed; ++it, ++itz) {

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -28,7 +28,7 @@ RooMultiPdf::RooMultiPdf(const char *name, const char *title, RooCategory& _x, c
   std::unique_ptr<RooAbsCollection> nonConstVariables(variables->selectByAttrib("Constant", false));
 	// Isn't there a better wat to hold on to these values?
 	RooConstVar *tmp = new RooConstVar((std::string{"const"} + pdf->GetName()).c_str(),"",nonConstVariables->size());
-	corr.add(*tmp);
+	corr.addOwned(*tmp);
 	count++;
   }
  _oldIndex=fIndex;

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -45,19 +45,10 @@ RooMultiPdf::RooMultiPdf(const RooMultiPdf& other, const char* name) :
 }
 
 //_____________________________________________________________________________
-Double_t RooMultiPdf::getValV(const RooArgSet* nset) const {
-  double val = getCurrentPdf()->getVal(nset);
+Double_t RooMultiPdf::evaluate() const{
+  double val = getCurrentPdf()->getVal(c.nset());
   _oldIndex=x;
   return val;
-}
-
-//_____________________________________________________________________________
-Double_t RooMultiPdf::evaluate() const{
-  // This is dangerous since if the underlying pdf is a RooAddPdf the meaning of the 
-  // coefficients depends on the normalization set, and we don't really know
-  // how this information is propagated.
-  // So, we just forward the getVal which is anyway the contract for RooMultiPdf.
-  throw std::invalid_argument("RooMultiPdf::evaluate() called\n");
 }
 
 //_____________________________________________________________________________

--- a/src/RooMultiPdf.cxx
+++ b/src/RooMultiPdf.cxx
@@ -4,44 +4,34 @@
 // END_HTML
 //
 
-#include "RooFit.h"
-
-#include "Riostream.h"
-#include "Riostream.h"
-#include <math.h>
-
 #include "../interface/RooMultiPdf.h"
-#include "RooRealVar.h"
-#include "RooAddPdf.h"
-#include <stdexcept>
+
+#include "RooConstVar.h"
 
 ClassImp(RooMultiPdf)
 
 
 //_____________________________________________________________________________
 RooMultiPdf::RooMultiPdf(const char *name, const char *title, RooCategory& _x, const RooArgList& _c) : 
-  RooAbsPdf(name, title),  //Why is this here? just to use the names to be used? 
+  RooAbsPdf(name, title),
   c("_pdfs","The list of pdfs",this),
   corr("_corrs","The list of correction factors",this),
   x("_index","the pdf index",this,_x) 
 {
   int count=0;
 
-  for (RooAbsArg *fPdf : _c) {
-	c.add(*fPdf);
+  c.add(_c);
+  for (RooAbsArg *pdf : c) {
 	// This is done by the user BUT is there a way to do it at construction?
-	_x.defineType(Form("_pdf%d",count),count);//(fPdf->getParameters())->getSize());
-  std::unique_ptr<RooArgSet> variables(fPdf->getVariables());
+	_x.defineType(("_pdf" + std::to_string(count)).c_str(), count);
+  std::unique_ptr<RooArgSet> variables(pdf->getVariables());
   std::unique_ptr<RooAbsCollection> nonConstVariables(variables->selectByAttrib("Constant", false));
 	// Isn't there a better wat to hold on to these values?
-	RooConstVar *tmp = new RooConstVar(Form("const%s",fPdf->GetName()),"",nonConstVariables->getSize());
+	RooConstVar *tmp = new RooConstVar((std::string{"const"} + pdf->GetName()).c_str(),"",nonConstVariables->size());
 	corr.add(*tmp);
 	count++;
   }
-  nPdfs=c.getSize();
-  cFactor=0.5; // correction to 2*NLL by default is -> 2*0.5 per param
  _oldIndex=fIndex;
- 
 }
 
 
@@ -49,55 +39,14 @@ RooMultiPdf::RooMultiPdf(const char *name, const char *title, RooCategory& _x, c
 RooMultiPdf::RooMultiPdf(const RooMultiPdf& other, const char* name) :
  RooAbsPdf(other, name),c("_pdfs",this,other.c),corr("_corrs",this,other.corr),x("_index",this,other.x)
 {
-
  fIndex=other.fIndex;
- nPdfs=other.nPdfs;
  _oldIndex=fIndex;
  cFactor=other.cFactor; // correction to 2*NLL by default is -> 2*0.5 per param
 }
 
-bool RooMultiPdf::checkIndexDirty() const {
-  return _oldIndex!=x;  
-}
-//_____________________________________________________________________________
-void RooMultiPdf::setCorrectionFactor(PenatlyScheme penal){
-  if ( penal==AIC ){
-  	cFactor=1.0;
-  } else if ( penal==PVAL ){
-	cFactor=0.5;
-  }
-}
-//_____________________________________________________________________________
-void RooMultiPdf::setCorrectionFactor(double penal){
-  cFactor=penal;
-}
-//_____________________________________________________________________________
-double RooMultiPdf::getCorrection() const {
-
-  double val = ((RooAbsReal*)corr.at(x))->getVal(); 
-  return cFactor*val;  //PVAL correction
-}
-//_____________________________________________________________________________
-RooAbsPdf* RooMultiPdf::getCurrentPdf() const {
-
-  RooAbsPdf *cPdf = ((RooAbsPdf*)c.at(x)); 
-  return cPdf; 
-}
-RooAbsPdf* RooMultiPdf::getPdf(int index) const {
-    
-  RooAbsPdf *cPdf = ((RooAbsPdf*)c.at(index));
-  return cPdf;
-}
-
-int RooMultiPdf::getCurrentIndex() const {
-    Int_t index = x;
-    return index;
-}
-
 //_____________________________________________________________________________
 Double_t RooMultiPdf::getValV(const RooArgSet* nset) const {
-  RooAbsPdf *cPdf = ((RooAbsPdf*)c.at(x)); 
-  double val = cPdf->getVal(nset);
+  double val = getCurrentPdf()->getVal(nset);
   _oldIndex=x;
   return val;
 }
@@ -113,9 +62,7 @@ Double_t RooMultiPdf::evaluate() const{
 
 //_____________________________________________________________________________
 Double_t  RooMultiPdf::getLogVal(const RooArgSet* nset) const {
-  RooAbsPdf *cPdf = ((RooAbsPdf*)c.at(x)); 
-  double logval = cPdf->getLogVal(nset);
+  double logval = getCurrentPdf()->getLogVal(nset);
   _oldIndex=x;
   return logval;	
 }
-


### PR DESCRIPTION
The people that implemented RooMultiPdf had a doubt: they didn't dare to
implement `RooMultiPdf::evaluate()` because they were not sure how the
normalization set information is propagated.

The anser is: it's propagated in the base implementation of `getValV()`
via the proxies, like the RooListProxy with the pdf in this case. The
propagated normalization set can be queried from the proxy with
`nset()`.

Hence, this PR suggests to implement `evaluate()` accordingly.

Furthermore, the `selfNormalized()` method needs to be overridden, to
indicate that the base implementation of `RooAbsPdf::getValV()` doesn't
need to create any normalization integrals implicitly, which would be a
huge performance hit.

This more standard implementation makes sure that the class is more
compatible with regular RooFit, which expects that `evaluate()` is
implemented.

It was validated with the following command that results and performance
remain unaffected:

```bash
text2workspace.py data/ci/datacard_RooMultiPdf.txt.gz -o multipdf_ws.root
combine -M MultiDimFit -m 125.38  --setParameters pdf_index_ggh=2 --freezeParameters MH --cminDefaultMinimizerStrategy 0 --X-rtd FAST_VERTICAL_MORPH --X-rtd MINIMIZER_freezeDisassociatedParams --X-rtd MINIMIZER_multiMin_maskChannels=2 --algo singles ws_RooMultiPdf.root
```

Two additional commits in this PR fix a memory leak and refactor the code to be less verbose respectively.