### PR TITLE
Replacing deprecated Mambaforge with Miniforge3 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2.2.0
       with:
         python-version: ${{ matrix.python }}
-        miniforge-variant: Miniforge
+        miniforge-variant: Miniforge3
         channels: conda-forge,defaults
         channel-priority: true
         activate-environment: combine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2.2.0
       with:
         python-version: ${{ matrix.python }}
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge
         channels: conda-forge,defaults
         channel-priority: true
         activate-environment: combine


### PR DESCRIPTION
The latest ci jobs failed because today is one of the burnout days for the deprecated since July Mambaforge https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/ 