### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -309,7 +309,9 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
   TString tmpDir = "", tmpFile = "", pwd(gSystem->pwd());
   if (makeTempDir_) { 
       tmpDir = "roostats-XXXXXX"; tmpFile = "model";
-      mkdtemp(const_cast<char *>(tmpDir.Data()));
+      if (mkdtemp(const_cast<char *>(tmpDir.Data())) == nullptr) {
+          throw std::runtime_error("Temporary file could not be created");
+      }
       gSystem->cd(tmpDir.Data());
       garbageCollect.path = tmpDir.Data(); // request that we delete this dir when done
   } else if (!hlfFile.EndsWith(".hlf") && !hlfFile.EndsWith(".root")) {

--- a/src/HZZ4L_RooCTauPdf_1D.cc
+++ b/src/HZZ4L_RooCTauPdf_1D.cc
@@ -128,17 +128,10 @@ Int_t HZZ4L_RooCTauPdf_1D::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& 
 }
 Double_t HZZ4L_RooCTauPdf_1D::analyticalIntegral(Int_t code, const char* rangeName) const
 {
-	switch (code)
-	{
-	case 1:
-		{
-			double integral = interpolateIntegral();
-			if( integral <= 0 ) integral = 1.0e-10;
-			return integral;
-		}
-	default:
-		cerr << "getAnalyticalIntegral failed, so analytical integration did not complete!" << endl;
-		assert(0);
-	}
+  R__ASSERT(code == 1);
+
+  double integral = interpolateIntegral();
+  if( integral <= 0 ) integral = 1.0e-10;
+  return integral;
 }
 

--- a/src/HZZ4L_RooCTauPdf_1D_Expanded.cc
+++ b/src/HZZ4L_RooCTauPdf_1D_Expanded.cc
@@ -304,17 +304,10 @@ Int_t HZZ4L_RooCTauPdf_1D_Expanded::getAnalyticalIntegral(RooArgSet& allVars, Ro
 }
 Double_t HZZ4L_RooCTauPdf_1D_Expanded::analyticalIntegral(Int_t code, const char* rangeName) const
 {
-	switch (code)
-	{
-	case 1:
-		{
-			double integral = interpolateIntegral();
-			if( integral <= 0 ) integral = 1.0e-10;
-			return integral;
-		}
-	default:
-		cerr << "getAnalyticalIntegral failed, so analytical integration did not complete!" << endl;
-		assert(0);
-	}
+  R__ASSERT(code == 1);
+
+  double integral = interpolateIntegral();
+  if( integral <= 0 ) integral = 1.0e-10;
+  return integral;
 }
 

--- a/src/HZZ4L_RooCTauPdf_2D.cc
+++ b/src/HZZ4L_RooCTauPdf_2D.cc
@@ -129,17 +129,10 @@ Int_t HZZ4L_RooCTauPdf_2D::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& 
 }
 Double_t HZZ4L_RooCTauPdf_2D::analyticalIntegral(Int_t code, const char* rangeName) const
 {
-	switch (code)
-	{
-	case 1:
-		{
-			double integral = interpolateIntegral();
-			if( integral <= 0 ) integral = 1.0e-10;
-			return integral;
-		}
-	default:
-		cerr << "getAnalyticalIntegral failed, so analytical integration did not complete!" << endl;
-		assert(0);
-	}
+  R__ASSERT(code == 1);
+
+  double integral = interpolateIntegral();
+  if( integral <= 0 ) integral = 1.0e-10;
+  return integral;
 }
 

--- a/src/HybridNew.cc
+++ b/src/HybridNew.cc
@@ -14,6 +14,7 @@
 #include <TCanvas.h>
 #include <TGraphErrors.h>
 #include <TStopwatch.h>
+#include <TSystem.h>
 #include <TRandom3.h>
 #include <TTree.h>
 #include "RooRealVar.h"
@@ -296,6 +297,7 @@ bool HybridNew::run(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::Mode
                                    return runTestStatistics(w, mc_s, mc_b, data, limit, limitErr, hint);
     }
     assert("Shouldn't get here" == 0);
+    return false;
 }
 
 bool HybridNew::runSignificance(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats::ModelConfig *mc_b, RooAbsData &data, double &limit, double &limitErr, const double *hint) {
@@ -1382,8 +1384,14 @@ RooStats::HypoTestResult * HybridNew::evalWithFork(RooStats::HybridCalculator &h
         }
     } else {
         RooRandom::randomGenerator()->SetSeed(newSeeds[ich]);
-        freopen(TString::Format("%s.%d.out.txt", tmpfile, ich).Data(), "w", stdout);
-        freopen(TString::Format("%s.%d.err.txt", tmpfile, ich).Data(), "w", stderr);
+        if(freopen(TString::Format("%s.%d.out.txt", tmpfile, ich).Data(), "w", stdout) == nullptr) {
+          SysError("RedirectOutput", "could not freopen stdout (errno: %d)", TSystem::GetErrno());
+          return result.release(); // nullptr at this point
+        }
+        if(freopen(TString::Format("%s.%d.err.txt", tmpfile, ich).Data(), "w", stderr) == nullptr) {
+          SysError("RedirectOutput", "could not freopen stderr (errno: %d)", TSystem::GetErrno());
+          return result.release(); // nullptr at this point
+        }
         CombineLogger::instance().log("HybridNew.cc",__LINE__,std::string(Form("  I am child %d, seed %d",ich, newSeeds[ich])),__func__);
         RooStats::HypoTestResult *hcResult = evalGeneric(hc, /*noFork=*/true);
         TFile *f = TFile::Open(TString::Format("%s.%d.root", tmpfile, ich), "RECREATE");

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -1138,6 +1138,7 @@ Double_t FastVerticalInterpHistPdf2D2::maxVal(int code) const {
 			  << ") unsupported integration code " << code << "\n" << std::endl;
     assert(0);
 
+    return 0.0;
 }
 
 FastVerticalInterpHistPdf2V::FastVerticalInterpHistPdf2V(const FastVerticalInterpHistPdf2 &hpdf, const RooAbsData &data, bool includeZeroWeights) :


### PR DESCRIPTION
Fix warnings about the control reaching the end of non-void functions and unused return values.

Especially the former warnings are important to fix, because forgetting to return from a function can result in undefined behavior.