### PR TITLE
Update CI implementation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - '**.cc'
       - '**.cxx'
       - '**.py'
+      - '**.yml'
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI/CD
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '**.h'
+      - '**.cc'
+      - '**.cxx'
+      - '**.py'
   push:
     branches:
       - main

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -28,10 +28,6 @@ jobs:
             CMSSW_VERSION: "CMSSW_14_2_0_pre2_ROOT632" 
             SCRAM_ARCH: "el8_amd64_gcc12"
             ROOT: "ROOT v6.32/06"
-          - IMAGE: "cmscloud/al8-cms"
-            CMSSW_VERSION: "CMSSW_15_1_ROOT6_X_2025-04-14-2300"
-            SCRAM_ARCH: "el8_amd64_gcc12"
-            ROOT: "ROOT v6.35/01"
     env:
       docker_opt_rw: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit  --mount source=cmsusr,destination=/home/cmsusr -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
       docker_opt_ro: -v /cvmfs:/cvmfs:shared -v cmsusr:/home/cmsusr/cmssw/:ro -w /home/cmsusr/ -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -8,6 +8,7 @@ on:
       - '**.cc'
       - '**.cxx'
       - '**.py'
+      - '**.yml'
   push:
     branches:
       - main

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -3,6 +3,11 @@ name: CI with CVMFS
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '**.h'
+      - '**.cc'
+      - '**.cxx'
+      - '**.py'
   push:
     branches:
       - main

--- a/.github/workflows/development-tests-ci.yml
+++ b/.github/workflows/development-tests-ci.yml
@@ -1,7 +1,10 @@
 name: CI with CVMFS for AD tests 
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [ labeled ]
+    branches: [ main ]
+
 
 jobs:
   test_workflow:

--- a/.github/workflows/development-tests-ci.yml
+++ b/.github/workflows/development-tests-ci.yml
@@ -1,0 +1,80 @@
+name: CI with CVMFS for AD tests 
+
+on:
+  pull_request:
+
+jobs:
+  test_workflow:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        IMAGE: ["cmscloud/al8-cms"]
+        CMSSW_VERSION: ["CMSSW_15_1_ROOT6_X_2025-04-27-2300"] 
+        SCRAM_ARCH: ["el9_amd64_gcc12"]
+        ROOT: ["ROOT v6.35/01"]
+        include:
+          - IMAGE: "cmscloud/al8-cms"
+            CMSSW_VERSION: "CMSSW_14_2_0_pre2_ROOT632" 
+            SCRAM_ARCH: "el8_amd64_gcc12"
+            ROOT: "ROOT v6.32/06"
+
+    env:
+      docker_opt_rw: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit  --mount source=cmsusr,destination=/home/cmsusr -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
+      docker_opt_ro: -v /cvmfs:/cvmfs:shared -v cmsusr:/home/cmsusr/cmssw/:ro -w /home/cmsusr/ -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
+    name: Test with ${{ matrix.CMSSW_VERSION }} and ${{ matrix.ROOT }} 
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
+        with:
+          cvmfs_repositories: 'cms.cern.ch'
+      - uses: rhaschke/docker-run-action@v5
+        name: Build Combine
+        with:
+          image: ${{ matrix.IMAGE }}
+          shell: bash
+          options: ${{env.docker_opt_rw}}
+          if: github.event.label.name == 'testAD' 
+          run: | 
+            cd /home/cmsusr/
+            source /cvmfs/cms.cern.ch/cmsset_default.sh
+            scram project ${CMSSW_VERSION}
+            cd ${CMSSW_VERSION}/src
+            cmsenv
+            mkdir -p HiggsAnalysis
+            cp -r /work/CombinedLimit HiggsAnalysis/
+            scramv1 b -j$(nproc)
+            echo ${PATH}
+            root --version
+            combine --help
+
+      - uses: rhaschke/docker-run-action@v5
+        name: Counting datacard
+        with:
+          image: ${{ matrix.IMAGE }}
+          shell: bash
+          options: ${{env.docker_opt_ro}}
+          if: github.event.label.name == 'testAD' 
+          run: |
+            cp -r cmssw/${CMSSW_VERSION} .
+            cd /home/cmsusr/${CMSSW_VERSION}/src
+            source /cvmfs/cms.cern.ch/cmsset_default.sh
+            cmsenv
+            text2workspace.py  HiggsAnalysis/CombinedLimit/data/tutorials/multiDim/toy-hgg-125.txt -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
+            combine -M MultiDimFit HiggsAnalysis/CombinedLimit/data/tutorials/multiDim/toy-hgg-125.root  --setParameterRanges r=-1,1
+
+      - uses: rhaschke/docker-run-action@v5
+        name: RooHistPdf
+        if: ${{ startsWith(matrix.CMSSW_VERSION, 'CMSSW_14') }}
+        with:
+          image: ${{ matrix.IMAGE }}
+          shell: bash
+          options: ${{env.docker_opt_ro}}
+          if: github.event.label.name == 'testAD' 
+          run: |
+            cp -r cmssw/${CMSSW_VERSION} .
+            cd /home/cmsusr/${CMSSW_VERSION}/src
+            source /cvmfs/cms.cern.ch/cmsset_default.sh
+            cmsenv
+            ulimit -s unlimited
+            text2workspace.py HiggsAnalysis/CombinedLimit/data/ci/datacard_RooHistPdf.txt.gz -o ws_RooHistPdf.root
+            combine -M MultiDimFit ws_RooHistPdf.root --algo singles -v -2  --setParameterRanges r=-1,2.

