### PR TITLE
Apply a few more clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,22 @@
 ---
 Checks: -*,
+  ,boost-use-to-string,
+  ,bugprone-string-constructor,
+  ,misc-definitions-in-headers,
+  ,misc-string-compare,
+  ,misc-uniqueptr-reset-release,
+  ,modernize-use-default-member-init
   ,modernize-use-override,
+  ,performance-faster-string-find,
+  ,performance-inefficient-algorithm,
+  ,performance-inefficient-vector-operation,
+  ,performance-move-const-arg,
+  ,performance-trivially-destructible,
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
+CheckOptions:
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           'h,hh,hpp,hxx,icc'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           true
 ...

--- a/interface/AtlasPdfs.h
+++ b/interface/AtlasPdfs.h
@@ -333,7 +333,7 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    CacheElem(RooAbsPdf& sumPdf, RooChangeTracker& tracker, const RooArgList& flist) : _sumPdf(&sumPdf), _tracker(&tracker), _fractionsCalculated(false) { 
+    CacheElem(RooAbsPdf& sumPdf, RooChangeTracker& tracker, const RooArgList& flist) : _sumPdf(&sumPdf), _tracker(&tracker) {
       _frac.add(flist) ; 
     } ;
     void operModeHook(RooAbsArg::OperMode) override {};
@@ -346,7 +346,7 @@ protected:
     RooRealVar* frac(Int_t i ) ;
     const RooRealVar* frac(Int_t i ) const ; 
     void calculateFractions(const RooStarMomentMorph& self, Bool_t verbose=kTRUE) const;
-    mutable bool _fractionsCalculated;
+    mutable bool _fractionsCalculated = false;
   } ;
   mutable RooObjCacheManager _cacheMgr ; // The cache manager
   mutable RooArgSet* _curNormSet ; //! Current normalization set

