### PR TITLE
Override `compileForNormSet()` in VerticalInterpPdf 

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -29,9 +29,9 @@ jobs:
             SCRAM_ARCH: "el8_amd64_gcc12"
             ROOT: "ROOT v6.32/06"
           - IMAGE: "cmscloud/al8-cms"
-            CMSSW_VERSION: "CMSSW_14_2_0_pre4_ROOT635" 
+            CMSSW_VERSION: "CMSSW_15_1_ROOT6_X_2025-03-30-2300"
             SCRAM_ARCH: "el8_amd64_gcc12"
-            ROOT: "ROOT v6.35/01"            
+            ROOT: "ROOT v6.35/01"
     env:
       docker_opt_rw: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit  --mount source=cmsusr,destination=/home/cmsusr -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
       docker_opt_ro: -v /cvmfs:/cvmfs:shared -v cmsusr:/home/cmsusr/cmssw/:ro -w /home/cmsusr/ -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -20,11 +20,10 @@ class FastVerticalInterpHistPdf2D2;
 class VerticalInterpHistPdf : public RooAbsPdf {
 public:
 
-  VerticalInterpHistPdf() ;
+  VerticalInterpHistPdf() = default;
   VerticalInterpHistPdf(const char *name, const char *title, const RooRealVar &x, const RooArgList& funcList, const RooArgList& coefList, Double_t smoothRegion=1., Int_t smoothAlgo=1) ;
   VerticalInterpHistPdf(const VerticalInterpHistPdf& other, const char* name=0) ;
   TObject* clone(const char* newname) const override { return new VerticalInterpHistPdf(*this,newname) ; }
-  ~VerticalInterpHistPdf() override ;
 
   Bool_t selfNormalized() const override { return kTRUE; }
 
@@ -49,11 +48,11 @@ protected:
 
   // TH1 containing the histogram of this pdf
   mutable SimpleCacheSentry _sentry; // !not to be serialized
-  mutable TH1  *_cacheTotal;     //! not to be serialized
+  mutable std::unique_ptr<TH1> _cacheTotal;     //! not to be serialized
   // For additive morphing, histograms of fNominal, fUp and fDown
   // For multiplicative morphing, histograms of fNominal, log(fUp/fNominal), -log(fDown/fNominal);
-  mutable TH1  **_cacheSingle; //! not to be serialized
-  mutable int  *_cacheSingleGood; //! not to be serialized
+  mutable std::vector<std::unique_ptr<TH1>> _cacheSingle; //! not to be serialized
+  mutable std::vector<int>  _cacheSingleGood; //! not to be serialized
 private:
 
   ClassDefOverride(VerticalInterpHistPdf,1) // 

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -28,6 +28,9 @@ public:
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
 
+  const Double_t quadraticRegion() const { return _quadraticRegion; }
+  const Int_t quadraticAlgo() const { return _quadraticAlgo; }
+
   void setFloorVals(Double_t const& pdf_val, Double_t const& integral_val);
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,34,06)

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -30,6 +30,10 @@ public:
 
   void setFloorVals(Double_t const& pdf_val, Double_t const& integral_val);
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,34,06)
+  std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
+#endif
+
 protected:
   
   class CacheElem : public RooAbsCacheElement {

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -6,17 +6,15 @@
 
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
-#include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
 
 class VerticalInterpPdf : public RooAbsPdf {
 public:
 
-  VerticalInterpPdf() ;
+  VerticalInterpPdf() = default;
   VerticalInterpPdf(const char *name, const char *title, const RooArgList& funcList, const RooArgList& coefList, Double_t quadraticRegion=0., Int_t quadraticAlgo=0) ;
   VerticalInterpPdf(const VerticalInterpPdf& other, const char* name=0) ;
   TObject* clone(const char* newname) const override { return new VerticalInterpPdf(*this,newname) ; }
-  ~VerticalInterpPdf() override ;
 
   Double_t evaluate() const override ;
   Bool_t checkObservables(const RooArgSet* nset) const override ;	
@@ -42,7 +40,6 @@ protected:
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem()  {} ;
-    ~CacheElem() override {} ; 
     RooArgList containedArgs(Action) override { RooArgList ret(_funcIntList) ; ret.add(_funcNormList) ; return ret ; }
     RooArgList _funcIntList ;
     RooArgList _funcNormList ;
@@ -51,11 +48,11 @@ protected:
 
   RooListProxy _funcList ;   //  List of component FUNCs
   RooListProxy _coefList ;  //  List of coefficients
-  Double_t     _quadraticRegion;
+  Double_t     _quadraticRegion = 0;
   Int_t        _quadraticAlgo;
 
-  Double_t _pdfFloorVal; // PDF floor should be customizable, default is 1e-15
-  Double_t _integralFloorVal; // PDF integral floor should be customizable, default is 1e-10
+  Double_t _pdfFloorVal = 1e-15; // PDF floor should be customizable, default is 1e-15
+  Double_t _integralFloorVal = 1e-10; // PDF integral floor should be customizable, default is 1e-10
 
   Double_t interpolate(Double_t coeff, Double_t central, RooAbsReal *fUp, RooAbsReal *fDown) const ; 
 

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -96,26 +96,13 @@ ClassImp(VerticalInterpHistPdf)
 
 
 //_____________________________________________________________________________
-VerticalInterpHistPdf::VerticalInterpHistPdf() :
-   _cacheTotal(0),
-   _cacheSingle(0),
-   _cacheSingleGood(0) 
-{
-  // Default constructor
-}
-
-
-//_____________________________________________________________________________
 VerticalInterpHistPdf::VerticalInterpHistPdf(const char *name, const char *title, const RooRealVar &x, const RooArgList& inFuncList, const RooArgList& inCoefList, Double_t smoothRegion, Int_t smoothAlgo) :
   RooAbsPdf(name,title),
   _x("x","Independent variable",this,const_cast<RooRealVar&>(x)),
   _funcList("funcList","List of pdfs",this),
   _coefList("coefList","List of coefficients",this), // we should get shapeDirty when coefficients change
   _smoothRegion(smoothRegion),
-  _smoothAlgo(smoothAlgo),
-  _cacheTotal(0),
-  _cacheSingle(0),
-  _cacheSingleGood(0) 
+  _smoothAlgo(smoothAlgo)
 { 
 
   if (inFuncList.getSize()!=2*inCoefList.getSize()+1) {
@@ -130,12 +117,11 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const char *name, const char *title
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") function  " << func->GetName() << " is not of type RooAbsPdf" << std::endl;
       assert(0);
     }
-    RooArgSet *params = pdf->getParameters(RooArgSet(x));
+    std::unique_ptr<RooArgSet> params{pdf->getParameters(RooArgSet(x))};
     if (params->getSize() > 0) {
       coutE(InputArguments) << "ERROR: VerticalInterpHistPdf::VerticalInterpHistPdf(" << GetName() << ") pdf  " << func->GetName() << " has some parameters." << std::endl;
       assert(0);
     }
-    delete params;
     _funcList.add(*func) ;
   }
 
@@ -158,32 +144,16 @@ VerticalInterpHistPdf::VerticalInterpHistPdf(const VerticalInterpHistPdf& other,
   _funcList("funcList",this,other._funcList),
   _coefList("coefList",this,other._coefList),
   _smoothRegion(other._smoothRegion),
-  _smoothAlgo(other._smoothAlgo),
-  _cacheTotal(0),
-  _cacheSingle(0),
-  _cacheSingleGood(0) 
+  _smoothAlgo(other._smoothAlgo)
 {
   // Copy constructor
 }
 
 
-
-//_____________________________________________________________________________
-VerticalInterpHistPdf::~VerticalInterpHistPdf()
-{
-  // Destructor
-  if (_cacheTotal) {
-      delete _cacheTotal;
-      for (int i = 0; i < _funcList.getSize(); ++i) delete _cacheSingle[i]; 
-      delete [] _cacheSingle;
-      delete [] _cacheSingleGood;
-  }
-}
-
 //_____________________________________________________________________________
 Double_t VerticalInterpHistPdf::evaluate() const 
 {
-  if (_cacheTotal == 0) setupCaches();
+  if (!_cacheTotal) setupCaches();
 #if 0
   printf("Evaluate called for x %f, cache status %d: ", _x.arg().getVal(), _sentry.good());
   int ndim = _coefList.getSize();
@@ -204,8 +174,7 @@ Double_t VerticalInterpHistPdf::evaluate() const
 
 void VerticalInterpHistPdf::syncComponent(int i) const {
     RooAbsPdf *pdfi = dynamic_cast<RooAbsPdf *>(_funcList.at(i));
-    if (_cacheSingle[i] != 0) delete _cacheSingle[i];
-    _cacheSingle[i] = pdfi->createHistogram("",dynamic_cast<const RooRealVar &>(_x.arg())); 
+    _cacheSingle[i] = std::unique_ptr<TH1>{pdfi->createHistogram("",dynamic_cast<const RooRealVar &>(_x.arg()))};
     _cacheSingle[i]->SetDirectory(0);
     if (_cacheSingle[i]->Integral("width")) { _cacheSingle[i]->Scale(1.0/_cacheSingle[i]->Integral("width")); }
     if (i > 0) {
@@ -265,12 +234,12 @@ void VerticalInterpHistPdf::syncTotal() const {
 
 void VerticalInterpHistPdf::setupCaches() const {
     int ndim = _coefList.getSize();
-    _cacheTotal     = (dynamic_cast<const RooRealVar &>(_x.arg())).createHistogram("total"); 
+    _cacheTotal = std::unique_ptr<TH1>{(dynamic_cast<const RooRealVar &>(_x.arg())).createHistogram("total")};
     _cacheTotal->SetDirectory(0);
-    _cacheSingle     = new TH1*[2*ndim+1]; assert(_cacheSingle);
-    _cacheSingleGood = new int[2*ndim+1];  assert(_cacheSingleGood);
+    _cacheSingle.resize(2*ndim+1);
+    _cacheSingleGood.resize(2*ndim+1);
     for (int i = 0; i < 2*ndim+1; ++i) { 
-        _cacheSingle[i] = 0; 
+        _cacheSingle[i] = nullptr;
         _cacheSingleGood[i] = 0; 
         syncComponent(i);  
     } 
@@ -937,10 +906,9 @@ void FastVerticalInterpHistPdf2::initNominal(TObject *templ) {
     } else {
         RooAbsPdf *pdf = dynamic_cast<RooAbsPdf *>(templ);
         const RooRealVar &x = dynamic_cast<const RooRealVar &>(_x.arg());
-        hist = pdf->createHistogram("",x);
+        std::unique_ptr<TH1> hist{pdf->createHistogram("",x)};
         hist->SetDirectory(0); 
         _cacheNominal = FastHisto(*hist);
-        delete hist;
     }
     _cacheNominal.Normalize();
     //printf("Normalized nominal templated: \n");  _cacheNominal.Dump(); 
@@ -952,18 +920,16 @@ void FastVerticalInterpHistPdf2::initNominal(TObject *templ) {
 }
 
 void FastVerticalInterpHistPdf2D2::initNominal(TObject *templ) {
-    TH2 *hist = dynamic_cast<TH2*>(templ);
-    if (hist) {
-        _cacheNominal = FastHisto2D(*hist, _conditional);
+    if (TH2 *templHist = dynamic_cast<TH2*>(templ)) {
+        _cacheNominal = FastHisto2D(*templHist, _conditional);
     } else {
         RooAbsPdf *pdf = dynamic_cast<RooAbsPdf *>(templ);
         const RooRealVar &x = dynamic_cast<const RooRealVar &>(_x.arg());
         const RooRealVar &y = dynamic_cast<const RooRealVar &>(_y.arg());
         const RooCmdArg &cond = _conditional ? RooFit::ConditionalObservables(RooArgSet(x)) : RooCmdArg::none();
-        hist = dynamic_cast<TH2*>(pdf->createHistogram("", x, RooFit::YVar(y), cond));
+        std::unique_ptr<TH1> hist{pdf->createHistogram("", x, RooFit::YVar(y), cond)};
         hist->SetDirectory(0); 
-        _cacheNominal = FastHisto2D(*hist, _conditional);
-        delete hist;
+        _cacheNominal = FastHisto2D(dynamic_cast<TH2&>(*hist), _conditional);
     }
     if (_conditional) _cacheNominal.NormalizeXSlices(); 
     else              _cacheNominal.Normalize(); 


### PR DESCRIPTION
The VerticalInterpPdf evaluates its input pdfs without a defined
normaliation set using `getVal()`, which is normally not allowed in
RooFit. The new CPU evaluation backend always propagates the
normalization set to the input functions, but given that the
VerticalInterpPdf uses bare `getVal()` calls, this would not be correct.

The sustainable solution would be to change VerticalInterpPdf such that
it evaluates its input with defined normSets, but this would require
some more validation.

The easier fix that this commit proposes is to hook into the compilation
of the model for a given normaliation set, which is used in RooFit CPU
evaluation backend. The same thing is also done in RooFit itself inside
the RooRealSumPdf, which is the class that inspired the
VerticalInterpPdf.

Also, clean the code a little bit to not add to the number of lines of code in Combine.