### PR TITLE
Bugfix for diffNuisances.py

### DIFF
--- a/test/diffNuisances.py
+++ b/test/diffNuisances.py
@@ -232,7 +232,8 @@ gr_fit_b.SetTitle("fit_b_g")
 gr_fit_s = ROOT.TGraphAsymmErrors()
 gr_fit_s.SetTitle("fit_b_s")
 
-if not options.skipFitS: error_poi = fpf_s.find(options.poi).getError()
+if not options.skipFitS:
+    error_poi = fpf_s.find(options.poi).getError()
 
 # loop over all fitted parameters
 for i in range(fpf_s.getSize()):
@@ -405,8 +406,10 @@ for i in range(fpf_s.getSize()):
 
     # end of loop over s and b
 
-    if not options.skipFitS: row += ["%+4.2f" % fit_s.correlation(name, options.poi)]
-    if not options.skipFitS: row += ["%+4.3f" % (nuis_x.getError() * fit_s.correlation(name, options.poi) * error_poi)]
+    if not options.skipFitS:
+        row += ["%+4.2f" % fit_s.correlation(name, options.poi)]
+    if not options.skipFitS:
+        row += ["%+4.3f" % (nuis_x.getError() * fit_s.correlation(name, options.poi) * error_poi)]
     if flag or options.show_all_parameters:
         table[name] = row
 

--- a/test/diffNuisances.py
+++ b/test/diffNuisances.py
@@ -565,9 +565,9 @@ for n in names:
     if sigsub != None:
         v = [re.sub(sigsub[0], sigsub[1], i) for i in v]
     if (n, "b") in isFlagged:
-        v[-2] = highlighters[isFlagged[(n, "b")]] % v[-2]
+        v[-4] = highlighters[isFlagged[(n, "b")]] % v[-4]
     if (n, "s") in isFlagged:
-        v[-1] = highlighters[isFlagged[(n, "s")]] % v[-1]
+        v[-3] = highlighters[isFlagged[(n, "s")]] % v[-3]
     if options.format == "latex":
         n = n.replace(r"_", r"\_")
     if options.absolute_values:


### PR DESCRIPTION
This script helps the user to make the nuisance parameters after fit with the method ``FitDiagnostics``. But if the user do a background-only fit (e.g. in a control region), they could use the option ``--skipSBFit``. The output file won't contain the fit-result object called "fit_s." Even if the user used ``--skipFitS``^[Different names...], the current script will still try to get the correlation and impact, which doesn't exist in "fit_b." Now these lines are executed only if ``--skipFitS`` is not selected. 

During the code-fixing, the highlight positions look odd as they would highlight rho and s+b fit (pulls). Now I highlight the fit (pulls).