--- a/.github/workflows/development-tests-ci.yml
+++ b/.github/workflows/development-tests-ci.yml
@@ -12,9 +12,14 @@ jobs:
     strategy:
       matrix:
         IMAGE: ["cmscloud/al8-cms"]
-        CMSSW_VERSION: ["CMSSW_15_1_ROOT6_X_2025-04-27-2300"] 
-        SCRAM_ARCH: ["el9_amd64_gcc12"]
-        ROOT: ["ROOT v6.35/01"]
+        CMSSW_VERSION: ["CMSSW_15_1_ROOT634_X_2025-04-25-2300"]
+        SCRAM_ARCH: ["el8_amd64_gcc12"]
+        ROOT: ["ROOT v6.34/09"]
+        include:
+          - IMAGE: "cmscloud/al8-cms"
+            CMSSW_VERSION: "CMSSW_15_1_ROOT6_X_2025-04-27-2300"
+            SCRAM_ARCH: "el8_amd64_gcc12"
+            ROOT: "ROOT v6.35/01"
 
     env:
       docker_opt_rw: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit  --mount source=cmsusr,destination=/home/cmsusr -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}

--- a/.github/workflows/development-tests-ci.yml
+++ b/.github/workflows/development-tests-ci.yml
@@ -12,11 +12,6 @@ jobs:
         CMSSW_VERSION: ["CMSSW_15_1_ROOT6_X_2025-04-27-2300"] 
         SCRAM_ARCH: ["el9_amd64_gcc12"]
         ROOT: ["ROOT v6.35/01"]
-        include:
-          - IMAGE: "cmscloud/al8-cms"
-            CMSSW_VERSION: "CMSSW_14_2_0_pre2_ROOT632" 
-            SCRAM_ARCH: "el8_amd64_gcc12"
-            ROOT: "ROOT v6.32/06"
 
     env:
       docker_opt_rw: -v /cvmfs:/cvmfs:shared -v ${{ github.workspace }}:/work/CombinedLimit  --mount source=cmsusr,destination=/home/cmsusr -w /home/cmsusr -e CMSSW_VERSION=${{ matrix.CMSSW_VERSION }} -e SCRAM_ARCH=${{ matrix.SCRAM_ARCH }}
@@ -29,11 +24,11 @@ jobs:
           cvmfs_repositories: 'cms.cern.ch'
       - uses: rhaschke/docker-run-action@v5
         name: Build Combine
+        if: github.event.label.name == 'testAD' 
         with:
           image: ${{ matrix.IMAGE }}
           shell: bash
           options: ${{env.docker_opt_rw}}
-          if: github.event.label.name == 'testAD' 
           run: | 
             cd /home/cmsusr/
             source /cvmfs/cms.cern.ch/cmsset_default.sh
@@ -49,27 +44,26 @@ jobs:
 
       - uses: rhaschke/docker-run-action@v5
         name: Counting datacard
+        if: github.event.label.name == 'testAD' 
         with:
           image: ${{ matrix.IMAGE }}
           shell: bash
           options: ${{env.docker_opt_ro}}
-          if: github.event.label.name == 'testAD' 
           run: |
             cp -r cmssw/${CMSSW_VERSION} .
             cd /home/cmsusr/${CMSSW_VERSION}/src
             source /cvmfs/cms.cern.ch/cmsset_default.sh
             cmsenv
             text2workspace.py  HiggsAnalysis/CombinedLimit/data/tutorials/multiDim/toy-hgg-125.txt -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
-            combine -M MultiDimFit HiggsAnalysis/CombinedLimit/data/tutorials/multiDim/toy-hgg-125.root  --setParameterRanges r=-1,1
+            combine -M MultiDimFit HiggsAnalysis/CombinedLimit/data/tutorials/multiDim/toy-hgg-125.root  --setParameterRanges r=-1,1 --nllbackend codegen 
 
       - uses: rhaschke/docker-run-action@v5
         name: RooHistPdf
-        if: ${{ startsWith(matrix.CMSSW_VERSION, 'CMSSW_14') }}
+        if: github.event.label.name == 'testAD' 
         with:
           image: ${{ matrix.IMAGE }}
           shell: bash
           options: ${{env.docker_opt_ro}}
-          if: github.event.label.name == 'testAD' 
           run: |
             cp -r cmssw/${CMSSW_VERSION} .
             cd /home/cmsusr/${CMSSW_VERSION}/src
@@ -77,4 +71,4 @@ jobs:
             cmsenv
             ulimit -s unlimited
             text2workspace.py HiggsAnalysis/CombinedLimit/data/ci/datacard_RooHistPdf.txt.gz -o ws_RooHistPdf.root
-            combine -M MultiDimFit ws_RooHistPdf.root --algo singles -v -2  --setParameterRanges r=-1,2.
+            combine -M MultiDimFit ws_RooHistPdf.root --algo singles  --setParameterRanges r=-1,2. --nllbackend codegen 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - '**.md'
+      - '**.yml'
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**.md'
 
 jobs:
   docs:


### PR DESCRIPTION
- Move the builds with ROOT>= 6.34.08 into a separate workflow file for AD related tests, they can be triggered with the `testAD` label. 
- Add paths requirements to the default workflows, to build documentation only when the relevant files are updated, and run the tests when .py or .cc files are updated. 