--- a/interface/CMSHistV.h
+++ b/interface/CMSHistV.h
@@ -20,7 +20,9 @@ class CMSHistV {
 
  private:
   const T& hpdf_;
-  int begin_, end_, nbins_;
+  int begin_ = 0;
+  int end_ = 0;
+  int nbins_;
   struct Block {
     int index, begin, end;
     Block(int i, int begin_, int end_) : index(i), begin(begin_), end(end_) {}
@@ -32,7 +34,7 @@ class CMSHistV {
 template <class T>
 CMSHistV<T>::CMSHistV(const T& hpdf, const RooAbsData& data,
                       bool includeZeroWeights)
-    : hpdf_(hpdf), begin_(0), end_(0) {
+    : hpdf_(hpdf) {
   hpdf.updateCache();
   std::vector<int> bins;
   RooArgSet obs(hpdf.x_.arg());

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -86,11 +86,11 @@ class CachingPdf : public CachingPdfBase {
         RooAbsReal *pdfOriginal_;
         RooArgSet  pdfPieces_;
         RooAbsReal *pdf_;
-        const RooAbsData *lastData_;
+        const RooAbsData *lastData_ = 0;
         ValuesCache cache_;
         std::vector<uint8_t> nonZeroW_;
         unsigned int         nonZeroWEntries_;
-        bool                 includeZeroWeights_;
+        bool                 includeZeroWeights_ = false;
         virtual void newData_(const RooAbsData &data) ;
         virtual void realFill_(const RooAbsData &data, std::vector<Double_t> &values) ;
 };
@@ -157,8 +157,8 @@ class CachingAddNLL : public RooAbsReal {
         mutable std::vector<Double_t> workingArea_;
         mutable bool isRooRealSum_, fastExit_;
         mutable int canBasicIntegrals_, basicIntegrals_;
-        double zeroPoint_; 
-        double constantZeroPoint_; // this is arbitrary and kept constant for all the lifetime of the PDF
+        double zeroPoint_ = 0;
+        double constantZeroPoint_ = 0; // this is arbitrary and kept constant for all the lifetime of the PDF
 };
 
 class CachingSimNLL  : public RooAbsReal {
@@ -199,7 +199,8 @@ class CachingSimNLL  : public RooAbsReal {
         const RooAbsData  *dataOriginal_;
         const RooArgSet   *nuis_;
         RooSetProxy        params_, catParams_;
-        bool hideRooCategories_, hideConstants_;
+        bool hideRooCategories_ = false;
+        bool hideConstants_ = false;
         RooArgSet piecesForCloning_;
         std::unique_ptr<RooSimultaneous>  factorizedPdf_;
         std::vector<RooAbsPdf *>        constrainPdfs_;
@@ -219,10 +220,10 @@ class CachingSimNLL  : public RooAbsReal {
         std::vector<double> constrainZeroPointsFastPoisson_;
         std::vector<RooAbsReal*> channelMasks_;
         std::vector<bool>        internalMasks_;
-        bool                     maskConstraints_;
+        bool                     maskConstraints_ = false;
         RooArgSet                activeParameters_, activeCatParameters_;
-        double                   maskingOffset_;     // offset to ensure that interal or constraint masking doesn't change NLL value
-        double                   maskingOffsetZero_; // and associated zero point
+        double                   maskingOffset_ = 0;     // offset to ensure that interal or constraint masking doesn't change NLL value
+        double                   maskingOffsetZero_ = 0; // and associated zero point
 };
 
 }

--- a/interface/CascadeMinimizer.h
+++ b/interface/CascadeMinimizer.h
@@ -47,10 +47,11 @@ class CascadeMinimizer {
         Mode         mode_;
         static int          strategy_;
         RooRealVar * poi_; 
-        const RooArgSet *nuisances_;
+        const RooArgSet *nuisances_ = nullptr;
         /// automatically enlarge bounds for POIs if they're within 10% from the boundary
-        bool autoBounds_;
-        const RooArgSet *poisForAutoBounds_, *poisForAutoMax_;
+        bool autoBounds_ = false;
+        const RooArgSet *poisForAutoBounds_ = nullptr;
+        const RooArgSet *poisForAutoMax_ = nullptr;
 
         bool improveOnce(int verbose, bool noHesse=false);
         bool autoBoundsOk(int verbose) ;

--- a/interface/CloseCoutSentry.h
+++ b/interface/CloseCoutSentry.h
@@ -22,7 +22,7 @@ class CloseCoutSentry {
         void static reallyClear() ;
         static FILE *trueStdOut_; 
         static CloseCoutSentry *owner_;
-        bool stdOutIsMine_;
+        bool stdOutIsMine_ = false;
 };
 
 #endif

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -35,8 +35,9 @@ extern  std::string defineBackgroundOnlyModelParameterExpression_;
 
 namespace { 
     struct ToCleanUp {
-        TFile *tfile; std::string file, path;
-        ToCleanUp() : tfile(0), file(""), path("") {}
+        TFile *tfile = nullptr;
+        std::string file;
+        std::string path;
         ~ToCleanUp() {
               if (tfile) { tfile->Close(); delete tfile; }
               if (!file.empty()) {  

--- a/interface/FastTemplate.h
+++ b/interface/FastTemplate.h
@@ -180,7 +180,7 @@ public:
         U GetEdge(unsigned int i) const { return GetXmin(i); }
         U GetWidth(unsigned int i) const { return GetBinWidth(i); }
 
-        void Dump() const ;
+        void Dump() const override ;
 
         FastHisto_t() : FastTemplate_t<T>(), axis_(), normX_(false) {}
         FastHisto_t(const TH1 &hist, bool normX=false);
@@ -195,7 +195,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        FastHisto_t<T,U>& operator=(const TH1 &other) {
+        FastHisto_t<T,U>& operator=(const TH1 &other) override {
           if ((int)this->size() != other.GetNbinsX()) {
             FastHisto_t<T,U> fh(other);
             swap(fh);
@@ -203,7 +203,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        ~FastHisto_t(){}
+        ~FastHisto_t() override {}
 };
 template <typename T, typename U=Double_t> class FastHisto2D_t : public FastTemplate_t<T> {
 private:
@@ -260,7 +260,7 @@ public:
         // For each X, normalize along Y
         void NormalizeXSlices() ;
 
-        void Dump() const ;
+        void Dump() const override ;
 
         T GetMaxOnXY() const ;
         T GetMaxOnX(const U &y) const ;
@@ -281,7 +281,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        FastHisto2D_t& operator=(const TH1 &other) {
+        FastHisto2D_t& operator=(const TH1 &other) override {
           if(other.GetDimension() != 2) {
              throw std::invalid_argument("FastHisto2D_t assignment error: right hand histogram must be 2-dimensional");
           }
@@ -292,7 +292,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        ~FastHisto2D_t(){}
+        ~FastHisto2D_t() override {}
 };
 
 template <typename T, typename U=Double_t> class FastHisto3D_t : public FastTemplate_t<T> {
@@ -361,7 +361,7 @@ public:
         // For each X, normalize along Y
         void NormalizeXSlices() ;
 
-        void Dump() const ;
+        void Dump() const override ;
 
         FastHisto3D_t() : FastTemplate_t<T>(), axisX_(), axisY_(), axisZ_(), normX_(false), normY_(false), normZ_(false) {}
         FastHisto3D_t(const TH3 &hist, bool normX=false, bool normY=false, bool normZ=false);
@@ -380,7 +380,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        FastHisto3D_t<T,U>& operator=(const TH1 &other) {
+        FastHisto3D_t<T,U>& operator=(const TH1 &other) override {
           if(other.GetDimension() != 3) {
              throw std::invalid_argument("FastHisto3D_t assignment error: right hand histogram must be 3-dimensional");
           }
@@ -391,7 +391,7 @@ public:
           else this->CopyValues(other);
           return *this;
         }
-        ~FastHisto3D_t(){}
+        ~FastHisto3D_t() override {}
 };
 
 #include "FastTemplate.hpp"

--- a/interface/FastTemplateFunc.h
+++ b/interface/FastTemplateFunc.h
@@ -16,7 +16,7 @@ public:
   FastTemplateFunc_t() : RooAbsReal(), obsList("obsList", "obsList", this){}
   FastTemplateFunc_t(const char *name, const char *title, RooArgList& inObsList) : RooAbsReal(name, title), obsList("obsList", "obsList", this){ setProxyList(obsList, inObsList); }
   FastTemplateFunc_t(const FastTemplateFunc_t& other, const char* name=0) : RooAbsReal(other, name), obsList("obsList", this, other.obsList){}
-  inline ~FastTemplateFunc_t() override{}
+  inline ~FastTemplateFunc_t() override {}
 
   void setProxyList(RooListProxy& proxyList, RooArgList& varList){
     for (RooAbsArg *var : varList) {
@@ -53,18 +53,18 @@ public:
     }
   }
   FastHistoFunc_t(const FastHistoFunc_t& other, const char* name=0) : FastTemplateFunc_t<T>(other, name), tpl(other.tpl), fullIntegral(other.fullIntegral){}
-  ~FastHistoFunc_t(){}
-  TObject* clone(const char* newname) const { return new FastHistoFunc_t(*this, newname); }
+  ~FastHistoFunc_t() override {}
+  TObject* clone(const char* newname) const override { return new FastHistoFunc_t(*this, newname); }
 
   FastHisto_t<T,U> getHistogram() const{ return tpl; }
   const Int_t getFullIntegralCode() const{ return 2; }
 
-  Double_t evaluate() const{
+  Double_t evaluate() const override {
     T x = (T)(dynamic_cast<RooAbsReal*>((this->obsList).at(0))->getVal());
     Double_t value=tpl.GetAt(x);
     return value;
   }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const{
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override {
     Int_t code=1;
     const Int_t code_prime[1]={ 2 };
     for (int ic=0; ic<(this->obsList).getSize(); ic++){
@@ -77,7 +77,7 @@ public:
     if (code==1) code=0;
     return code;
   }
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const{
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override {
     if (code==0) return evaluate();
     U xmin = (U)(dynamic_cast<RooRealVar*>((this->obsList).at(0))->getMin(rangeName));
     U xmax = (U)(dynamic_cast<RooRealVar*>((this->obsList).at(0))->getMax(rangeName));
@@ -114,19 +114,19 @@ public:
     }
   }
   FastHisto2DFunc_t(const FastHisto2DFunc_t& other, const char* name=0) : FastTemplateFunc_t<T>(other, name), tpl(other.tpl), fullIntegral(other.fullIntegral){}
-  ~FastHisto2DFunc_t(){}
-  TObject* clone(const char* newname) const { return new FastHisto2DFunc_t(*this, newname); }
+  ~FastHisto2DFunc_t() override {}
+  TObject* clone(const char* newname) const override { return new FastHisto2DFunc_t(*this, newname); }
 
   FastHisto2D_t<T,U> getHistogram() const{ return tpl; }
   const Int_t getFullIntegralCode() const{ return /*2*3*/6; }
 
-  Double_t evaluate() const{
+  Double_t evaluate() const override {
     U x = (U)(dynamic_cast<RooAbsReal*>((this->obsList).at(0))->getVal());
     U y = (U)(dynamic_cast<RooAbsReal*>((this->obsList).at(1))->getVal());
     Double_t value=tpl.GetAt(x, y);
     return value;
   }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const{
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override {
     Int_t code=1;
     const Int_t code_prime[2]={ 2, 3 };
     for (int ic=0; ic<(this->obsList).getSize(); ic++){
@@ -139,7 +139,7 @@ public:
     if (code==1) code=0;
     return code;
   }
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const{
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override {
     if (code==0) return evaluate();
     U xmin, xmax, ymin, ymax;
     if (code%2==0){
@@ -206,20 +206,20 @@ public:
     }
   }
   FastHisto3DFunc_t(const FastHisto3DFunc_t& other, const char* name=0) : FastTemplateFunc_t<T>(other, name), tpl(other.tpl), fullIntegral(other.fullIntegral){}
-  ~FastHisto3DFunc_t(){}
-  TObject* clone(const char* newname) const { return new FastHisto3DFunc_t(*this, newname); }
+  ~FastHisto3DFunc_t() override {}
+  TObject* clone(const char* newname) const override { return new FastHisto3DFunc_t(*this, newname); }
 
   FastHisto3D_t<T,U> getHistogram() const{ return tpl; }
   const Int_t getFullIntegralCode() const{ return /*2*3*5*/30; }
 
-  Double_t evaluate() const{
+  Double_t evaluate() const override {
     U x = (U)(dynamic_cast<RooAbsReal*>((this->obsList).at(0))->getVal());
     U y = (U)(dynamic_cast<RooAbsReal*>((this->obsList).at(1))->getVal());
     U z = (U)(dynamic_cast<RooAbsReal*>((this->obsList).at(2))->getVal());
     Double_t value=tpl.GetAt(x, y, z);
     return value;
   }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const{
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override {
     Int_t code=1;
     const Int_t code_prime[3]={ 2, 3, 5 };
     for (int ic=0; ic<(this->obsList).getSize(); ic++){
@@ -232,7 +232,7 @@ public:
     if (code==1) code=0;
     return code;
   }
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const{
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override {
     if (code==0) return evaluate();
     U xmin, xmax, ymin, ymax, zmin, zmax;
     if (code%2==0){

--- a/interface/FitDiagnostics.h
+++ b/interface/FitDiagnostics.h
@@ -60,13 +60,15 @@ protected:
   int fitStatus_, numbadnll_;
   double mu_, muErr_, muLoErr_, muHiErr_, nll_nll0_, nll_bonly_, nll_sb_;
   std::unique_ptr<TFile> fitOut;
-  double* globalObservables_;
-  double* nuisanceParameters_;
-  double* processNormalizations_;
-  double* processNormalizationsShapes_;
+  double* globalObservables_ = nullptr;
+  double* nuisanceParameters_ = nullptr;
+  double* processNormalizations_ = nullptr;
+  double* processNormalizationsShapes_ = nullptr;
 
-  TTree *t_fit_b_, *t_fit_sb_, *t_prefit_;
-   
+  TTree *t_fit_b_ = nullptr;
+  TTree *t_fit_sb_ = nullptr;
+  TTree *t_prefit_ = nullptr;
+
   void getNormalizationsSimple(RooAbsPdf *pdf, const RooArgSet &obs, RooArgSet &out);
   void createFitResultTrees(const RooStats::ModelConfig &,bool,bool);
   void resetFitResultTrees(bool);
@@ -112,7 +114,7 @@ protected:
         const RooAbsCollection & centralValues() override;
     private:
         RooAbsPdf  *pdf_;
-        RooAbsData *data_;
+        RooAbsData *data_ = nullptr;
         RooArgSet  snapshot_; 
   };
 };

--- a/interface/FnTimer.h
+++ b/interface/FnTimer.h
@@ -77,11 +77,11 @@ class FnTimer {
 
  private:
   std::string name_;
-  unsigned calls_;
+  unsigned calls_ = 0;
   std::chrono::time_point<std::chrono::high_resolution_clock> start_;
   std::chrono::time_point<std::chrono::high_resolution_clock> end_;
-  double elapsed_;
-  double elapsed_overhead_;
+  double elapsed_ = 0.;
+  double elapsed_overhead_ = 0.;
 };
 
 

--- a/interface/HMuMuRooPdfs.h
+++ b/interface/HMuMuRooPdfs.h
@@ -22,11 +22,11 @@ class RooModZPdf : public RooAbsPdf {
   RooModZPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a, RooAbsReal& _b, RooAbsReal& _c, const RooArgList& _coef); // BWZRedux x Bernstein with mean and width fixed to Z-boson 
   RooModZPdf(const RooModZPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooModZPdf(*this,newname);
   }
   
-  inline virtual ~RooModZPdf() {}
+  inline ~RooModZPdf() override {}
   
  protected:
   RooRealProxy x;
@@ -37,10 +37,10 @@ class RooModZPdf : public RooAbsPdf {
   RooRealProxy w;
   
   RooListProxy bernCoef;  
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   
  private:
-  ClassDef(RooModZPdf,1)
+  ClassDefOverride(RooModZPdf,1)
 };
 
 
@@ -53,25 +53,25 @@ class RooExpPdf : public RooAbsPdf {
   RooExpPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a1, RooAbsReal& _m);  // exponential with free paramaters for center x0
   RooExpPdf(const RooExpPdf& other, const char* name=0) ;
   
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooExpPdf(*this, newname);
   }
   
-  inline virtual ~RooExpPdf() {
+  inline ~RooExpPdf() override {
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
   
  protected:
   RooRealProxy x;
   RooRealProxy a1;
   RooRealProxy m;
   bool offset;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   
  private:  
-  ClassDef(RooExpPdf,1)
+  ClassDefOverride(RooExpPdf,1)
 
 };
 
@@ -85,15 +85,15 @@ class RooSumTwoExpPdf : public RooAbsPdf {
   RooSumTwoExpPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a1, RooAbsReal& _a2, RooAbsReal& _f, RooAbsReal& _m);  
   RooSumTwoExpPdf(const RooSumTwoExpPdf& other, const char* name=0) ;
   
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooSumTwoExpPdf(*this, newname);
   }
   
-  inline virtual ~RooSumTwoExpPdf() {
+  inline ~RooSumTwoExpPdf() override {
   }
     
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
  protected:
   RooRealProxy x;
@@ -102,10 +102,10 @@ class RooSumTwoExpPdf : public RooAbsPdf {
   RooRealProxy f;
   RooRealProxy m;
   bool offset;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   
  private:  
-  ClassDef(RooSumTwoExpPdf,1)
+  ClassDefOverride(RooSumTwoExpPdf,1)
     
 };
 
@@ -118,25 +118,25 @@ class RooPowerLawPdf : public RooAbsPdf {
   RooPowerLawPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a1, RooAbsReal& _m);  
   RooPowerLawPdf(const RooPowerLawPdf& other, const char* name=0) ;
   
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooPowerLawPdf(*this, newname);
   }
   
-  inline virtual ~RooPowerLawPdf() {
+  inline ~RooPowerLawPdf() override {
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
   
  protected:
   RooRealProxy x;
   RooRealProxy a1;
   RooRealProxy m;
   bool offset;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
  private:  
-  ClassDef(RooPowerLawPdf,1)
+  ClassDefOverride(RooPowerLawPdf,1)
 
 };
 
@@ -149,15 +149,15 @@ class RooSumTwoPowerLawPdf : public RooAbsPdf {
   RooSumTwoPowerLawPdf(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _a1, RooAbsReal& _a2, RooAbsReal& _f, RooAbsReal& _m);
   RooSumTwoPowerLawPdf(const RooSumTwoPowerLawPdf& other, const char* name=0) ;
   
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooSumTwoPowerLawPdf(*this, newname);
   }
   
-  inline virtual ~RooSumTwoPowerLawPdf() {
+  inline ~RooSumTwoPowerLawPdf() override {
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
     
  protected:
   RooRealProxy x;
@@ -166,10 +166,10 @@ class RooSumTwoPowerLawPdf : public RooAbsPdf {
   RooRealProxy f;
   RooRealProxy m;
   bool offset;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   
  private:  
-  ClassDef(RooSumTwoPowerLawPdf,1)
+  ClassDefOverride(RooSumTwoPowerLawPdf,1)
 
 };
 

--- a/interface/ProfilingTools.h
+++ b/interface/ProfilingTools.h
@@ -7,7 +7,6 @@ bool setupIgProfDumpHook() ;
 //#include <boost/unordered_map.hpp>
 class PerfCounter {
     public:
-        PerfCounter() : value_(0) {}
         static PerfCounter & get(const char *name) ;
 
         void   add(double increment=1.0) { value_ += increment; }
@@ -17,7 +16,7 @@ class PerfCounter {
         static void enable() ;
         static void printAll() ;
     private:
-        double value_;
+        double value_ = 0.0;
 };
 
 namespace runtimedef {

--- a/interface/SequentialMinimizer.h
+++ b/interface/SequentialMinimizer.h
@@ -11,7 +11,7 @@ namespace cmsmath {
 
     /// Basic struct to call a function
     struct MinimizerContext {
-        MinimizerContext(const ROOT::Math::IMultiGenFunction *function) : func(function), x(func->NDim()), nCalls(0) {}
+        MinimizerContext(const ROOT::Math::IMultiGenFunction *function) : func(function), x(func->NDim()) {}
         // convenience methods
         double eval() const { nCalls++; return (*func)(&x[0]); }
         double setAndEval(unsigned int i, double xi) const { x[i] = xi; return eval(); }
@@ -20,7 +20,7 @@ namespace cmsmath {
         const ROOT::Math::IMultiGenFunction * func;
         // data, mutable
         mutable std::vector<double> x;
-        mutable unsigned int nCalls;
+        mutable unsigned int nCalls = 0;
     };
 
     class OneDimMinimizer {
@@ -162,8 +162,7 @@ namespace cmsmath {
             // these have to be public for ROOT to handle
             enum State { Cleared, Ready, Active, Done, Fixed, Unknown };
             struct Worker : public OneDimMinimizer {
-                Worker() : OneDimMinimizer(), state(Unknown) {}
-                State state;
+                State state = Unknown;
                 int   nUnaffected; /// number of consecutive times it has been woken up and set to sleep immediately afterwards
             };
         protected:

--- a/interface/ToyMCSamplerOpt.h
+++ b/interface/ToyMCSamplerOpt.h
@@ -23,10 +23,10 @@ namespace toymcoptutils {
             RooAbsPdf *pdf_; 
             RooArgSet observables_;
             bool       canUseSpec_;
-            RooAbsPdf::GenSpec *spec_;
-            TH1        *histoSpec_;
-            bool        keepHistoSpec_;
-            RooRealVar *weightVar_;
+            RooAbsPdf::GenSpec *spec_ = nullptr;
+            TH1        *histoSpec_ = nullptr;
+            bool        keepHistoSpec_ = false;
+            RooRealVar *weightVar_ = nullptr;
             RooDataSet *generateWithHisto(RooRealVar *&weightVar, bool asimov, double weightScale = 1.0, int verbose = 0) ;
             RooDataSet *generateCountingAsimov() ;
             void setToExpected(RooProdPdf &prod, RooArgSet &obs) ;
@@ -43,12 +43,12 @@ namespace toymcoptutils {
             void setCacheTemplates(bool cache) ;
         private:
             RooAbsPdf                       *pdf_; 
-            RooAbsCategoryLValue            *cat_;
+            RooAbsCategoryLValue            *cat_ = nullptr;
             RooArgSet                        observables_;
             std::vector<SinglePdfGenInfo *>  pdfs_; 
             RooArgSet                        ownedCrap_;
             std::map<std::string,RooAbsData*> datasetPieces_;
-            bool                              copyData_;
+            bool                              copyData_ = true;
             //std::map<std::string,RooDataSet*> datasetPieces_;
 
     }; 
@@ -72,15 +72,15 @@ class ToyMCSamplerOpt : public RooStats::ToyMCSampler{
 
         RooAbsData* Generate(RooAbsPdf& pdf, RooArgSet& observables, const RooDataSet* protoData = NULL, int forceEvents = 0) const ;
         RooAbsPdf *globalObsPdf_;
-        mutable RooDataSet *globalObsValues_; 
-        mutable int globalObsIndex_;
+        mutable RooDataSet *globalObsValues_ = nullptr;
+        mutable int globalObsIndex_ = -1;
 
         // We can't use the NuisanceParameterSampler because, even if public, there's no interface file for it
-        mutable RooDataSet *nuisValues_; 
-        mutable int nuisIndex_;
+        mutable RooDataSet *nuisValues_ = nullptr;
+        mutable int nuisIndex_ = -1;
         bool genNuis_;
 
-        mutable RooRealVar *weightVar_;
+        mutable RooRealVar *weightVar_ = nullptr;
         mutable std::map<RooAbsPdf *, toymcoptutils::SimPdfGenInfo *> genCache_;
 
         mutable std::unique_ptr<RooArgSet> paramsForImportanceSampling_;

--- a/interface/VectorizedHistFactoryPdfs.h
+++ b/interface/VectorizedHistFactoryPdfs.h
@@ -17,7 +17,7 @@ namespace cacheutils {
             void  setIncludeZeroWeights(bool includeZeroWeights) override { includeZeroWeights_ = includeZeroWeights; }
         private:
             const RooHistFunc * pdf_;
-            const RooAbsData * data_;
+            const RooAbsData * data_ = nullptr;
             bool includeZeroWeights_;
             std::vector<Double_t> yvals_;
             void fill() ;

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -167,7 +167,9 @@ class FastVerticalInterpHistPdfV {
         void fill(std::vector<Double_t> &out) const ;
     private:
         const FastVerticalInterpHistPdf & hpdf_;
-        int begin_, end_, nbins_;
+        int begin_ = 0;
+        int end_ = 0;
+        int nbins_;
         struct Block { 
             int index, begin, end; 
             Block(int i, int begin_, int end_) : index(i), begin(begin_), end(end_) {}
@@ -335,7 +337,9 @@ class FastVerticalInterpHistPdf2V {
         void fill(std::vector<Double_t> &out) const ;
     private:
         const FastVerticalInterpHistPdf2 & hpdf_;
-        int begin_, end_, nbins_;
+        int begin_ = 0;
+        int end_ = 0;
+        int nbins_;
         struct Block { 
             int index, begin, end; 
             Block(int i, int begin_, int end_) : index(i), begin(begin_), end(end_) {}

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -257,9 +257,7 @@ cacheutils::CachingPdf::CachingPdf(RooAbsReal *pdf, const RooArgSet *obs)
                : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE")
                       ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_)
                       : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
-      lastData_(0),
-      cache_(*pdf_, *obs_),
-      includeZeroWeights_(false) {
+      cache_(*pdf_, *obs_) {
   if (runtimedef::get("CACHINGPDF_DIRECT") || pdf->getAttribute("CachingPdf_Direct")) {
     cache_.setDirectMode(true);
   }
@@ -275,7 +273,6 @@ cacheutils::CachingPdf::CachingPdf(const CachingPdf &other)
                : (runtimedef::get("CACHINGPDF_NOCHEAPCLONE")
                       ? utils::fullCloneFunc(pdfOriginal_, pdfPieces_)
                       : utils::fullCloneFunc(pdfOriginal_, *obs_, pdfPieces_))),
-      lastData_(0),
       cache_(*pdf_, *obs_),
       includeZeroWeights_(other.includeZeroWeights_) {
   if (runtimedef::get("CACHINGPDF_DIRECT") ||
@@ -388,9 +385,7 @@ cacheutils::CachingAddNLL::CachingAddNLL(const char *name, const char *title, Ro
     pdf_(pdf),
     params_("params","parameters",this),
     catParams_("catParams","RooCategory parameters",this),
-    includeZeroWeights_(includeZeroWeights),
-    zeroPoint_(0),
-    constantZeroPoint_(0)
+    includeZeroWeights_(includeZeroWeights)
 {
     if (pdf == 0) throw std::invalid_argument(std::string("Pdf passed to ")+name+" is null");
     setData(*data);
@@ -404,9 +399,7 @@ cacheutils::CachingAddNLL::CachingAddNLL(const CachingAddNLL &other, const char 
     pdf_(other.pdf_),
     params_("params","parameters",this),
     catParams_("catParams","RooCategory parameters",this),
-    includeZeroWeights_(other.includeZeroWeights_),
-    zeroPoint_(0),
-    constantZeroPoint_(0)
+    includeZeroWeights_(other.includeZeroWeights_)
 {
     setData(*other.data_);
     setup_();
@@ -870,8 +863,7 @@ cacheutils::CachingSimNLL::CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data,
     dataOriginal_(data),
     nuis_(nuis),
     params_("params","parameters",this),
-    catParams_("catParams","Category parameters",this),
-    hideRooCategories_(false), hideConstants_(false), maskConstraints_(false), maskingOffset_(0), maskingOffsetZero_(0)
+    catParams_("catParams","Category parameters",this)
 {
     setup_();
 }

--- a/src/CascadeMinimizer.cc
+++ b/src/CascadeMinimizer.cc
@@ -47,11 +47,7 @@ CascadeMinimizer::CascadeMinimizer(RooAbsReal &nll, Mode mode, RooRealVar *poi) 
     nll_(nll),
     mode_(mode),
     //strategy_(0),
-    poi_(poi),
-    nuisances_(0),
-    autoBounds_(false),
-    poisForAutoBounds_(0),
-    poisForAutoMax_(0)
+    poi_(poi)
 {
     remakeMinimizer();
 }
@@ -795,13 +791,13 @@ void CascadeMinimizer::applyOptions(const boost::program_options::variables_map 
 	    std::string type; 
             float tolerance = Algo::default_tolerance(); 
             int   strategy = Algo::default_strategy(); 
-            string::size_type idx = std::min(algo.find(";"), algo.find(":"));
+            string::size_type idx = std::min(algo.find(';'), algo.find(':'));
             if (idx != string::npos && idx < algo.length()) {
                  tolerance = atof(algo.substr(idx+1).c_str());
                  algo      = algo.substr(0,idx); // DON'T SWAP THESE TWO LINES
 		 type	   = std::string(defaultMinimizerType_);
             }
-            idx = algo.find(",");
+            idx = algo.find(',');
             if (idx != string::npos && idx < algo.length()) {
                 // if after the comma there's a number, then it's a strategy
                 if ( '0' <= algo[idx+1] && algo[idx+1] <= '9' ) {

--- a/src/CloseCoutSentry.cc
+++ b/src/CloseCoutSentry.cc
@@ -17,7 +17,7 @@ CloseCoutSentry *CloseCoutSentry::owner_ = 0;
 
 
 CloseCoutSentry::CloseCoutSentry(bool silent) :
-    silent_(silent), stdOutIsMine_(false)
+    silent_(silent)
 {
     if (silent_) {
         if (open_) {

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -219,7 +219,7 @@ std::string Combine::parseRegex(std::string instr, const RooArgSet *nuisances, R
   // expand regexps inside the "rgx{}" option
   while (instr.find("rgx{") != std::string::npos) {          
     size_t pos1 = instr.find("rgx{");
-    size_t pos2 = instr.find("}",pos1);
+    size_t pos2 = instr.find('}',pos1);
     std::string prestr = instr.substr(0,pos1);
     std::string poststr = instr.substr(pos2+1,instr.size()-pos2);
     std::string reg_esp = instr.substr(pos1+4,pos2-pos1-4);
@@ -242,7 +242,7 @@ std::string Combine::parseRegex(std::string instr, const RooArgSet *nuisances, R
   // expand regexps inside the "var{}" option        
   while (instr.find("var{") != std::string::npos) {          
     size_t pos1 = instr.find("var{");
-    size_t pos2 = instr.find("}",pos1);
+    size_t pos2 = instr.find('}',pos1);
     std::string prestr = instr.substr(0,pos1);
     std::string poststr = instr.substr(pos2+1,instr.size()-pos2);
     std::string reg_esp = instr.substr(pos1+4,pos2-pos1-4);
@@ -556,18 +556,18 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     }
   }
 
-  if (dataset.find(":") != std::string::npos) {
+  if (dataset.find(':') != std::string::npos) {
     std::string filename, wspname, dname;
     switch (std::count(dataset.begin(), dataset.end(), ':')) {
         case 2: // file:wsp:dataset
-            filename = dataset.substr(                   0, dataset.find(":"));
-            wspname  = dataset.substr( dataset.find(":")+1, dataset.rfind(":")-dataset.find(":")-1);
-            dname    = dataset.substr(dataset.rfind(":")+1, std::string::npos);
+            filename = dataset.substr(                   0, dataset.find(':'));
+            wspname  = dataset.substr( dataset.find(':')+1, dataset.rfind(':')-dataset.find(':')-1);
+            dname    = dataset.substr(dataset.rfind(':')+1, std::string::npos);
             if (verbose) std::cout << "Will read dataset '" << dname << "' from workspace '" << wspname << "' of file '" << filename << "'" << std::endl;
             break;
         case 1:
-            filename = dataset.substr(                  0, dataset.find(":"));
-            dname    = dataset.substr(dataset.find(":")+1, std::string::npos);
+            filename = dataset.substr(                  0, dataset.find(':'));
+            dname    = dataset.substr(dataset.find(':')+1, std::string::npos);
             if (verbose) std::cout << "Will read dataset '" << dname << "' from file '" << filename << "'" << std::endl;
             break;
         default:

--- a/src/FitDiagnostics.cc
+++ b/src/FitDiagnostics.cc
@@ -65,15 +65,7 @@ bool        FitDiagnostics::saveWithUncertsRequested_=false;
 bool        FitDiagnostics::ignoreCovWarning_=false;
 
 
-FitDiagnostics::FitDiagnostics() :
-    FitterAlgoBase("FitDiagnostics specific options"),
-    globalObservables_(0),
-    nuisanceParameters_(0),
-    processNormalizations_(0),
-    processNormalizationsShapes_(0),
-    t_fit_b_(nullptr),
-    t_fit_sb_(nullptr),
-    t_prefit_(nullptr)
+FitDiagnostics::FitDiagnostics() : FitterAlgoBase("FitDiagnostics specific options")
 {
     options_.add_options()
         ("minos",              	boost::program_options::value<std::string>(&minos_)->default_value(minos_), "Compute MINOS errors for: 'none', 'poi', 'all'")
@@ -1405,8 +1397,7 @@ void FitDiagnostics::createFitResultTrees(const RooStats::ModelConfig &mc, bool 
 }
 
 FitDiagnostics::ToySampler::ToySampler(RooAbsPdf *pdf, const RooArgSet *nuisances) :
-    pdf_(pdf),
-    data_(0)
+    pdf_(pdf)
 {
     nuisances->snapshot(snapshot_);
 }

--- a/src/FnTimer.cc
+++ b/src/FnTimer.cc
@@ -24,7 +24,7 @@ std::string GetQualififedName(std::string const& str) {
 
 
 // Implementation of FnTimer ("Function Timer") class
-FnTimer::FnTimer(std::string name) : name_(name), calls_(0), elapsed_(0.), elapsed_overhead_(0.) {}
+FnTimer::FnTimer(std::string name) : name_(name) {}
 FnTimer::~FnTimer() {
   printf(
       "[Timer] %-40s Calls: %-20u Total [s]: %-20.5g Per-call [s]: %-20.5g\n",

--- a/src/RandStartPt.cc
+++ b/src/RandStartPt.cc
@@ -47,9 +47,9 @@ std::vector<std::vector<float>> RandStartPt::vectorOfPointsToTry (){
     int n_prof_params = specifiedvars_.size();
 
     if(!skipdefaultstart_) {
-        std::vector<float> default_start_pt_vec;
+        std::vector<float> default_start_pt_vec(n_prof_params);
         for (int prof_param_idx = 0; prof_param_idx<n_prof_params; prof_param_idx++){
-            default_start_pt_vec.push_back(specifiedvars_[prof_param_idx]->getVal());
+            default_start_pt_vec[prof_param_idx] = specifiedvars_[prof_param_idx]->getVal();
         }
         wc_vals_vec_of_vec.push_back(default_start_pt_vec);
     }

--- a/src/RobustHesse.cc
+++ b/src/RobustHesse.cc
@@ -424,9 +424,9 @@ int RobustHesse::hesse() {
     for (int ei = 0; ei < eigenvals.GetNrows(); ++ei) {
       if (eigenvals[ei] < 0.) have_negative_eigenvalues = true;
 
-      std::vector<std::pair<unsigned, double>> eigenvec;
+      std::vector<std::pair<unsigned, double>> eigenvec(eigenvecs.GetNrows());
       for (int ej = 0; ej < eigenvecs.GetNrows(); ++ej) {
-        eigenvec.push_back(std::make_pair(unsigned(ej), eigenvecs[ej][ei]));
+        eigenvec[ej] = std::make_pair(unsigned(ej), eigenvecs[ej][ei]);
       }
       if ((!print_only_negative) || (print_only_negative && eigenvals[ei] < 0.)) {
         std::cout << "Eigenvalue " << ei << " : " << eigenvals[ei] << "\n";

--- a/src/Significance.cc
+++ b/src/Significance.cc
@@ -90,8 +90,8 @@ Significance::MinimizerSentry::MinimizerSentry(const std::string &minimizerAlgo,
     minimizerTollBackup(ROOT::Math::MinimizerOptions::DefaultTolerance())
 {
   ROOT::Math::MinimizerOptions::SetDefaultTolerance(tolerance);
-  if (minimizerAlgo.find(",") != std::string::npos) {
-      size_t idx = minimizerAlgo.find(",");
+  if (minimizerAlgo.find(',') != std::string::npos) {
+      size_t idx = minimizerAlgo.find(',');
       std::string type = minimizerAlgo.substr(0,idx), algo = minimizerAlgo.substr(idx+1);
       if (verbose > 1) std::cout << "Set default minimizer to " << type << ", algorithm " << algo << ", tolerance " << tolerance << std::endl;
       ROOT::Math::MinimizerOptions::SetDefaultMinimizer(type.c_str(), algo.c_str());

--- a/src/ToyMCSamplerOpt.cc
+++ b/src/ToyMCSamplerOpt.cc
@@ -21,9 +21,7 @@ using namespace std;
 ToyMCSamplerOpt::ToyMCSamplerOpt(RooStats::TestStatistic& ts, Int_t ntoys, RooAbsPdf *globalObsPdf, bool generateNuisances) :
     ToyMCSampler(ts, ntoys),
     globalObsPdf_(globalObsPdf),
-    globalObsValues_(0), globalObsIndex_(-1),
-    nuisValues_(0), nuisIndex_(-1), genNuis_(generateNuisances),
-    weightVar_(0)
+     genNuis_(generateNuisances)
 {
     if (!generateNuisances) fPriorNuisance = 0; // set things straight from the beginning
 }
@@ -66,8 +64,7 @@ ToyMCSamplerOpt::~ToyMCSamplerOpt()
 toymcoptutils::SinglePdfGenInfo::SinglePdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents, bool canUseSpec) :
    mode_(pdf.canBeExtended() ? (preferBinned ? Binned : Unbinned) : Counting),
    pdf_(&pdf),
-   canUseSpec_(canUseSpec),
-   spec_(0),histoSpec_(0),keepHistoSpec_(0),weightVar_(0)
+   canUseSpec_(canUseSpec)
 {
    if (pdf.canBeExtended()) {
        if (pdf.getAttribute("forceGenBinned")) mode_ = Binned;
@@ -318,9 +315,7 @@ toymcoptutils::SinglePdfGenInfo::setToExpected(RooPoisson &pois, RooArgSet &obs)
 
 toymcoptutils::SimPdfGenInfo::SimPdfGenInfo(RooAbsPdf &pdf, const RooArgSet& observables, bool preferBinned, const RooDataSet* protoData, int forceEvents, bool canUseSpec) :
     pdf_(&pdf),
-    cat_(0),
-    observables_(observables),
-    copyData_(true)
+    observables_(observables)
 {
     assert(forceEvents == 0 && "SimPdfGenInfo: forceEvents must be zero.");
     RooSimultaneous *simPdf = dynamic_cast<RooSimultaneous *>(&pdf);

--- a/src/VectorizedHistFactoryPdfs.cc
+++ b/src/VectorizedHistFactoryPdfs.cc
@@ -3,7 +3,7 @@
 #include <RooRealVar.h>
 
 cacheutils::VectorizedHistFunc::VectorizedHistFunc(const RooHistFunc &pdf, bool includeZeroWeights) :
-    pdf_(&pdf), data_(0), includeZeroWeights_(includeZeroWeights)
+    pdf_(&pdf), includeZeroWeights_(includeZeroWeights)
 {
 }
 

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -650,7 +650,7 @@ void FastVerticalInterpHistPdf3D::setupCaches() const {
 
 
 FastVerticalInterpHistPdfV::FastVerticalInterpHistPdfV(const FastVerticalInterpHistPdf &hpdf, const RooAbsData &data, bool includeZeroWeights) :
-    hpdf_(hpdf),begin_(0),end_(0)
+    hpdf_(hpdf)
 {
     // check init
     if (hpdf._cache.size() == 0) hpdf.setupCaches();
@@ -1141,7 +1141,7 @@ Double_t FastVerticalInterpHistPdf2D2::maxVal(int code) const {
 }
 
 FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &hpdf, const RooAbsData &data, bool includeZeroWeights) :
-    hpdf_(hpdf),begin_(0),end_(0)
+    hpdf_(hpdf)
 {
     // check init
     if (!hpdf._initBase) hpdf.initBase();

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -716,7 +716,7 @@ void utils::setModelParameters( const std::string & setPhysicsModelParameterExpr
                line=line.substr(string("RooRealVar::").size()) ;//Remove RooRealVar::
                string tosearch=" = ",replace="=";
                line.replace(line.find(tosearch), tosearch.size(), replace);
-               line=line.substr(0,line.find("+"));
+               line=line.substr(0,line.find('+'));
                line=line.substr(0,line.find(" C "));
 
             }
@@ -816,10 +816,10 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
                //RooRealVar::cms_ps = -0.013155 +/- 0.995142  L(-INF - +INF) 
                line=line.substr(string("RooRealVar::").size()) ;//Remove RooRealVar::
                string newline=line.substr(0,line.find(" = "));
-               size_t pos1=line.find("=")+1, pos2=line.find(" +/- ");
+               size_t pos1=line.find('=')+1, pos2=line.find(" +/- ");
                float value=std::atof(line.substr(pos1, pos2-pos1).c_str());
                std::cout<<"->Obtaining value from:"<<pos1<<","<<pos2<<":"<<line.substr(pos1, pos2-pos1).c_str()<<std::endl;
-               size_t pos3=line.find(" ",pos2+5);
+               size_t pos3=line.find(' ',pos2+5);
                float err = std::atof(line.substr(pos2+5,pos3-(pos2+5)).c_str());
                float mult=7; // arbitrary number
                std::cout<<"Range manipulation result: "<<newline<<"="<< value<<"+/-"<<err<<"Mult factor"<<mult<<std::endl;
@@ -908,7 +908,7 @@ void utils::check_inf_parameters(const RooArgSet & params, int verbosity) {
 }
 
 void utils::createSnapshotFromString( const std::string expression, const RooArgSet &allvars, RooArgSet &output, const char *context) {
-    if (expression.find("=") == std::string::npos) {
+    if (expression.find('=') == std::string::npos) {
         if (allvars.getSize() != 1) throw std::invalid_argument(std::string("Error: the argument to ")+context+" is a single value, but there are multiple variables to choose from");
         allvars.snapshot(output);
         errno = 0; // check for errors in str->float conversion
@@ -917,8 +917,8 @@ void utils::createSnapshotFromString( const std::string expression, const RooArg
     } else {
         std::string::size_type eqidx = 0, colidx = 0, colidx2;
         do {
-            eqidx   = expression.find("=", colidx);
-            colidx2 = expression.find(",", colidx+1);
+            eqidx   = expression.find('=', colidx);
+            colidx2 = expression.find(',', colidx+1);
             if (eqidx == std::string::npos || (colidx2 != std::string::npos && colidx2 < eqidx)) {
                 throw std::invalid_argument(std::string("Error: the argument to ")+context+" is not in the form 'value' or 'name1=value1,name2=value2,...'\n");
             }


### PR DESCRIPTION
Add a few more clang-tidy checks and apply them to the codebase.

The most important check here is `modernize-use-default-member-init`, because it helps to ensure that we do default member variable initialization. Doing this consistently helps to avoid undefined behavior.

How this was done:

```
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=../install -DINSTALL_PYTHON=FALSE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
make -j12
run-clang-tidy -config-file=../.clang-tidy -export-fixes fixes.yaml -header-filter="interface/.*" .
mv fixes.yaml ..
cd ..
clang-apply-replacements .
```