### PR TITLE
Fix CMSHistErrorPropagator integration for the builds with ROOT>= 6.32  

### DIFF
--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -506,6 +506,9 @@ void CMSHistErrorPropagator::printMultiline(std::ostream& os, Int_t contents, Bo
 Int_t CMSHistErrorPropagator::getAnalyticalIntegral(RooArgSet& allVars,
                                          RooArgSet& analVars,
                                          const char* /*rangeName*/) const {
+  #if ROOT_VERSION_CODE >= ROOT_VERSION(6,32,0) // force x_ as CMSHistErrorPropagator dependent (needed since ROOT 6.32 to support analytic integration)
+  allVars.add(x_.arg());
+  #endif
   if (matchArgs(allVars, analVars, x_)) return 1;
   return 0;
 }

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -506,9 +506,7 @@ void CMSHistErrorPropagator::printMultiline(std::ostream& os, Int_t contents, Bo
 Int_t CMSHistErrorPropagator::getAnalyticalIntegral(RooArgSet& allVars,
                                          RooArgSet& analVars,
                                          const char* /*rangeName*/) const {
-  #if ROOT_VERSION_CODE >= ROOT_VERSION(6,32,0) // force x_ as CMSHistErrorPropagator dependent (needed since ROOT 6.32 to support analytic integration)
-  allVars.add(x_.arg());
-  #endif
+  if (allVars.find(x_.arg().GetName()) == nullptr) allVars.add(x_.arg());
   if (matchArgs(allVars, analVars, x_)) return 1;
   return 0;
 }

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -747,6 +747,7 @@ void CMSHistSum::printMultiline(std::ostream& os, Int_t contents, Bool_t verbose
 Int_t CMSHistSum::getAnalyticalIntegral(RooArgSet& allVars,
                                          RooArgSet& analVars,
                                          const char* /*rangeName*/) const {
+  if (allVars.find(x_.arg().GetName()) == nullptr) allVars.add(x_.arg());
   if (matchArgs(allVars, analVars, x_)) return 1;
   return 0;
 }


### PR DESCRIPTION
Quick fix addressing the issue https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/issues/1067 , adds the dependent back to the list of allVars, which is removed due to ROOT 6.32 updates [here](https://github.com/root-project/root/commit/2be3da117bc883d9f7d58fe66d3d96931925f8b1#diff-81fc18bbc8b0de47f01060358b761cfc554cd53ba6aa24d68c486c0f9b15844fR208) 
