### PR TITLE
differentiate between rateParams with and without formulas when combining datacards

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -469,14 +469,31 @@ for pname, pargs in paramSysts.items():
 
 for pname in six.iterkeys(flatParamNuisances):
     print("%-12s  flatParam" % pname)
+
+# filter rateParams to only include those that are not any formulas
+rateParams_withFormula = list(filter(
+    lambda x: any(entry[0][-1] == 1 for entry in x[-1] if isinstance(entry, list)),
+    rateParamsPerCard,
+))
+
+# first process all parameters that do not contain formulars
 for tbin, tproc, params in rateParamsPerCard:
-    for param in params:
+    simple_params = list(filter(lambda x: x[0][-1] != 1, params))
+    for param in simple_params:
         print("%-12s  rateParam %s %s %s" % (param[0][0], tbin + " " + tproc, " ".join(param[0][1:-1]), param[1]))
         # param[0][-1] is parameter type, see DatacardParser:addRateParam()
 for dname in six.iterkeys(discreteNuisances):
     print("%-12s  discrete" % dname)
 for ext in six.iterkeys(extArgs):
     print("%s" % " ".join(extArgs[ext]))
+
+# after including all the 'simple' parameters, include the ones with formulas
+for tbin, tproc, params in rateParams_withFormula:
+    forumla_params = list(filter(lambda x: x[0][-1] == 1, params))
+    for param in forumla_params:
+        print("%-12s  rateParam %s %s %s" % (param[0][0], tbin + " " + tproc, " ".join(param[0][1:-1]), param[1]))
+
+
 for groupName, nuisanceNames in six.iteritems(groups):
     nuisances = " ".join(nuisanceNames)
     print("%(groupName)s group = %(nuisances)s" % locals())

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -471,10 +471,12 @@ for pname in six.iterkeys(flatParamNuisances):
     print("%-12s  flatParam" % pname)
 
 # filter rateParams to only include those that are not any formulas
-rateParams_withFormula = list(filter(
-    lambda x: any(entry[0][-1] == 1 for entry in x[-1] if isinstance(entry, list)),
-    rateParamsPerCard,
-))
+rateParams_withFormula = list(
+    filter(
+        lambda x: any(entry[0][-1] == 1 for entry in x[-1] if isinstance(entry, list)),
+        rateParamsPerCard,
+    )
+)
 
 # first process all parameters that do not contain formulars
 for tbin, tproc, params in rateParamsPerCard:


### PR DESCRIPTION
When combining multiple datacards, the order of `rateParams` is fixed in order to account for possible differences between multiple datacards. This makes parsing the combined datacard down the line easier.

However, this can also have the effect that `rateParams` that contain formulars can be defined before the underlying parameters they are based on are defined in the datacard. For combine (specifically `text2workspace.py`), this makes no difference because of the logic that is used when parsing a datacard. The current version of the CombineHarvester cannot handle this though. This has become a problem in the CMS datacard validation pipeline, see [this test example](https://gitlab.cern.ch/cms-analysis/hig/hig-24-003/datacards/-/pipelines/10415195).

This PR introduces a fix where `rateParams` that contain a formular are de-prioritized in favor of simple `rateParams` (i.e. w/o formulars), discrete and flat parameters. Only after these parameters have been parsed, the formular-based parameters are written to the combined datacard. Long term, this should not be needed since we want to unify the CombineHarvester and combine. However, since this could still take a while, this PR would fix the issue we're facing right now. Additionally, the structure of the datacard becomes more logical imho since formulars can no longer be defined before the underlying parameters by accident. 