### PR TITLE
Automatically modernize Python code with pyupgrade --py38-plus

### DIFF
--- a/python/AdditionalModels.py
+++ b/python/AdditionalModels.py
@@ -49,7 +49,7 @@ class C8(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", pois + ",MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -104,7 +104,7 @@ class C8(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::c8_BRscal_hinv("@0>=0?@0:-100", BRInv)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c8_XSBRscal_{}_{}".format(production, decay)
+        name = f"c8_XSBRscal_{production}_{decay}"
         print("[LOFullParametrization::C7]")
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
@@ -122,7 +122,7 @@ class C8(SMLikeHiggsModel):
                 BRscal = "hzg"
             if self.doHInv and decay == "hinv":
                 BRscal = "hinv"
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, c8_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, c8_BRscal_{BRscal})')
         return name
 
 
@@ -175,7 +175,7 @@ class CWidth(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", pois + ",MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -263,7 +263,7 @@ class CWidth(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::c7_BRscal_hinv("@0>=0?@0:-100", BRInvUndet)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_{}_{}".format(production, decay)
+        name = f"c7_XSBRscal_{production}_{decay}"
         print("[LOFullParametrization::C7]")
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
@@ -281,7 +281,7 @@ class CWidth(SMLikeHiggsModel):
                 BRscal = "hzg"
             if self.doHInv and decay == "hinv":
                 BRscal = "hinv"
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, c7_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, c7_BRscal_{BRscal})')
         return name
 
 
@@ -319,7 +319,7 @@ class TwoHDM(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "cosbma,tanbeta,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -435,9 +435,9 @@ class TwoHDM(SMLikeHiggsModel):
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
         if "Scaling_" in XSscal:  # it's a Scaling, which means it's already squared
-            self.modelBuilder.factory_('expr::{}("@0 * @1", {}, twohdm_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0 * @1", {XSscal}, twohdm_BRscal_{BRscal})')
         else:  # It's a kappa, so it's linear and I must square it
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, twohdm_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, twohdm_BRscal_{BRscal})')
         return name
 
 

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -332,7 +332,7 @@ def addRateParam(lsyst, f, ret):
     # check for malformed bin/process
     if f[2] not in ret.bins or f[3] not in ret.processes:
         raise RuntimeError(" No such channel/process '{}/{}', malformed line:\n   {}".format(f[2], f[3], " ".join(f)))
-    key = "{}AND{}".format(f[2], f[3])
+    key = f"{f[2]}AND{f[3]}"
     if key in ret.rateParams:
         ret.rateParams[key].append(tmp_exp)
     else:
@@ -385,7 +385,7 @@ def parseCard(file, options):
                 if f[2] not in ret.shapeMap:
                     ret.shapeMap[f[2]] = {}
                 if f[1] in ret.shapeMap[f[2]]:
-                    raise RuntimeError("Duplicate definition for process '{}', channel '{}'".format(f[1], f[2]))
+                    raise RuntimeError(f"Duplicate definition for process '{f[1]}', channel '{f[2]}'")
                 ret.shapeMap[f[2]][f[1]] = f[3:]
                 if "$CHANNEL" in l:
                     shapesUseBin = True
@@ -427,7 +427,7 @@ def parseCard(file, options):
                     ret.keyline.append((b, processline[i], s))
                     if hadBins:
                         if b not in ret.bins:
-                            raise RuntimeError("Bin {} not among the declared bins {}".format(b, ret.bins))
+                            raise RuntimeError(f"Bin {b} not among the declared bins {ret.bins}")
                     else:
                         if b not in ret.bins:
                             ret.bins.append(b)
@@ -495,7 +495,7 @@ def parseCard(file, options):
                 nofloat = True
             if options.nuisancesToExclude and isVetoed(lsyst, options.nuisancesToExclude):
                 if options.verbose > 0:
-                    stderr.write("Excluding nuisance {} selected by a veto pattern among {}\n".format(lsyst, options.nuisancesToExclude))
+                    stderr.write(f"Excluding nuisance {lsyst} selected by a veto pattern among {options.nuisancesToExclude}\n")
                 if nuisances != -1:
                     nuisances -= 1
                 continue
@@ -554,7 +554,7 @@ def parseCard(file, options):
                             addRateParam(lsyst, f_tmp, ret)
                             found = True
                     if not found:
-                        raise RuntimeError("rateParam {} with process {!r} bin {!r} doesn't match anything.".format(lsyst, f[3], f[2]))
+                        raise RuntimeError(f"rateParam {lsyst} with process {f[3]!r} bin {f[2]!r} doesn't match anything.")
                 else:
                     addRateParam(lsyst, f, ret)
                 continue
@@ -590,7 +590,7 @@ def parseCard(file, options):
                 defToks = ("=", "+=")
                 defTok = groupNuisances.pop(0)
                 if defTok not in defToks:
-                    raise RuntimeError("Syntax error for group '{}': first thing after 'group' is not '[+]=' but '{}'.".format(groupName, defTok))
+                    raise RuntimeError(f"Syntax error for group '{groupName}': first thing after 'group' is not '[+]=' but '{defTok}'.")
 
                 if groupName not in ret.groups:
                     if defTok == "=":
@@ -639,16 +639,14 @@ def parseCard(file, options):
                     errline[b][p] = [float(x) for x in r.split("/")]
                     for v in errline[b][p]:
                         if v <= 0.00:
-                            raise ValueError(
-                                'Found "{}" in the nuisances affecting {} for {}. This would lead to NANs later on, so please fix it.'.format(r, p, b)
-                            )
+                            raise ValueError(f'Found "{r}" in the nuisances affecting {p} for {b}. This would lead to NANs later on, so please fix it.')
                 else:
                     if r == "-" * len(r):
                         r = 0.0
                     errline[b][p] = float(r)
                     # values of 0.0 are treated as 1.0; scrap negative values.
                     if pdf not in ["trG", "dFD", "dFD2"] and errline[b][p] < 0:
-                        raise ValueError('Found "{}" in the nuisances affecting {} in {}. This would lead to NANs later on, so please fix it.'.format(r, p, b))
+                        raise ValueError(f'Found "{r}" in the nuisances affecting {p} in {b}. This would lead to NANs later on, so please fix it.')
                 # set the rate to epsilon for backgrounds with zero observed sideband events.
                 if pdf == "gmN" and ret.exp[b][p] == 0 and float(r) != 0:
                     ret.exp[b][p] = 1e-6

--- a/python/DatacardPruner.py
+++ b/python/DatacardPruner.py
@@ -100,12 +100,12 @@ class DatacardPruner:
                             output[key] = line
             file.close()
         rnd_name = "".join(random.choice(string.ascii_uppercase + string.digits) for x in range(10))
-        file = open("/tmp/{NAME}".format(NAME=rnd_name), "w")
+        file = open(f"/tmp/{rnd_name}", "w")
         file.write(headline)
         for line in output.values():
             file.write(line)
         file.close()
-        return "/tmp/{NAME}".format(NAME=rnd_name)
+        return f"/tmp/{rnd_name}"
 
     def determine_shapes(self, DATACARD):
         """
@@ -307,7 +307,7 @@ class DatacardPruner:
                     keep.append(name)
         file.close()
         # print "wrote combined cards to: {NAME}".format(NAME=file_name)
-        os.system("rm {NAME}".format(NAME=file_name))
+        os.system(f"rm {file_name}")
         return (drop, keep, confused)
 
     def list_to_file(self, LIST, FILE):
@@ -334,7 +334,7 @@ class DatacardPruner:
         excl = 0
         file = open(DATACARD)
         rnd_name = "".join(random.choice(string.ascii_uppercase + string.digits) for x in range(10))
-        output = open("/tmp/{NAME}".format(NAME=rnd_name), "w")
+        output = open(f"/tmp/{rnd_name}", "w")
         for line in file:
             words = line.split()
             if len(words) > 1:
@@ -360,5 +360,5 @@ class DatacardPruner:
             output.write(line)
         file.close()
         output.close()
-        os.system("mv /tmp/{NAME} {DATACARD}".format(NAME=rnd_name, DATACARD=DATACARD))
+        os.system(f"mv /tmp/{rnd_name} {DATACARD}")
         return excl

--- a/python/DegenerateMatrixRank.py
+++ b/python/DegenerateMatrixRank.py
@@ -49,9 +49,9 @@ class AllMuiLambdaHiggs(SMLikeHiggsModel):
                 poi.append("mu_" + decay)
             else:
                 self.modelBuilder.doVar("mu_%s[1,0,5]" % decay)
-            self.modelBuilder.factory_('expr::lambdamu_{}("@0*@1",lambda,mu_{})'.format(decay, decay))
-            self.modelBuilder.factory_('expr::lambdavmu_{}("@0*@1",lambdav,mu_{})'.format(decay, decay))
-            self.modelBuilder.factory_('expr::lambdatmu_{}("@0*@1",lambdat,mu_{})'.format(decay, decay))
+            self.modelBuilder.factory_(f'expr::lambdamu_{decay}("@0*@1",lambda,mu_{decay})')
+            self.modelBuilder.factory_(f'expr::lambdavmu_{decay}("@0*@1",lambdav,mu_{decay})')
+            self.modelBuilder.factory_(f'expr::lambdatmu_{decay}("@0*@1",lambdat,mu_{decay})')
         self.modelBuilder.doSet("POI", ",".join(poi))
         if self.modelBuilder.out.var("MH"):
             if len(self.mHRange):
@@ -78,7 +78,7 @@ class AllMuiLambdaHiggs(SMLikeHiggsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 poi.append("MH")
                 self.modelBuilder.doSet("POI", ",".join(poi))
                 # self.modelBuilder.doSet('POI','poi,MH')
@@ -155,9 +155,9 @@ class AllMuiLambdasHiggs(SMLikeHiggsModel):
             self.modelBuilder.doVar("lambda_%s[1,0,10]" % decay)
             self.modelBuilder.doVar("lambdav_%s[1,0,10]" % decay)
             self.modelBuilder.doVar("lambdat_%s[1,0,10]" % decay)
-            self.modelBuilder.factory_('expr::lambda_{}mu_{}("@0*@1",lambda_{},mu_{})'.format(decay, decay, decay, decay))
-            self.modelBuilder.factory_('expr::lambdav_{}mu_{}("@0*@1",lambdav_{},mu_{})'.format(decay, decay, decay, decay))
-            self.modelBuilder.factory_('expr::lambdat_{}mu_{}("@0*@1",lambdat_{},mu_{})'.format(decay, decay, decay, decay))
+            self.modelBuilder.factory_(f'expr::lambda_{decay}mu_{decay}("@0*@1",lambda_{decay},mu_{decay})')
+            self.modelBuilder.factory_(f'expr::lambdav_{decay}mu_{decay}("@0*@1",lambdav_{decay},mu_{decay})')
+            self.modelBuilder.factory_(f'expr::lambdat_{decay}mu_{decay}("@0*@1",lambdat_{decay},mu_{decay})')
         self.modelBuilder.doSet("POI", ",".join(poi))
         if self.modelBuilder.out.var("MH"):
             if len(self.mHRange):
@@ -184,7 +184,7 @@ class AllMuiLambdasHiggs(SMLikeHiggsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 poi.append("MH")
                 self.modelBuilder.doSet("POI", ",".join(poi))
                 # self.modelBuilder.doSet('POI','poi,MH')

--- a/python/FloatingHiggsWidth.py
+++ b/python/FloatingHiggsWidth.py
@@ -42,7 +42,7 @@ class FloatingHiggsWidth(SMLikeHiggsModel):
                     self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                     self.modelBuilder.out.var("MH").setConstant(False)
                 else:
-                    self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                    self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 POIs = "r,MH,HiggsDecayWidth"
             else:
                 if self.modelBuilder.out.var("MH"):
@@ -58,7 +58,7 @@ class FloatingHiggsWidth(SMLikeHiggsModel):
                     self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                     self.modelBuilder.out.var("MH").setConstant(False)
                 else:
-                    self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                    self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 POIs = "MH,HiggsDecayWidth"
             else:
                 if self.modelBuilder.out.var("MH"):
@@ -73,7 +73,7 @@ class FloatingHiggsWidth(SMLikeHiggsModel):
             self.modelBuilder.out.var("HiggsDecayWidth").setRange(float(self.widthRange[0]), float(self.widthRange[1]))
             self.modelBuilder.out.var("HiggsDecayWidth").setConstant(False)
         else:
-            self.modelBuilder.doVar("HiggsDecayWidth[{},{}]".format(self.widthRange[0], self.widthRange[1]))
+            self.modelBuilder.doVar(f"HiggsDecayWidth[{self.widthRange[0]},{self.widthRange[1]}]")
         self.modelBuilder.doSet("POI", POIs)
 
     def getHiggsSignalYieldScale(self, production, decay, energy):

--- a/python/HTTAnomalousCouplings.py
+++ b/python/HTTAnomalousCouplings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import six
 
 from .PhysicsModel import PhysicsModelBase_NiceSubclasses
@@ -66,7 +64,7 @@ class Anomalous_Interference_JHU_rw(PhysicsModelBase_NiceSubclasses):
         self.anomalouscoupling = None
         self.dofa3gg = None
         self.adjustmuVbyfai = None
-        super(Anomalous_Interference_JHU_rw, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def getPOIList(self):
         myxsecs = {
@@ -138,7 +136,7 @@ class Anomalous_Interference_JHU_rw(PhysicsModelBase_NiceSubclasses):
         if not self.modelBuilder.out.var("RV"):
             self.modelBuilder.doVar("RV[1.0,0.0,10.0]")
         if self.adjustmuVbyfai is not None:
-            self.modelBuilder.factory_('expr::muVc("@1/(1+{}*abs(@0))", CMS_zz4l_fai1,RV)'.format(self.adjustmuVbyfai))
+            self.modelBuilder.factory_(f'expr::muVc("@1/(1+{self.adjustmuVbyfai}*abs(@0))", CMS_zz4l_fai1,RV)')
             myxsecs["muV"] = "muVc"
         else:
             myxsecs["muV"] = "RV"
@@ -196,7 +194,7 @@ class Anomalous_Interference_JHU_rw(PhysicsModelBase_NiceSubclasses):
         else:
             self.modelBuilder.out.var("muTT").setConstant()
 
-        return pois + super(Anomalous_Interference_JHU_rw, self).getPOIList()
+        return pois + super().getPOIList()
 
     def getYieldScale(self, bin, process):
         if process in [
@@ -224,7 +222,7 @@ class Anomalous_Interference_JHU_rw(PhysicsModelBase_NiceSubclasses):
 
         pureBSMs = {"fa3": "0M", "fa2": "0PH", "fL1": "0L1", "fL1Zg": "0L1Zg"}
 
-        for anomalouscoupling, pureBSM in six.iteritems(pureBSMs):
+        for anomalouscoupling, pureBSM in pureBSMs.items():
             if anomalouscoupling != self.anomalouscoupling and (process.endswith(pureBSM) or process.endswith(pureBSM + "f05ph0")):
                 raise ValueError("Can't have " + process + " for " + self.anomalouscoupling + " (it's for " + anomalouscoupling + ")")
             if process in [
@@ -249,14 +247,14 @@ class Anomalous_Interference_JHU_rw(PhysicsModelBase_NiceSubclasses):
         if "reweighted_" in process or "GGH2Jets" in process:
             raise ValueError("Don't know what to do with " + process)
 
-        return super(Anomalous_Interference_JHU_rw, self).getYieldScale(bin, process)
+        return super().getYieldScale(bin, process)
 
     def processPhysicsOptions(self, physOptions):
-        processed = super(Anomalous_Interference_JHU_rw, self).processPhysicsOptions(physOptions)
+        processed = super().processPhysicsOptions(physOptions)
         for po in physOptions:
             if po in ("fa3", "fa2", "fL1", "fL1Zg"):
                 if self.anomalouscoupling is not None:
-                    raise ValueError("Multiple anomalous couplings provided as physics options ({}, {})".format(self.anomalouscoupling, po))
+                    raise ValueError(f"Multiple anomalous couplings provided as physics options ({self.anomalouscoupling}, {po})")
                 self.anomalouscoupling = po
                 processed.append(po)
             if po.lower() == "dofa3gg=true":
@@ -282,7 +280,7 @@ class Anomalous_Interference_JHU_rw_HTTHZZ(Anomalous_Interference_JHU_rw, MultiS
     usemuTT = True  # because it's now needed to float the TT vs. ZZ BR
 
     def processPhysicsOptions(self, physOptions):
-        result = super(Anomalous_Interference_JHU_rw_HTTHZZ, self).processPhysicsOptions(physOptions)
+        result = super().processPhysicsOptions(physOptions)
         if self.scaledifferentsqrtsseparately:
             raise ValueError("Can't scale different sqrts separately for HZZ+HTT combination")
         if not self.scalemuvfseparately:
@@ -292,13 +290,13 @@ class Anomalous_Interference_JHU_rw_HTTHZZ(Anomalous_Interference_JHU_rw, MultiS
         return result
 
     def getPOIList(self):
-        result = super(Anomalous_Interference_JHU_rw_HTTHZZ, self).getPOIList()
+        result = super().getPOIList()
         if self.adjustmuVbyfai is not None:
             self.modelBuilder.factory_('expr::newmuVoveroldmuV("@0/@1", muVc, RV)')
         return result
 
     def getYieldScale(self, bin, process):
-        result = super(Anomalous_Interference_JHU_rw_HTTHZZ, self).getYieldScale(bin, process)
+        result = super().getYieldScale(bin, process)
         if self.adjustmuVbyfai is not None and process in ("qqH", "ZH", "WH", "VVH"):
             assert result == 1, result  # from MultiSignalSpinZeroHiggs
             return "newmuVoveroldmuV"

--- a/python/HiggsBenchmarkModels/CSquared.py
+++ b/python/HiggsBenchmarkModels/CSquared.py
@@ -26,7 +26,7 @@ class CSquaredHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "C,MH")
         else:
             if self.modelBuilder.out.var("MH"):

--- a/python/HiggsBenchmarkModels/CustodialSymmetryModels.py
+++ b/python/HiggsBenchmarkModels/CustodialSymmetryModels.py
@@ -37,7 +37,7 @@ class LambdaWZHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kZ,lambdaWZ,kf,MH" if self.floatKF else "kZ,lambdaWZ,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -127,7 +127,7 @@ class LambdaWZHiggs(SMLikeHiggsModel):
         try:
             BRscal = self.decayScaling[decay]
             XSscal = self.productionScaling[production]
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, lambdaWZ_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, lambdaWZ_BRscal_{BRscal})')
             return name
         except KeyError:
             if production == "VH":
@@ -135,7 +135,7 @@ class LambdaWZHiggs(SMLikeHiggsModel):
                     "WARNING: You are trying to use a VH production mode in a model that needs WH and ZH separately. "
                     "The best I can do is to scale [%(production)s, %(decay)s, %(energy)s] with the decay BR only but this is wrong..." % locals()
                 )
-                self.modelBuilder.factory_('expr::{}("1.0*@0", lambdaWZ_BRscal_{})'.format(name, BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("1.0*@0", lambdaWZ_BRscal_{BRscal})')
                 return name
             raise
 
@@ -167,7 +167,7 @@ class RzwHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Rzw,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -219,7 +219,7 @@ class RwzHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Rwz,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -271,7 +271,7 @@ class CzwHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Czw,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -306,23 +306,23 @@ class CzwHiggs(SMLikeHiggsModel):
                 os.path.join(datadir, "couplings/R_VBF_%s.txt" % e),
                 ycol=1,
             )
-            self.modelBuilder.factory_('expr::Czw_XSscal_qqH_{}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{})'.format(e, e))
+            self.modelBuilder.factory_(f'expr::Czw_XSscal_qqH_{e}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{e})')
             self.modelBuilder.factory_('expr::Czw_XSscal_WH_%s("@0", Cw)' % e)
             self.modelBuilder.factory_('expr::Czw_XSscal_ZH_%s("@0", Cz)' % e)
             self.SMH.makeXS("WH", e)
             self.SMH.makeXS("ZH", e)
-            self.modelBuilder.factory_('expr::Czw_XSscal_VH_{}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{}, Cz, SM_XS_ZH_{})'.format(e, e, e))
+            self.modelBuilder.factory_(f'expr::Czw_XSscal_VH_{e}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{e}, Cz, SM_XS_ZH_{e})')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
         if decay not in ["hww", "hzz"]:
             return 0
 
-        name = "Czw_XSBRscal_{}_{}_{}".format(production, decay, energy)
+        name = f"Czw_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "ttH"]:
-                self.modelBuilder.factory_('expr::{}("@0", Czw_BRscal_{})'.format(name, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0", Czw_BRscal_{decay})')
             else:
-                self.modelBuilder.factory_('expr::{}("@0 * @1", Czw_XSscal_{}_{}, Czw_BRscal_{})'.format(name, production, energy, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0 * @1", Czw_XSscal_{production}_{energy}, Czw_BRscal_{decay})')
         return name
 
 
@@ -353,7 +353,7 @@ class CwzHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Cwz,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -387,21 +387,21 @@ class CwzHiggs(SMLikeHiggsModel):
                 os.path.join(datadir, "couplings/R_VBF_%s.txt" % e),
                 ycol=1,
             )
-            self.modelBuilder.factory_('expr::Cwz_XSscal_qqH_{}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{})'.format(e, e))
+            self.modelBuilder.factory_(f'expr::Cwz_XSscal_qqH_{e}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{e})')
             self.modelBuilder.factory_('expr::Cwz_XSscal_WH_%s("@0", Cw)' % e)
             self.modelBuilder.factory_('expr::Cwz_XSscal_ZH_%s("@0", Cz)' % e)
             self.SMH.makeXS("WH", e)
             self.SMH.makeXS("ZH", e)
-            self.modelBuilder.factory_('expr::Cwz_XSscal_VH_{}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{}, Cz, SM_XS_ZH_{})'.format(e, e, e))
+            self.modelBuilder.factory_(f'expr::Cwz_XSscal_VH_{e}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{e}, Cz, SM_XS_ZH_{e})')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
         if decay not in ["hww", "hzz"]:
             return 0
 
-        name = "Cwz_XSBRscal_{}_{}_{}".format(production, decay, energy)
+        name = f"Cwz_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "ttH"]:
-                self.modelBuilder.factory_('expr::{}("@0", Cwz_BRscal_{})'.format(name, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0", Cwz_BRscal_{decay})')
             else:
-                self.modelBuilder.factory_('expr::{}("@0 * @1", Cwz_XSscal_{}_{}, Cwz_BRscal_{})'.format(name, production, energy, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0 * @1", Cwz_XSscal_{production}_{energy}, Cwz_BRscal_{decay})')
         return name

--- a/python/HiggsBenchmarkModels/FermionSectorModels.py
+++ b/python/HiggsBenchmarkModels/FermionSectorModels.py
@@ -33,7 +33,7 @@ class LambdaduHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kV,lambdadu,ku,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -127,9 +127,9 @@ class LambdaduHiggs(SMLikeHiggsModel):
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
         if "Scaling_" in XSscal:  # it's a Scaling, which means it's already squared
-            self.modelBuilder.factory_('expr::{}("@0 * @1", {}, lambdadu_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0 * @1", {XSscal}, lambdadu_BRscal_{BRscal})')
         else:  # It's a kappa, so it's linear and I must square it
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, lambdadu_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, lambdadu_BRscal_{BRscal})')
         return name
 
 
@@ -161,7 +161,7 @@ class LambdalqHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kV,lambdalq,kq,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -245,7 +245,7 @@ class LambdalqHiggs(SMLikeHiggsModel):
 
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
-        self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, lambdalq_BRscal_{})'.format(name, XSscal, BRscal))
+        self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, lambdalq_BRscal_{BRscal})')
         return name
 
 
@@ -292,7 +292,7 @@ class C5qlHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             POI += ",MH"
         else:
             if self.modelBuilder.out.var("MH"):
@@ -352,7 +352,7 @@ class C5qlHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::C5ql_BRscal_htt("@0*@0/@1", Cl, C5ql_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "C5ql_XSBRscal_{}_{}".format(production, decay)
+        name = f"C5ql_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "Cglu" if production in ["ggH"] else "Cv"
             if production in ["ttH"]:
@@ -362,7 +362,7 @@ class C5qlHiggs(SMLikeHiggsModel):
                 BRscal = "hvv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hff" if self.universalCF else decay
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, C5ql_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, C5ql_BRscal_{BRscal})')
         return name
 
 
@@ -409,7 +409,7 @@ class C5udHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             POI += ",MH"
         else:
             if self.modelBuilder.out.var("MH"):
@@ -469,7 +469,7 @@ class C5udHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::C5ud_BRscal_htt("@0*@0/@1", Cd, C5ud_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "C5ud_XSBRscal_{}_{}".format(production, decay)
+        name = f"C5ud_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "Cglu" if production in ["ggH"] else "Cv"
             if production in ["ttH"]:
@@ -479,5 +479,5 @@ class C5udHiggs(SMLikeHiggsModel):
                 BRscal = "hvv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hff" if self.universalCF else decay
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, C5ud_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, C5ud_BRscal_{BRscal})')
         return name

--- a/python/HiggsBenchmarkModels/LoopAndInvisibleModel.py
+++ b/python/HiggsBenchmarkModels/LoopAndInvisibleModel.py
@@ -41,7 +41,7 @@ class HiggsLoops(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             myPOIs.append("MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -120,7 +120,7 @@ class HiggsLoops(SMLikeHiggsModel):
         # self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "loopGluonGamma_XSBRscal_{}_{}".format(production, decay)
+        name = f"loopGluonGamma_XSBRscal_{production}_{decay}"
 
         if self.modelBuilder.out.function(name):
             return name
@@ -128,9 +128,9 @@ class HiggsLoops(SMLikeHiggsModel):
         BRscal = self.decayScaling[decay]
 
         if production == "ggH":
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", kgluon, loopGluonGamma_BRscal_{})'.format(name, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", kgluon, loopGluonGamma_BRscal_{BRscal})')
         else:
-            self.modelBuilder.factory_('expr::{}("1.0 * @0", loopGluonGamma_BRscal_{})'.format(name, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("1.0 * @0", loopGluonGamma_BRscal_{BRscal})')
 
         return name
 
@@ -163,7 +163,7 @@ class HiggsLoopsInvisible(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kgluon,kgamma,BRInvUndet,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -224,7 +224,7 @@ class HiggsLoopsInvisible(SMLikeHiggsModel):
         # self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "loopGluonGamma_XSBRscal_{}_{}".format(production, decay)
+        name = f"loopGluonGamma_XSBRscal_{production}_{decay}"
 
         if self.modelBuilder.out.function(name):
             return name
@@ -232,8 +232,8 @@ class HiggsLoopsInvisible(SMLikeHiggsModel):
         BRscal = self.decayScaling[decay]
 
         if production == "ggH":
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", kgluon, loopGluonGamma_BRscal_{})'.format(name, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", kgluon, loopGluonGamma_BRscal_{BRscal})')
         else:
-            self.modelBuilder.factory_('expr::{}("1.0 * @0", loopGluonGamma_BRscal_{})'.format(name, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("1.0 * @0", loopGluonGamma_BRscal_{BRscal})')
 
         return name

--- a/python/HiggsBenchmarkModels/MinimalModels.py
+++ b/python/HiggsBenchmarkModels/MinimalModels.py
@@ -34,7 +34,7 @@ class HiggsMinimal(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kgluon,kgamma,kV,kf,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -104,13 +104,13 @@ class HiggsMinimal(SMLikeHiggsModel):
         # self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "minimal_XSBRscal_{}_{}".format(production, decay)
+        name = f"minimal_XSBRscal_{production}_{decay}"
 
         if self.modelBuilder.out.function(name):
             return name
 
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
-        self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, minimal_BRscal_{})'.format(name, XSscal, BRscal))
+        self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, minimal_BRscal_{BRscal})')
 
         return name

--- a/python/HiggsBenchmarkModels/VectorsAndFermionsModels.py
+++ b/python/HiggsBenchmarkModels/VectorsAndFermionsModels.py
@@ -40,15 +40,15 @@ class CvCfHiggs(SMLikeHiggsModel):
     def doParametersOfInterest(self):
         """Create POI out of signal strength and MH"""
         # --- Signal Strength as only POI ---
-        self.modelBuilder.doVar("CV[1,{},{}]".format(self.cVRange[0], self.cVRange[1]))
-        self.modelBuilder.doVar("CF[1,{},{}]".format(self.cFRange[0], self.cFRange[1]))
+        self.modelBuilder.doVar(f"CV[1,{self.cVRange[0]},{self.cVRange[1]}]")
+        self.modelBuilder.doVar(f"CF[1,{self.cFRange[0]},{self.cFRange[1]}]")
 
         if self.floatMass:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -120,13 +120,13 @@ class CvCfHiggs(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCf_XSBRscal_{}_{}".format(production, decay)
+        name = f"CvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name):
             return name
 
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
-        self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, CvCf_BRscal_{})'.format(name, XSscal, BRscal))
+        self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCf_BRscal_{BRscal})')
         return name
 
 
@@ -159,7 +159,7 @@ class CvCfXgHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,XG,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -215,7 +215,7 @@ class CvCfXgHiggs(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCfXg_XSBRscal_{}_{}".format(production, decay)
+        name = f"CvCfXg_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -223,7 +223,7 @@ class CvCfXgHiggs(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, CvCfXg_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCfXg_BRscal_{BRscal})')
         return name
 
 
@@ -256,7 +256,7 @@ class CfXgHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CF,XG,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -312,7 +312,7 @@ class CfXgHiggs(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CfXg_XSBRscal_{}_{}".format(production, decay)
+        name = f"CfXg_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -320,7 +320,7 @@ class CfXgHiggs(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, CfXg_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CfXg_BRscal_{BRscal})')
         return name
 
 
@@ -369,7 +369,7 @@ class CvCfInvHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[{},{}]".format(self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,BRInvUndet,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -444,17 +444,17 @@ class CvCfInvHiggs(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCf_XSBRscal_{}_{}".format(production, decay)
+        name = f"CvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name):
             return name
 
         BRscal = self.decayScaling[decay]
         if production in list(self.productionScaling.keys()):  # Simple scalings
             XSscal = self.productionScaling[production]
-            self.modelBuilder.factory_('expr::{}("@0*@0 * @1", {}, CvCf_BRscal_{})'.format(name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCf_BRscal_{BRscal})')
         else:
             self.SMH.makeScaling(production, Cb="CF", Ctop="CF", Ctau="CF", CW="CV", CZ="CV")
-            XSscal = "Scaling_{}_{}".format(production, energy)
-            self.modelBuilder.factory_('expr::{}("@0 * @1", {}, CvCf_BRscal_{})'.format(name, XSscal, BRscal))
+            XSscal = f"Scaling_{production}_{energy}"
+            self.modelBuilder.factory_(f'expr::{name}("@0 * @1", {XSscal}, CvCf_BRscal_{BRscal})')
 
         return name

--- a/python/HiggsCouplings.py
+++ b/python/HiggsCouplings.py
@@ -1,7 +1,6 @@
 # Benchmark Higgs models as defined in (put ref to LHCXSWG document)
 
 # the model equivalent to mu
-from __future__ import absolute_import
 
 from HiggsAnalysis.CombinedLimit.HiggsBenchmarkModels.CSquared import CSquaredHiggs
 

--- a/python/HiggsCouplingsLOSM.py
+++ b/python/HiggsCouplingsLOSM.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import ROOT
@@ -35,7 +33,7 @@ class CvCfHiggsLOSM(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -90,7 +88,7 @@ class CvCfHiggsLOSM(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCf_XSBRscal_%s_%s" % (production, decay)
+        name = f"CvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -98,7 +96,7 @@ class CvCfHiggsLOSM(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, CvCf_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCf_BRscal_{BRscal})')
         return name
 
 
@@ -131,7 +129,7 @@ class CvCfXgHiggsLOSM(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,XG,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -187,7 +185,7 @@ class CvCfXgHiggsLOSM(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCfXg_XSBRscal_%s_%s" % (production, decay)
+        name = f"CvCfXg_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -195,7 +193,7 @@ class CvCfXgHiggsLOSM(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, CvCfXg_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCfXg_BRscal_{BRscal})')
         return name
 
 
@@ -228,7 +226,7 @@ class CfXgHiggsLOSM(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CF,XG,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -284,7 +282,7 @@ class CfXgHiggsLOSM(SMLikeHiggsModel):
         self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CfXg_XSBRscal_%s_%s" % (production, decay)
+        name = f"CfXg_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -292,7 +290,7 @@ class CfXgHiggsLOSM(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, CfXg_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CfXg_BRscal_{BRscal})')
         return name
 
 

--- a/python/HiggsCouplings_ICHEP12.py
+++ b/python/HiggsCouplings_ICHEP12.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import ROOT
@@ -35,7 +33,7 @@ class CvCfHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "CV,CF,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -94,7 +92,7 @@ class CvCfHiggs(SMLikeHiggsModel):
         # self.modelBuilder.out.Print()
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "CvCf_XSBRscal_%s_%s" % (production, decay)
+        name = f"CvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "CF" if production in ["ggH", "ttH"] else "CV"
             BRscal = "hgg"
@@ -102,7 +100,7 @@ class CvCfHiggs(SMLikeHiggsModel):
                 BRscal = "hv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hf"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, CvCf_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, CvCf_BRscal_{BRscal})')
         return name
 
 
@@ -149,7 +147,7 @@ class C5qlHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             POI += ",MH"
         else:
             if self.modelBuilder.out.var("MH"):
@@ -209,7 +207,7 @@ class C5qlHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::C5ql_BRscal_htt("@0*@0/@1", Cl, C5ql_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "C5ql_XSBRscal_%s_%s" % (production, decay)
+        name = f"C5ql_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "Cglu" if production in ["ggH"] else "Cv"
             if production in ["ttH"]:
@@ -219,7 +217,7 @@ class C5qlHiggs(SMLikeHiggsModel):
                 BRscal = "hvv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hff" if self.universalCF else decay
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, C5ql_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, C5ql_BRscal_{BRscal})')
         return name
 
 
@@ -266,7 +264,7 @@ class C5udHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             POI += ",MH"
         else:
             if self.modelBuilder.out.var("MH"):
@@ -326,7 +324,7 @@ class C5udHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::C5ud_BRscal_htt("@0*@0/@1", Cd, C5ud_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "C5ud_XSBRscal_%s_%s" % (production, decay)
+        name = f"C5ud_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name) == None:
             XSscal = "Cglu" if production in ["ggH"] else "Cv"
             if production in ["ttH"]:
@@ -336,7 +334,7 @@ class C5udHiggs(SMLikeHiggsModel):
                 BRscal = "hvv"
             if decay in ["hbb", "htt"]:
                 BRscal = "hff" if self.universalCF else decay
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, C5ud_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, C5ud_BRscal_{BRscal})')
         return name
 
 
@@ -367,7 +365,7 @@ class RzwHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Rzw,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -419,7 +417,7 @@ class RwzHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Rwz,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -471,7 +469,7 @@ class CzwHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Czw,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -506,23 +504,23 @@ class CzwHiggs(SMLikeHiggsModel):
                 os.path.join(datadir, "couplings/R_VBF_%s.txt" % e),
                 ycol=1,
             )
-            self.modelBuilder.factory_('expr::Czw_XSscal_qqH_%s("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_%s)' % (e, e))
+            self.modelBuilder.factory_(f'expr::Czw_XSscal_qqH_{e}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{e})')
             self.modelBuilder.factory_('expr::Czw_XSscal_WH_%s("@0", Cw)' % e)
             self.modelBuilder.factory_('expr::Czw_XSscal_ZH_%s("@0", Cz)' % e)
             self.SMH.makeXS("WH", e)
             self.SMH.makeXS("ZH", e)
-            self.modelBuilder.factory_('expr::Czw_XSscal_VH_%s("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_%s, Cz, SM_XS_ZH_%s)' % (e, e, e))
+            self.modelBuilder.factory_(f'expr::Czw_XSscal_VH_{e}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{e}, Cz, SM_XS_ZH_{e})')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
         if decay not in ["hww", "hzz"]:
             return 0
 
-        name = "Czw_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"Czw_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "ttH"]:
-                self.modelBuilder.factory_('expr::%s("@0", Czw_BRscal_%s)' % (name, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0", Czw_BRscal_{decay})')
             else:
-                self.modelBuilder.factory_('expr::%s("@0 * @1", Czw_XSscal_%s_%s, Czw_BRscal_%s)' % (name, production, energy, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0 * @1", Czw_XSscal_{production}_{energy}, Czw_BRscal_{decay})')
         return name
 
 
@@ -553,7 +551,7 @@ class CwzHiggs(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "Cwz,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -588,23 +586,23 @@ class CwzHiggs(SMLikeHiggsModel):
                 os.path.join(datadir, "couplings/R_VBF_%s.txt" % e),
                 ycol=1,
             )
-            self.modelBuilder.factory_('expr::Cwz_XSscal_qqH_%s("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_%s)' % (e, e))
+            self.modelBuilder.factory_(f'expr::Cwz_XSscal_qqH_{e}("(@0 + @1*@2) / (1.0 + @2) ", Cw, Cz, RqqH_{e})')
             self.modelBuilder.factory_('expr::Cwz_XSscal_WH_%s("@0", Cw)' % e)
             self.modelBuilder.factory_('expr::Cwz_XSscal_ZH_%s("@0", Cz)' % e)
             self.SMH.makeXS("WH", e)
             self.SMH.makeXS("ZH", e)
-            self.modelBuilder.factory_('expr::Cwz_XSscal_VH_%s("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_%s, Cz, SM_XS_ZH_%s)' % (e, e, e))
+            self.modelBuilder.factory_(f'expr::Cwz_XSscal_VH_{e}("(@0*@1 + @2*@3) / (@1 + @3) ", Cw, SM_XS_WH_{e}, Cz, SM_XS_ZH_{e})')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
         if decay not in ["hww", "hzz"]:
             return 0
 
-        name = "Cwz_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"Cwz_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "ttH"]:
-                self.modelBuilder.factory_('expr::%s("@0", Cwz_BRscal_%s)' % (name, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0", Cwz_BRscal_{decay})')
             else:
-                self.modelBuilder.factory_('expr::%s("@0 * @1", Cwz_XSscal_%s_%s, Cwz_BRscal_%s)' % (name, production, energy, decay))
+                self.modelBuilder.factory_(f'expr::{name}("@0 * @1", Cwz_XSscal_{production}_{energy}, Cwz_BRscal_{decay})')
         return name
 
 

--- a/python/HiggsFermiophobic.py
+++ b/python/HiggsFermiophobic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import ROOT
@@ -32,7 +30,7 @@ class FermiophobicHiggs(SMLikeHiggsModel):
             self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
             self.modelBuilder.out.var("MH").setConstant(False)
         else:
-            self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+            self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
         self.modelBuilder.doSet("POI", "r,MH")
         self.SMH = SMHiggsBuilder(self.modelBuilder)
         self.setup()
@@ -47,7 +45,7 @@ class FermiophobicHiggs(SMLikeHiggsModel):
 
         for decay in ["hww", "hzz", "hgg", "hzg"]:
             self.SMH.makeBR(decay)
-            self.modelBuilder.factory_('expr::FP_BRScal_%s("@0*@1/@2",r,FP_BR_%s,SM_BR_%s)' % (decay, decay, decay))
+            self.modelBuilder.factory_(f'expr::FP_BRScal_{decay}("@0*@1/@2",r,FP_BR_{decay},SM_BR_{decay})')
 
         self.modelBuilder.out.Print()
 

--- a/python/HiggsJPC.py
+++ b/python/HiggsJPC.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 
 
@@ -132,7 +130,7 @@ class TwoHypotesisHiggs(PhysicsModel):
 
                 if self.fqqIncluded:
                     if self.fqqFloating:
-                        self.modelBuilder.doVar("fqq[0,%s,%s]" % (self.fqqRange[0], self.fqqRange[1]))
+                        self.modelBuilder.doVar(f"fqq[0,{self.fqqRange[0]},{self.fqqRange[1]}]")
                     else:
                         self.modelBuilder.doVar("fqq[0]")
                     self.modelBuilder.factory_('expr::r_times_x_times_fqq("@0*@1", r_times_x, fqq)')
@@ -166,7 +164,7 @@ class TwoHypotesisHiggs(PhysicsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 poi += ",MH"
             else:
                 print("MH (not there before) will be assumed to be", self.options.mass)

--- a/python/HiggsWidth.py
+++ b/python/HiggsWidth.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 
 ### This is the base python class to study the Higgs width

--- a/python/InterferenceModels.py
+++ b/python/InterferenceModels.py
@@ -19,7 +19,7 @@ def read_scaling(path):
         with gzip.open(path, "rb") as fin:
             out = pickle.load(fin)
     else:
-        raise RuntimeError("Unrecognized scaling data path {path}; must be either .json, .json.gz, or .pkl.gz".format(path=path))
+        raise RuntimeError(f"Unrecognized scaling data path {path}; must be either .json, .json.gz, or .pkl.gz")
     # normalize
     if not isinstance(out, list):
         raise RuntimeError("Scaling data in invalid format: expected list")
@@ -29,21 +29,21 @@ def read_scaling(path):
             raise RuntimeError("Scaling data in invalid format: expected each item in list to be a dict")
         missing = expected_fields - set(item)
         if missing:
-            raise RuntimeError("Missing fields in scaling item: {missing}".format(missing=missing))
+            raise RuntimeError(f"Missing fields in scaling item: {missing}")
         shortname = item["channel"] + "/" + item["process"]
         if not all(isinstance(par, str) for par in item["parameters"]):
-            raise RuntimeError("Parameters must be a list of strings in {shortname}".format(shortname=shortname))
+            raise RuntimeError(f"Parameters must be a list of strings in {shortname}")
         try:
             # coerce into numpy with C-contiguous memory (needed for fast std::vector copy)
             item["scaling"] = np.ascontiguousarray(item["scaling"], dtype=float)
         except ValueError:
             # python3: raise from ex
-            raise RuntimeError("Scaling data invalid: could not normalize array for {shortname}".format(shortname=shortname))
+            raise RuntimeError(f"Scaling data invalid: could not normalize array for {shortname}")
         if len(item["scaling"].shape) != 2:
-            raise RuntimeError("Scaling data invalid: array shape incorrect for {shortname}".format(shortname=shortname))
+            raise RuntimeError(f"Scaling data invalid: array shape incorrect for {shortname}")
         npar = len(item["parameters"])
         if item["scaling"].shape[1] != npar * (npar + 1) // 2:
-            raise RuntimeError("Scaling data invalid: array has insufficent terms for parameters in {shortname}".format(shortname=shortname))
+            raise RuntimeError(f"Scaling data invalid: array has insufficent terms for parameters in {shortname}")
     return out
 
 
@@ -53,7 +53,7 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
         self.scaling = None
         self.scaling_map = {}
         self.explict_pois = None
-        super(InterferenceModel, self).__init__()
+        super().__init__()
 
     def processPhysicsOptions(self, physOptions):
         processed = []
@@ -72,7 +72,7 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
         # make map for quick lookup
         for item in self.scaling:
             self.scaling_map[(item["channel"], item["process"])] = item
-        return processed + super(InterferenceModel, self).processPhysicsOptions(physOptions)
+        return processed + super().processPhysicsOptions(physOptions)
 
     def getPOIList(self):
         poiNames = []
@@ -81,11 +81,11 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
                 print("Building explicitly requested POIs:")
             for poi in self.explict_pois:
                 if self.verbose:
-                    print(" - {poi}".format(poi=poi))
+                    print(f" - {poi}")
                 self.modelBuilder.doVar(poi)
                 poiname = re.sub(r"\[.*", "", poi)
                 if not self.modelBuilder.out.var(poiname):
-                    raise RuntimeError("Could not find POI {poiname} after factory call".format(poiname=poiname))
+                    raise RuntimeError(f"Could not find POI {poiname} after factory call")
                 poiNames.append(poiname)
         # RooFit would also detect duplicate params with mismatched factory, but this is faster
         constructed = {}
@@ -97,25 +97,25 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
                 else:
                     rooparam = self.modelBuilder.factory_(param)
                     if not rooparam:
-                        raise RuntimeError("Failed to build {param}".format(param=param))
+                        raise RuntimeError(f"Failed to build {param}")
                     if not self.explict_pois and isinstance(rooparam, ROOT.RooRealVar) and not rooparam.isConstant():
                         if self.verbose:
-                            print("Assuming parameter {param} is to be a POI (name: {name})".format(param=param, name=rooparam.GetName()))
+                            print(f"Assuming parameter {param} is to be a POI (name: {rooparam.GetName()})")
                         poiNames.append(rooparam.GetName())
                     constructed[param] = rooparam
                 # save for later use in making CMSInterferenceFunc
                 item["parameters_inworkspace"].append(rooparam)
         if self.verbose:
-            print("All POIs: {poiNames}".format(poiNames=poiNames))
+            print(f"All POIs: {poiNames}")
         return poiNames
 
     def getYieldScale(self, channel, process):
-        string = "%s/%s" % (channel, process)
+        string = f"{channel}/{process}"
         try:
             item = self.scaling_map[(channel, process)]
         except KeyError:
             if self.verbose:
-                print("Will scale {string} by 1".format(string=string))
+                print(f"Will scale {string} by 1")
             return 1
         print("Will scale {string} using CMSInterferenceFunc dependent on parameters {parameters}".format(string=string, parameters=item["parameters"]))
         item["found"] = True
@@ -127,29 +127,29 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
         for item in self.scaling_map.values():
             channel = item["channel"]
             process = item["process"]
-            string = "%s/%s" % (channel, process)
+            string = f"{channel}/{process}"
             if "found" not in item:
                 if self.verbose:
-                    print("Did not find {string} in workspace, even though it is in scaling data".format(string=string))
+                    print(f"Did not find {string} in workspace, even though it is in scaling data")
                 continue
 
-            hfname = "shapeSig_{channel}_{process}_morph".format(channel=channel, process=process)
+            hfname = f"shapeSig_{channel}_{process}_morph"
             histfunc = self.modelBuilder.out.function(hfname)
             if not histfunc:
                 # if there are no systematics, it ends up with a different name?
-                hfname = "shapeSig_{process}_{channel}_rebinPdf".format(channel=channel, process=process)
+                hfname = f"shapeSig_{process}_{channel}_rebinPdf"
                 histfunc = self.modelBuilder.out.function(hfname)
             if not histfunc:
                 # assume this is a CMSHistSum workspace
-                histsum_name = "prop_bin{channel}".format(channel=channel)
+                histsum_name = f"prop_bin{channel}"
                 histfunc = self.modelBuilder.out.function(histsum_name)
                 # in this workspace there is no object representing the process morphing
                 # make one up so that funcname is still unique
-                hfname = "prop_bin{channel}_process{process}".format(channel=channel, process=process)
+                hfname = f"prop_bin{channel}_process{process}"
             # TODO: support FastVerticalInterpHistPdf2
             if not isinstance(histfunc, (ROOT.CMSHistFunc, ROOT.CMSHistSum)):
                 raise RuntimeError(
-                    "Could not locate the CMSHistFunc or CMSHistSum for {string}.\n".format(string=string)
+                    f"Could not locate the CMSHistFunc or CMSHistSum for {string}.\n"
                     + "Note that CMSInterferenceFunc currently only supports workspaces that use these classes"
                 )
 
@@ -172,7 +172,7 @@ class InterferenceModel(PhysicsModelBase_NiceSubclasses):
             if isinstance(histfunc, ROOT.CMSHistFunc):
                 histfunc.injectExternalMorph(func)
             elif isinstance(histfunc, ROOT.CMSHistSum):
-                postfix = "bin{channel}_proc_{process}".format(channel=channel, process=process)
+                postfix = f"bin{channel}_proc_{process}"
                 for idx, coef in enumerate(histfunc.coefList()):
                     if coef.GetName() in ("n_exp_" + postfix, "n_exp_final_" + postfix):
                         if self.verbose:

--- a/python/InvisibleWidth.py
+++ b/python/InvisibleWidth.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import ROOT
@@ -39,7 +37,7 @@ class InvisibleWidth(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kV,ktau,ktop,kbottom,kgluon,kgamma,BRInvUndet,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -87,7 +85,7 @@ class InvisibleWidth(SMLikeHiggsModel):
         self.modelBuilder.factory_('expr::invisibleWidth_BRscal_hgg("@0*@0/@1", kgamma, invisibleWidth_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "invisibleWidth_XSBRscal_%s_%s" % (production, decay)
+        name = f"invisibleWidth_XSBRscal_{production}_{decay}"
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
             XSscal = "kgluon"
@@ -96,7 +94,7 @@ class InvisibleWidth(SMLikeHiggsModel):
             if production == "ttH":
                 XSscal = "ktop"
             if decay == "hinv":
-                self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, BRInvUndet)' % (name, XSscal))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, BRInvUndet)')
             else:
                 if decay in ["hbb", "htt", "hgg"]:
                     BRscal = decay
@@ -104,5 +102,5 @@ class InvisibleWidth(SMLikeHiggsModel):
                     BRscal = "hvv"
                 else:
                     print("Unknown decay mode:", decay)
-                self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, invisibleWidth_BRscal_%s)' % (name, XSscal, BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, invisibleWidth_BRscal_{BRscal})')
         return name

--- a/python/LHCHCGModels.py
+++ b/python/LHCHCGModels.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import ROOT
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 from HiggsAnalysis.CombinedLimit.SMHiggsBuilder import SMHiggsBuilder
@@ -136,7 +134,7 @@ class LHCHCGBaseModel(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
         else:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setVal(self.options.mass)
@@ -162,7 +160,7 @@ class SignalStrengths(LHCHCGBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         self.modelBuilder.out.var(vname).setConstant(constant)
-        print("SignalStrengths:: declaring %s as %s, and set to constant" % (vname, x))
+        print(f"SignalStrengths:: declaring {vname} as {x}, and set to constant")
 
     def doParametersOfInterest(self):
         """Create POI out of signal strength and MH"""
@@ -186,7 +184,7 @@ class SignalStrengths(LHCHCGBaseModel):
             self.doVar("mu_XS8_%s[1,0,5]" % X)
             self.doVar("mu_XS13_%s[1,0,5]" % X)
             for Y in CMS_to_LHCHCG_Dec.values():
-                self.doVar("mu_XS_%s_BR_%s[1,0,5]" % (X, Y))
+                self.doVar(f"mu_XS_{X}_BR_{Y}[1,0,5]")
         for X in CMS_to_LHCHCG_DecSimple.values():
             self.doVar("mu_V_%s[1,0,5]" % X)
             self.doVar("mu_F_%s[1,0,5]" % X)
@@ -256,7 +254,7 @@ class SignalStrengths(LHCHCGBaseModel):
                     self.modelBuilder.out.function("scaling_%s_%s_%dTeV" % (P, D, E)).Print("")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        return "scaling_%s_%s_%s" % (production, decay, energy)
+        return f"scaling_{production}_{decay}_{energy}"
 
 
 class SignalStrengthRatios(LHCHCGBaseModel):
@@ -275,7 +273,7 @@ class SignalStrengthRatios(LHCHCGBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         self.modelBuilder.out.var(vname).setConstant(constant)
-        print("SignalStrengthRatios:: declaring %s as %s, and set to constant" % (vname, x))
+        print(f"SignalStrengthRatios:: declaring {vname} as {x}, and set to constant")
 
     def doParametersOfInterest(self):
         """Create POI out of signal strength ratios and MH"""
@@ -312,7 +310,7 @@ class SignalStrengthRatios(LHCHCGBaseModel):
                     self.modelBuilder.out.function("scaling_%s_%s_%dTeV" % (P, D, E)).Print("")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        return "scaling_%s_%s_%s" % (production, decay, energy)
+        return f"scaling_{production}_{decay}_{energy}"
 
 
 class XSBRratios(LHCHCGBaseModel):
@@ -332,7 +330,7 @@ class XSBRratios(LHCHCGBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         self.modelBuilder.out.var(vname).setConstant(constant)
-        print("XSBRratios:: declaring %s as %s, and set to constant" % (vname, x))
+        print(f"XSBRratios:: declaring {vname} as {x}, and set to constant")
 
     def doParametersOfInterest(self):
         """Create POI out of signal strength ratios and MH"""
@@ -351,8 +349,8 @@ class XSBRratios(LHCHCGBaseModel):
         for X in ["ZZ", "tautau", "bb", "gamgam", "WW", "mumu"]:
             if X == self.denominator:
                 continue
-            self.modelBuilder.doVar("mu_BR_%s_r_BR_%s[1,0,5]" % (X, self.denominator))
-            self.POIs += ",mu_BR_%s_r_BR_%s" % (X, self.denominator)
+            self.modelBuilder.doVar(f"mu_BR_{X}_r_BR_{self.denominator}[1,0,5]")
+            self.POIs += f",mu_BR_{X}_r_BR_{self.denominator}"
         print("Default parameters of interest: ", self.POIs)
         self.modelBuilder.doSet("POI", self.POIs)
         self.SMH = SMHiggsBuilder(self.modelBuilder)
@@ -367,7 +365,7 @@ class XSBRratios(LHCHCGBaseModel):
                 for E in 7, 8, 13:
                     terms = ["mu_XS_ggF_x_BR_%s" % self.denominator]
                     if CMS_to_LHCHCG_DecSimple[D] != self.denominator:
-                        terms += ["mu_BR_%s_r_BR_%s" % (CMS_to_LHCHCG_DecSimple[D], self.denominator)]
+                        terms += [f"mu_BR_{CMS_to_LHCHCG_DecSimple[D]}_r_BR_{self.denominator}"]
                     if P in ["ttH", "tHq", "tHW"]:
                         terms += ["mu_XS_ttH_r_XS_ggF"]
                     if P in ["ZH", "ggZH"]:
@@ -398,7 +396,7 @@ class XSBRratios(LHCHCGBaseModel):
                     self.modelBuilder.out.function("scaling_%s_%s_%dTeV" % (P, D, E)).Print("")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        return "scaling_%s_%s_%s" % (production, decay, energy)
+        return f"scaling_{production}_{decay}_{energy}"
 
 
 class Kappas(LHCHCGBaseModel):
@@ -574,10 +572,10 @@ class Kappas(LHCHCGBaseModel):
         self.modelBuilder.factory_('expr::c7_BRscal_hinv("@0", BRinv)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"c7_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "qqH", "ggZH", "tHq", "tHW"]:
-                XSscal = ("@0", "Scaling_%s_%s" % (production, energy))
+                XSscal = ("@0", f"Scaling_{production}_{energy}")
             elif production == "WH":
                 XSscal = ("@0*@0", self.kappa_W)
             elif production == "ZH":
@@ -594,13 +592,11 @@ class Kappas(LHCHCGBaseModel):
             if decay == "hss":
                 BRscal = "hbb"
             if production == "ggH" and (decay in self.add_bbH) and energy in ["7TeV", "8TeV", "13TeV", "14TeV"]:
-                b2g = "CMS_R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01)
+                b2g = f"CMS_R_bbH_ggH_{decay}_{energy}[{0.01:g}]"
                 b2gs = "CMS_bbH_scaler_%s" % energy
-                self.modelBuilder.factory_(
-                    'expr::%s("(%s + @1*@1*@2*@3)*@4", %s, kappa_b, %s, %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], b2g, b2gs, BRscal)
-                )
+                self.modelBuilder.factory_(f'expr::{name}("({XSscal[0]} + @1*@1*@2*@3)*@4", {XSscal[1]}, kappa_b, {b2g}, {b2gs}, c7_BRscal_{BRscal})')
             else:
-                self.modelBuilder.factory_('expr::%s("%s*@1", %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("{XSscal[0]}*@1", {XSscal[1]}, c7_BRscal_{BRscal})')
             print("[LHC-HCG Kappas]", name, production, decay, energy, ": ", end=" ")
             self.modelBuilder.out.function(name).Print("")
         return name
@@ -644,7 +640,7 @@ class Lambdas(LHCHCGBaseModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
         else:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setVal(self.options.mass)
@@ -676,7 +672,7 @@ class Lambdas(LHCHCGBaseModel):
 
         for E in "7TeV", "8TeV", "13TeV", "14TeV":
             for P in "qqH", "tHq", "tHW", "ggZH":
-                self.modelBuilder.factory_('expr::PW_XSscal_%s_%s("@0*@1*@1",Scaling_%s_%s,lambda_Zg)' % (P, E, P, E))
+                self.modelBuilder.factory_(f'expr::PW_XSscal_{P}_{E}("@0*@1*@1",Scaling_{P}_{E},lambda_Zg)')
             self.modelBuilder.factory_('expr::PW_XSscal_WH_%s("@0*@0*@1*@1",lambda_Zg,lambda_WZ)' % E)
             self.modelBuilder.factory_('expr::PW_XSscal_ZH_%s("@0*@0",lambda_Zg)' % E)
             self.modelBuilder.factory_('expr::PW_XSscal_ttH_%s("@0*@0",lambda_tg)' % E)
@@ -698,7 +694,7 @@ class Lambdas(LHCHCGBaseModel):
             self.decayMap_["hmm"] = "lambda_tauZ"
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"c7_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name):
             return name
         dscale = self.decayMap_[decay]
@@ -706,17 +702,17 @@ class Lambdas(LHCHCGBaseModel):
             name += "_noBRU"
         if production == "ggH":
             if decay in self.add_bbH:
-                b2g = "CMS_R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01)
+                b2g = f"CMS_R_bbH_ggH_{decay}_{energy}[{0.01:g}]"
                 b2gs = "CMS_bbH_scaler_%s" % energy
-                self.modelBuilder.factory_('expr::%s("@0*@0*@1*@1*(1+@2*@3*@4*@4*@5*@5)",kappa_gZ,%s,%s,%s,lambda_bZ,lambda_Zg)' % (name, dscale, b2g, b2gs))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@0*@1*@1*(1+@2*@3*@4*@4*@5*@5)",kappa_gZ,{dscale},{b2g},{b2gs},lambda_bZ,lambda_Zg)')
             else:
-                self.modelBuilder.factory_('expr::%s("@0*@0*   @1*@1",kappa_gZ,%s)' % (name, dscale))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@0*   @1*@1",kappa_gZ,{dscale})')
         else:
-            self.modelBuilder.factory_('expr::%s("@0*@0*@1*@2*@2",kappa_gZ,PW_XSscal_%s_%s,%s)' % (name, production, energy, dscale))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0*@1*@2*@2",kappa_gZ,PW_XSscal_{production}_{energy},{dscale})')
         if self.doBRU:
             name = name.replace("_noBRU", "")
             if decay == "hzz":
-                self.modelBuilder.factory_("prod::%s(%s_noBRU, HiggsDecayWidth_UncertaintyScaling_%s)" % (name, name, "hzz"))
+                self.modelBuilder.factory_("prod::{}({}_noBRU, HiggsDecayWidth_UncertaintyScaling_{})".format(name, name, "hzz"))
             else:
                 self.modelBuilder.factory_(
                     'expr::%s("@0*(@1/@2)", %s_noBRU, HiggsDecayWidth_UncertaintyScaling_%s, HiggsDecayWidth_UncertaintyScaling_%s)'
@@ -785,8 +781,8 @@ class KappaVKappaF(LHCHCGBaseModel):
         self.modelBuilder.out.function("c7_SMBRs").Print("")
 
         for ds in ["WW", "ZZ", "gamgam", "bb", "tautau", "mumu", "inv"]:
-            self.modelBuilder.factory_('expr::kVkV_%s("@0*@1", kappa_V,kappa_V_%s)' % (ds, ds))
-            self.modelBuilder.factory_('expr::kFkF_%s("@0*@1", kappa_F,kappa_F_%s)' % (ds, ds))
+            self.modelBuilder.factory_(f'expr::kVkV_{ds}("@0*@1", kappa_V,kappa_V_{ds})')
+            self.modelBuilder.factory_(f'expr::kFkF_{ds}("@0*@1", kappa_F,kappa_F_{ds})')
 
             # get tHq, tHW, ggZH cross section
             self.SMH.makeScaling("tHq_" + ds, CW="kVkV_" + ds, Ctop="kFkF_" + ds)
@@ -808,19 +804,17 @@ class KappaVKappaF(LHCHCGBaseModel):
                 Ctau="kFkF_" + ds,
             )
             ## partial witdhs, normalized to the SM one
-            self.modelBuilder.factory_('expr::c7_Gscal_Z_%s("@0*@0*@1*@2", kVkV_%s, SM_BR_hzz, HiggsDecayWidth_UncertaintyScaling_hzz)' % (ds, ds))
-            self.modelBuilder.factory_('expr::c7_Gscal_W_%s("@0*@0*@1*@2", kVkV_%s, SM_BR_hww, HiggsDecayWidth_UncertaintyScaling_hww)' % (ds, ds))
+            self.modelBuilder.factory_(f'expr::c7_Gscal_Z_{ds}("@0*@0*@1*@2", kVkV_{ds}, SM_BR_hzz, HiggsDecayWidth_UncertaintyScaling_hzz)')
+            self.modelBuilder.factory_(f'expr::c7_Gscal_W_{ds}("@0*@0*@1*@2", kVkV_{ds}, SM_BR_hww, HiggsDecayWidth_UncertaintyScaling_hww)')
             self.modelBuilder.factory_(
                 'expr::c7_Gscal_tau_%s("@0*@0*@1*@3+@0*@0*@2*@4", kFkF_%s, SM_BR_htt, SM_BR_hmm, HiggsDecayWidth_UncertaintyScaling_htt, HiggsDecayWidth_UncertaintyScaling_hmm)'
                 % (ds, ds)
             )
-            self.modelBuilder.factory_('expr::c7_Gscal_top_%s("@0*@0 * @1*@2", kFkF_%s, SM_BR_hcc, HiggsDecayWidth_UncertaintyScaling_hcc)' % (ds, ds))
+            self.modelBuilder.factory_(f'expr::c7_Gscal_top_{ds}("@0*@0 * @1*@2", kFkF_{ds}, SM_BR_hcc, HiggsDecayWidth_UncertaintyScaling_hcc)')
             self.modelBuilder.factory_(
-                'expr::c7_Gscal_bottom_%s("@0*@0 * (@1*@3+@2)", kFkF_%s, SM_BR_hbb, SM_BR_hss, HiggsDecayWidth_UncertaintyScaling_hbb)' % (ds, ds)
+                f'expr::c7_Gscal_bottom_{ds}("@0*@0 * (@1*@3+@2)", kFkF_{ds}, SM_BR_hbb, SM_BR_hss, HiggsDecayWidth_UncertaintyScaling_hbb)'
             )
-            self.modelBuilder.factory_(
-                'expr::c7_Gscal_gluon_%s("  @0*@0*@1*@2", kFkF_%s, SM_BR_hgluglu, HiggsDecayWidth_UncertaintyScaling_hgluglu)' % (ds, ds)
-            )
+            self.modelBuilder.factory_(f'expr::c7_Gscal_gluon_{ds}("  @0*@0*@1*@2", kFkF_{ds}, SM_BR_hgluglu, HiggsDecayWidth_UncertaintyScaling_hgluglu)')
             self.modelBuilder.factory_(
                 'expr::c7_Gscal_gamma_%s("@0*@1*@4 + @2*@3*@5",  Scaling_hgg_%s, SM_BR_hgg, Scaling_hzg_%s, SM_BR_hzg, HiggsDecayWidth_UncertaintyScaling_hgg, HiggsDecayWidth_UncertaintyScaling_hzg)'
                 % (ds, ds, ds)
@@ -853,12 +847,12 @@ class KappaVKappaF(LHCHCGBaseModel):
         self.modelBuilder.factory_('expr::c7_BRscal_hinv("@0", BRinv)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"c7_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggZH", "tHq", "tHW"]:
                 XSscal = (
                     "@0",
-                    "Scaling_%s_%s_%s" % (production, CMS_to_LHCHCG_DecSimple[decay], energy),
+                    f"Scaling_{production}_{CMS_to_LHCHCG_DecSimple[decay]}_{energy}",
                 )
             elif production in ["ggH", "ttH", "bbH"]:
                 XSscal = ("@0*@0", "kFkF_" + CMS_to_LHCHCG_DecSimple[decay])
@@ -872,7 +866,7 @@ class KappaVKappaF(LHCHCGBaseModel):
             if not self.modelBuilder.out.function("c7_BRscal_" + BRscal):
                 raise RuntimeError("Decay mode %s not supported" % decay)
             if production == "ggH" and (decay in self.add_bbH) and energy in ["7TeV", "8TeV", "13TeV", "14TeV"]:
-                b2g = "CMS_R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01)
+                b2g = f"CMS_R_bbH_ggH_{decay}_{energy}[{0.01:g}]"
                 b2gs = "CMS_bbH_scaler_%s" % energy
                 self.modelBuilder.factory_(
                     'expr::%s("(%s + @1*@1*@2*@3)*@4", %s, kFkF_%s, %s, %s, c7_BRscal_%s)'
@@ -887,7 +881,7 @@ class KappaVKappaF(LHCHCGBaseModel):
                     )
                 )
             else:
-                self.modelBuilder.factory_('expr::%s("%s*@1", %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("{XSscal[0]}*@1", {XSscal[1]}, c7_BRscal_{BRscal})')
             print("[LHC-HCG Kappas]", name, production, decay, energy, ": ", end=" ")
             self.modelBuilder.out.function(name).Print("")
         return name
@@ -976,7 +970,7 @@ class LambdasReduced(LHCHCGBaseModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
         else:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setVal(self.options.mass)
@@ -1016,11 +1010,9 @@ class LambdasReduced(LHCHCGBaseModel):
 
         for E in "7TeV", "8TeV", "13TeV", "14TeV":
             for P in "ggH", "tHq", "tHW", "ggZH":
-                self.modelBuilder.factory_('expr::PW_XSscal_%s_%s("@0*@1*@1*@2*@2*@3*@3",Scaling_%s_%s,kappa_qq, kappa_uu, kappa_VV)' % (P, E, P, E))
+                self.modelBuilder.factory_(f'expr::PW_XSscal_{P}_{E}("@0*@1*@1*@2*@2*@3*@3",Scaling_{P}_{E},kappa_qq, kappa_uu, kappa_VV)')
             for P in "qqH", "WH", "ZH":
-                self.modelBuilder.factory_(
-                    'expr::PW_XSscal_%s_%s("@0*@0*@1*@1*@2*@2*@3*@3*@4*@4", kappa_qq, lambda_Vq, kappa_uu, lambda_Vu, kappa_VV)' % (P, E)
-                )
+                self.modelBuilder.factory_(f'expr::PW_XSscal_{P}_{E}("@0*@0*@1*@1*@2*@2*@3*@3*@4*@4", kappa_qq, lambda_Vq, kappa_uu, lambda_Vu, kappa_VV)')
             if self.flipped:
                 self.modelBuilder.factory_('expr::PW_XSscal_bbH_%s("@0*@0*@1*@1*@2*@2*@3*@3",kappa_qq,kappa_uu,kappa_VV,lambda_FV)' % E)
                 self.modelBuilder.factory_('expr::PW_XSscal_ttH_%s("@0*@0*@1*@1*@2*@2*@3*@3*@4*@4",kappa_qq,kappa_uu,lambda_du,kappa_VV,lambda_FV)' % E)
@@ -1043,7 +1035,7 @@ class LambdasReduced(LHCHCGBaseModel):
         }
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"c7_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name):
             return name
         dscale = self.decayMap_[decay]
@@ -1051,30 +1043,26 @@ class LambdasReduced(LHCHCGBaseModel):
             name += "_noBRU"
         if production == "ggH":
             if decay in self.add_bbH:
-                b2g = "CMS_R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01)
+                b2g = f"CMS_R_bbH_ggH_{decay}_{energy}[{0.01:g}]"
                 b2gs = "CMS_bbH_scaler_%s" % energy
                 if decay in ["hgg", "hgluglu", "hzg"]:
-                    self.modelBuilder.factory_(
-                        'expr::%s("@0*@1*(1+@2*@3*@4)",PW_XSscal_ggH_%s,%s,%s,%s,PW_XSscal_bbH_%s)' % (name, energy, dscale, b2g, b2gs, energy)
-                    )
+                    self.modelBuilder.factory_(f'expr::{name}("@0*@1*(1+@2*@3*@4)",PW_XSscal_ggH_{energy},{dscale},{b2g},{b2gs},PW_XSscal_bbH_{energy})')
                 else:
-                    self.modelBuilder.factory_(
-                        'expr::%s("@0*@1*@1*(1+@2*@3*@4)",PW_XSscal_ggH_%s,%s,%s,%s,PW_XSscal_bbH_%s)' % (name, energy, dscale, b2g, b2gs, energy)
-                    )
+                    self.modelBuilder.factory_(f'expr::{name}("@0*@1*@1*(1+@2*@3*@4)",PW_XSscal_ggH_{energy},{dscale},{b2g},{b2gs},PW_XSscal_bbH_{energy})')
             else:
                 if decay in ["hgg", "hgluglu", "hzg"]:
-                    self.modelBuilder.factory_('expr::%s("@0*@1",PW_XSscal_ggH_%s,%s)' % (name, energy, dscale))
+                    self.modelBuilder.factory_(f'expr::{name}("@0*@1",PW_XSscal_ggH_{energy},{dscale})')
                 else:
-                    self.modelBuilder.factory_('expr::%s("@0*@1*@1",PW_XSscal_ggH_%s,%s)' % (name, energy, dscale))
+                    self.modelBuilder.factory_(f'expr::{name}("@0*@1*@1",PW_XSscal_ggH_{energy},{dscale})')
         else:
             if decay in ["hgg", "hgluglu", "hzg"]:
-                self.modelBuilder.factory_('expr::%s("@0*@1",PW_XSscal_%s_%s,%s)' % (name, production, energy, dscale))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@1",PW_XSscal_{production}_{energy},{dscale})')
             else:
-                self.modelBuilder.factory_('expr::%s("@0*@1*@1",PW_XSscal_%s_%s,%s)' % (name, production, energy, dscale))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@1*@1",PW_XSscal_{production}_{energy},{dscale})')
         if self.doBRU:
             name = name.replace("_noBRU", "")
             if decay == "hzz":
-                self.modelBuilder.factory_("prod::%s(%s_noBRU, HiggsDecayWidth_UncertaintyScaling_%s)" % (name, name, "hzz"))
+                self.modelBuilder.factory_("prod::{}({}_noBRU, HiggsDecayWidth_UncertaintyScaling_{})".format(name, name, "hzz"))
             else:
                 self.modelBuilder.factory_(
                     'expr::%s("@0*(@1/@2)", %s_noBRU, HiggsDecayWidth_UncertaintyScaling_%s, HiggsDecayWidth_UncertaintyScaling_%s)'
@@ -1101,7 +1089,7 @@ class XSBRratiosAlternative(LHCHCGBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         self.modelBuilder.out.var(vname).setConstant(constant)
-        print("XSBRratios:: declaring %s as %s, and set to constant" % (vname, x))
+        print(f"XSBRratios:: declaring {vname} as {x}, and set to constant")
 
     def doParametersOfInterest(self):
         """Create POI out of signal strength ratios and MH"""
@@ -1185,7 +1173,7 @@ class XSBRratiosAlternative(LHCHCGBaseModel):
                     self.modelBuilder.out.function("scaling_%s_%s_%dTeV" % (P, D, E)).Print("")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        return "scaling_%s_%s_%s" % (production, decay, energy)
+        return f"scaling_{production}_{decay}_{energy}"
 
 
 class CommonMatrixModel(LHCHCGBaseModel):
@@ -1212,7 +1200,7 @@ class CommonMatrixModel(LHCHCGBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         self.modelBuilder.out.var(vname).setConstant(constant)
-        print("DegenerateMatrixModel:: declaring %s as %s, and set to constant" % (vname, x))
+        print(f"DegenerateMatrixModel:: declaring {vname} as {x}, and set to constant")
 
     def doParametersOfInterest(self):
         """Create POI out of l_j and l_j_i, and mu_i"""
@@ -1220,8 +1208,8 @@ class CommonMatrixModel(LHCHCGBaseModel):
             self.doVar("l_%s[1,0,10]" % X)
             self.POIs.append("l_%s" % X)
             for Y in ["gamgam", "WW", "ZZ", "tautau", "bb"]:
-                self.doVar("l_%s_%s[1,0,10]" % (X, Y))
-                self.POIs.append("l_%s_%s" % (X, Y))
+                self.doVar(f"l_{X}_{Y}[1,0,10]")
+                self.POIs.append(f"l_{X}_{Y}")
         for D in ["gamgam", "WW", "ZZ", "tautau", "bb"]:
             self.modelBuilder.doVar("mu_%s[1,0,5]" % D)
             if D in self.fixDecays:  # If there are any missing ggH measurements, create the mus here and a POI out of it.
@@ -1276,7 +1264,7 @@ class CommonMatrixModel(LHCHCGBaseModel):
                         terms += [
                             "mu_" + CMS_to_LHCHCG_DecSimple[D],
                             "l_" + CMS_to_LHCHCG_Prod[P],
-                            "l_%s_%s" % (CMS_to_LHCHCG_Prod[P], CMS_to_LHCHCG_DecSimple[D]),
+                            f"l_{CMS_to_LHCHCG_Prod[P]}_{CMS_to_LHCHCG_DecSimple[D]}",
                         ]
                     if P in ["ZH", "ggZH"]:
                         # Will the production mode be now ZH, qqZH or what? See naming conventions... qqHz missing completely in ALL_HIGGS_PROD
@@ -1289,7 +1277,7 @@ class CommonMatrixModel(LHCHCGBaseModel):
                         terms += [
                             "mu_" + CMS_to_LHCHCG_DecSimple[D],
                             "l_" + CMS_to_LHCHCG_Prod[P],
-                            "l_%s_%s" % (CMS_to_LHCHCG_Prod[P], CMS_to_LHCHCG_DecSimple[D]),
+                            f"l_{CMS_to_LHCHCG_Prod[P]}_{CMS_to_LHCHCG_DecSimple[D]}",
                         ]
                     if P in ["ttH", "tHq", "tHW"]:
                         terms += [
@@ -1301,7 +1289,7 @@ class CommonMatrixModel(LHCHCGBaseModel):
                     self.modelBuilder.out.function("scaling_%s_%s_%dTeV" % (P, D, E)).Print("")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        return "scaling_%s_%s_%s" % (production, decay, energy)
+        return f"scaling_{production}_{decay}_{energy}"
 
 
 A1 = SignalStrengths()

--- a/python/LOFullParametrization.py
+++ b/python/LOFullParametrization.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import ROOT
@@ -37,7 +35,7 @@ class C5(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "kV,ktau,kquark,kgluon,kgamma,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -81,7 +79,7 @@ class C5(SMLikeHiggsModel):
         self.modelBuilder.factory_('expr::c6_BRscal_hgg("@0*@0/@1", kgamma, c6_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c6_XSBRscal_%s_%s" % (production, decay)
+        name = f"c6_XSBRscal_{production}_{decay}"
         print("[LOFullParametrization::C6]")
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
@@ -95,7 +93,7 @@ class C5(SMLikeHiggsModel):
                 BRscal = decay
             if decay in ["hww", "hzz"]:
                 BRscal = "hvv"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, c6_BRscal_{BRscal})')
         return name
 
 
@@ -137,7 +135,7 @@ class C6(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", pois + ",MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -190,7 +188,7 @@ class C6(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::c6_BRscal_hzg("@0*@0/@1", kZgamma, c6_Gscal_tot)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c6_XSBRscal_%s_%s" % (production, decay)
+        name = f"c6_XSBRscal_{production}_{decay}"
         print("[LOFullParametrization::C6]")
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
@@ -200,7 +198,7 @@ class C6(SMLikeHiggsModel):
             if production == "ttH":
                 XSscal = "ktop"
             if production in ["tHq", "tHW"]:
-                XSscal = "Scaling_%s_%s" % (production, energy)
+                XSscal = f"Scaling_{production}_{energy}"
             BRscal = "hgg"
             if decay in ["hbb", "htt"]:
                 BRscal = decay
@@ -209,9 +207,9 @@ class C6(SMLikeHiggsModel):
             if self.doHZg and decay == "hzg":
                 BRscal = "hzg"
             if "Scaling" in XSscal:  # already squared, just put XSscal
-                self.modelBuilder.factory_('expr::%s("@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("@0 * @1", {XSscal}, c6_BRscal_{BRscal})')
             else:  # plain coupling, put (XSscal)^2
-                self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, c6_BRscal_%s)' % (name, XSscal, BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, c6_BRscal_{BRscal})')
 
         return name
 
@@ -258,7 +256,7 @@ class C7(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", pois + ",MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -313,7 +311,7 @@ class C7(SMLikeHiggsModel):
             self.modelBuilder.factory_('expr::c7_BRscal_hinv("@0>=0?@0:-100", BRInvUndet)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s" % (production, decay)
+        name = f"c7_XSBRscal_{production}_{decay}"
         print("[LOFullParametrization::C7]")
         print(name, production, decay, energy)
         if self.modelBuilder.out.function(name) == None:
@@ -331,7 +329,7 @@ class C7(SMLikeHiggsModel):
                 BRscal = "hzg"
             if self.doHInv and decay == "hinv":
                 BRscal = "hinv"
-            self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, c7_BRscal_%s)' % (name, XSscal, BRscal))
+            self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, c7_BRscal_{BRscal})')
         return name
 
 
@@ -368,7 +366,7 @@ class PartialWidthsModel(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "r_WZ,r_gZ,r_tZ,r_bZ,r_mZ,r_topglu,r_Zglu,c_gluZ,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -419,7 +417,7 @@ class PartialWidthsModel(SMLikeHiggsModel):
         }
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s" % (production, decay)
+        name = f"c7_XSBRscal_{production}_{decay}"
         if production == "qqH":
             name += "_%s" % energy
         if self.modelBuilder.out.function(name):
@@ -438,5 +436,5 @@ class PartialWidthsModel(SMLikeHiggsModel):
             pscale,
             dscale,
         )
-        self.modelBuilder.factory_("prod::%s(%s,sc_gluZ,%s)" % (name, dscale, pscale))
+        self.modelBuilder.factory_(f"prod::{name}({dscale},sc_gluZ,{pscale})")
         return name

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 import sys
 from math import exp, hypot, log
@@ -37,9 +35,9 @@ def fullmatch(regex, line):
 
 def quadratureAdd(pdf, val1, val2, context=None):
     if type(val1) == list and len(val1) != 2:
-        raise RuntimeError("{} is a list of length != 2".format(val1))
+        raise RuntimeError(f"{val1} is a list of length != 2")
     if type(val2) == list and len(val2) != 2:
-        raise RuntimeError("{} is a list of length != 2".format(val2))
+        raise RuntimeError(f"{val2} is a list of length != 2")
 
     if type(val1) == list and type(val2) == list:
         return [
@@ -58,13 +56,11 @@ def quadratureAdd(pdf, val1, val2, context=None):
         ]
     if pdf in ["lnN", "lnU"]:
         if log(val1) * log(val2) < 0:
-            raise RuntimeError(
-                "Can't add in quadrature nuisances of pdf %s with values %s, %s that go in different directions (at %s)" % (pdf, val1, val2, context)
-            )
+            raise RuntimeError(f"Can't add in quadrature nuisances of pdf {pdf} with values {val1}, {val2} that go in different directions (at {context})")
         ret = exp(hypot(abs(log(val1)), abs(log(val2))))
         return ret if val1 > 1 else 1.0 / ret
     else:
-        raise RuntimeError("Quadrature add not implemented for pdf %s (at %s)" % (pdf, context))
+        raise RuntimeError(f"Quadrature add not implemented for pdf {pdf} (at {context})")
 
 
 def doAddNuisance(datacard, args):
@@ -77,11 +73,11 @@ def doAddNuisance(datacard, args):
         cchannel = re.compile(channel.replace("+", r"\+"))
     opts = args[5:]
     found = False
-    errline = dict([(b, dict([(p, 0) for p in datacard.exp[b]])) for b in datacard.bins])
+    errline = {b: {p: 0 for p in datacard.exp[b]} for b in datacard.bins}
     for lsyst, nofloat, pdf0, args0, errline0 in datacard.systs:
         if lsyst == name:
             if pdf != pdf0:
-                raise RuntimeError("Can't add nuisance %s with pdf %s ad it already exists as %s" % (name, pdf, pdf0))
+                raise RuntimeError(f"Can't add nuisance {name} with pdf {pdf} ad it already exists as {pdf0}")
             found = True
             errline = errline0
     if not found:
@@ -204,7 +200,7 @@ def doRenameNuisance(datacard, args):
                 )
             if newname in list(datacard.systIDMap.keys()):
                 if not checkRenameSafety(id, datacard, newname):
-                    raise RuntimeError("Error: Cannot rename %s to %s, which exists and is incompatible" % (oldname, newname))
+                    raise RuntimeError(f"Error: Cannot rename {oldname} to {newname}, which exists and is incompatible")
 
             if isGlobal:  # easy case
                 # print " global command, ", " looking at "
@@ -226,7 +222,7 @@ def doRenameNuisance(datacard, args):
                 if pdf0 == "param":
                     continue
                 # for dcs in datacard.systs: print " --> ", dcs
-                errline2 = dict([(b, dict([(p, 0) for p in datacard.exp[b]])) for b in datacard.bins])
+                errline2 = {b: {p: 0 for p in datacard.exp[b]} for b in datacard.bins}
                 found = False
                 if newname in list(datacard.systIDMap.keys()):
                     for id2 in datacard.systIDMap[newname]:
@@ -316,7 +312,7 @@ def doChangeNuisancePdf(datacard, args):
             if ok:
                 datacard.systs[i][2] = newpdf
             else:
-                raise RuntimeError("I can't convert pdf %s from pdf %s to %s" % (lsyst, pdf, newpdf))
+                raise RuntimeError(f"I can't convert pdf {lsyst} from pdf {pdf} to {newpdf}")
     if not found:
         sys.stderr.write("Warning: no pdf found for changepdf with args %s\n" % args)
 
@@ -425,7 +421,7 @@ def doFlipNuisance(datacard, args):
     for lsyst, nofloat, pdf, args0, errline in datacard.systs:
         if fullmatch(name, lsyst):
             if pdf not in ["lnN"]:
-                raise RuntimeError("Error: nuisance edit flip %s currently not support pdftype %s" % (args, pdf))
+                raise RuntimeError(f"Error: nuisance edit flip {args} currently not support pdftype {pdf}")
             for b in errline.keys():
                 if channel == "*" or fullmatch(cchannel, b):
                     for p in datacard.exp[b]:
@@ -474,4 +470,4 @@ def doEditNuisance(datacard, command, args):
     elif command == "flip":
         doFlipNuisance(datacard, args)
     else:
-        raise RuntimeError("Error, unknown nuisance edit command %s (args %s)" % (command, args))
+        raise RuntimeError(f"Error, unknown nuisance edit command {command} (args {args})")

--- a/python/QuadraticScaling.py
+++ b/python/QuadraticScaling.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import numpy as np
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import PhysicsModel
@@ -40,7 +38,7 @@ class Quadratic(PhysicsModel):
         scaling = np.load(self.scaling, allow_pickle=True)[()]
         for process in self.processes:
             self.modelBuilder.out.var(process)
-            name = "r_{0}_{1}".format(process, self.coefficient)
+            name = f"r_{process}_{self.coefficient}"
             if not self.modelBuilder.out.function(name):
                 template = "expr::{name}('{a0} + ({a1} * {c}) + ({a2} * {c} * {c})', {c})"
                 a0, a1, a2 = scaling[self.coefficient][process]
@@ -49,7 +47,7 @@ class Quadratic(PhysicsModel):
 
     def doParametersOfInterest(self):
         # user should call combine with `--setPhysicsModelParameterRanges` set to sensible ranges
-        self.modelBuilder.doVar("{0}[0, -inf, inf]".format(self.coefficient))
+        self.modelBuilder.doVar(f"{self.coefficient}[0, -inf, inf]")
         self.modelBuilder.doSet("POI", self.coefficient)
         self.setup()
 
@@ -57,7 +55,7 @@ class Quadratic(PhysicsModel):
         if process not in self.processes:
             return 1
         else:
-            name = "r_{0}_{1}".format(process, self.coefficient)
+            name = f"r_{process}_{self.coefficient}"
 
             return name
 

--- a/python/QuasiDegenerate.py
+++ b/python/QuasiDegenerate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 
 # class for testing two near mass-degenerate Higgs model
@@ -108,7 +106,7 @@ class QuasiDegenerate(PhysicsModel):
                 self.modelBuilder.out.var("DMH").setVal(float(self.DMH))
                 self.modelBuilder.out.var("DMH").setConstant(True)
         else:
-            self.modelBuilder.doVar("DMH[%s,%s,%s]" % (self.DMH, self.DMHRange[0], self.DMHRange[1]))
+            self.modelBuilder.doVar(f"DMH[{self.DMH},{self.DMHRange[0]},{self.DMHRange[1]}]")
             if self.floatDMH:
                 if self.DMHAsPOI:
                     poi += ",DMH"
@@ -139,7 +137,7 @@ class QuasiDegenerate(PhysicsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             if self.mHAsPOI:
                 poi += ",MH"
         else:

--- a/python/SMHiggsBuilder.py
+++ b/python/SMHiggsBuilder.py
@@ -1,11 +1,8 @@
-from __future__ import absolute_import
-
 import os
 from array import array
 from math import *
 
 import six
-from six.moves import zip
 
 import ROOT
 from HiggsAnalysis.CombinedLimit.PhysicsModel import ALL_HIGGS_DECAYS
@@ -75,7 +72,7 @@ class SMHiggsBuilder:
     def makePartialWidth(self, decay):
         self.makeTotalWidth()
         self.makeBR(decay)
-        self.modelBuilder.factory_("prod::SM_Gamma_%s(SM_GammaTot,SM_BR_%s)" % (decay, decay))
+        self.modelBuilder.factory_(f"prod::SM_Gamma_{decay}(SM_GammaTot,SM_BR_{decay})")
 
     def makeScaling(
         self,
@@ -124,7 +121,7 @@ class SMHiggsBuilder:
                 "c_kc2": 6,
             }
             for sqrts in ("7TeV", "8TeV", "13TeV", "14TeV"):
-                for qty, column in six.iteritems(structure):
+                for qty, column in structure.items():
                     rooName = prefix + qty + "_" + sqrts
                     self.textToSpline(
                         rooName,
@@ -153,7 +150,7 @@ class SMHiggsBuilder:
                 self.modelBuilder.factory_(rooExpr)
         elif what.startswith("hgluglu"):
             structure = {"Gamma_tt": 2, "Gamma_bb": 3, "Gamma_tb": 4}
-            for qty, column in six.iteritems(structure):
+            for qty, column in structure.items():
                 rooName = prefix + qty
                 self.textToSpline(
                     rooName,
@@ -186,7 +183,7 @@ class SMHiggsBuilder:
                 "Gamma_bl": 10,
                 "Gamma_lW": 11,
             }
-            for qty, column in six.iteritems(structure):
+            for qty, column in structure.items():
                 rooName = prefix + qty
                 self.textToSpline(
                     rooName,
@@ -221,7 +218,7 @@ class SMHiggsBuilder:
                 "c_kbkZ": 6,
             }
             for sqrts in ("7TeV", "8TeV", "13TeV", "14TeV"):
-                for qty, column in six.iteritems(structure):
+                for qty, column in structure.items():
                     rooName = prefix + qty + "_" + sqrts
                     self.textToSpline(
                         rooName,
@@ -251,7 +248,7 @@ class SMHiggsBuilder:
                 scalingName = "Scaling_" + what + "_" + sqrts
                 rooExpr = (
                     "expr::%(scalingName)s" % locals()
-                    + '( "( (@0*@0)*(%g)  + (@1*@1)*(%g) + (@0*@1)*(%g) )/%g"' % tuple((coeffs[sqrts] + [sum(coeffs[sqrts])]))
+                    + '( "( (@0*@0)*(%g)  + (@1*@1)*(%g) + (@0*@1)*(%g) )/%g"' % tuple(coeffs[sqrts] + [sum(coeffs[sqrts])])
                     + ", %(Ctop)s, %(CW)s)" % locals()
                 )
                 self.modelBuilder.factory_(rooExpr)
@@ -266,7 +263,7 @@ class SMHiggsBuilder:
                 scalingName = "Scaling_" + what + "_" + sqrts
                 rooExpr = (
                     "expr::%(scalingName)s" % locals()
-                    + '( "( (@0*@0)*(%g)  + (@1*@1)*(%g) + (@0*@1)*(%g) )/%g"' % tuple((coeffs[sqrts] + [sum(coeffs[sqrts])]))
+                    + '( "( (@0*@0)*(%g)  + (@1*@1)*(%g) + (@0*@1)*(%g) )/%g"' % tuple(coeffs[sqrts] + [sum(coeffs[sqrts])])
                     + ", %(Ctop)s, %(CW)s,)" % locals()
                 )
                 self.modelBuilder.factory_(rooExpr)
@@ -289,7 +286,7 @@ class SMHiggsBuilder:
                 widthUncertaintiesKeys = line.split()[1:]
             else:
                 fields = line.split()
-                widthUncertainties[fields[0]] = dict([(k, 0.01 * float(v)) for (k, v) in zip(widthUncertaintiesKeys, fields[1:])])
+                widthUncertainties[fields[0]] = {k: 0.01 * float(v) for (k, v) in zip(widthUncertaintiesKeys, fields[1:])}
         for K in widthUncertaintiesKeys[:-1]:
             self.modelBuilder.doVar("param_%s[-7,7]" % K)
         for K, DS in THU_GROUPS:
@@ -325,14 +322,14 @@ class SMHiggsBuilder:
         log = open(logfile, "w")
         for x in values:
             xv.setVal(x)
-            log.write("%.3f\t%.7g\n" % (x, yf.getVal()))
+            log.write(f"{x:.3f}\t{yf.getVal():.7g}\n")
 
     def textToSpline(self, name, filename, xvar="MH", ycol=1, xcol=0, skipRows=1, algo="CSPLINE"):
         if self.modelBuilder.out.function(name) != None:
             return
         x = []
         y = []
-        file = open(filename, "r")
+        file = open(filename)
         lines = [l for l in file]
         for line in lines[skipRows:]:
             if len(line.strip()) == 0:

--- a/python/STXSModels.py
+++ b/python/STXSModels.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import fnmatch
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -65,7 +63,7 @@ def getSTXSProdDecMode(bin, process, options):
                 foundEnergy = D
     if not foundEnergy:
         foundEnergy = "13TeV"  ## if using 81x, chances are its 13 TeV
-        print("Warning: decay string %s does not contain any known energy, assuming %s" % (decaySource, foundEnergy))
+        print(f"Warning: decay string {decaySource} does not contain any known energy, assuming {foundEnergy}")
     #
     return (processSource, foundDecay, foundEnergy)
 
@@ -98,7 +96,7 @@ class STXSBaseModel(PhysicsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.POIs += ",MH"
         else:
             if self.modelBuilder.out.var("MH"):
@@ -131,7 +129,7 @@ class StageZero(STXSBaseModel):
         self.modelBuilder.doVar(x)
         vname = re.sub(r"\[.*", "", x)
         # self.modelBuilder.out.var(vname).setConstant(constant)
-        print("SignalStrengths:: declaring %s as %s" % (vname, x))
+        print(f"SignalStrengths:: declaring {vname} as {x}")
 
     def doParametersOfInterest(self):
         """Create POI out of signal strengths (and MH)"""
@@ -146,13 +144,13 @@ class StageZero(STXSBaseModel):
             for dec in SM_HIGG_DECAYS:
                 D = CMS_to_LHCHCG_DecSimple[dec]
                 if D == self.denominator:
-                    if not "mu_XS_%s_x_BR_%s" % (P, self.denominator) in pois:
-                        self.modelBuilder.doVar("mu_XS_%s_x_BR_%s[1,0,5]" % (P, self.denominator))
-                        pois.append("mu_XS_%s_x_BR_%s" % (P, self.denominator))
+                    if f"mu_XS_{P}_x_BR_{self.denominator}" not in pois:
+                        self.modelBuilder.doVar(f"mu_XS_{P}_x_BR_{self.denominator}[1,0,5]")
+                        pois.append(f"mu_XS_{P}_x_BR_{self.denominator}")
                 else:
-                    if not "mu_BR_%s_r_BR_%s" % (D, self.denominator) in pois:
-                        self.modelBuilder.doVar("mu_BR_%s_r_BR_%s[1,0,5]" % (D, self.denominator))
-                        pois.append("mu_BR_%s_r_BR_%s" % (D, self.denominator))
+                    if f"mu_BR_{D}_r_BR_{self.denominator}" not in pois:
+                        self.modelBuilder.doVar(f"mu_BR_{D}_r_BR_{self.denominator}[1,0,5]")
+                        pois.append(f"mu_BR_{D}_r_BR_{self.denominator}")
 
         print(pois)
         self.POIs = ",".join(pois)
@@ -179,17 +177,17 @@ class StageZero(STXSBaseModel):
                     continue
                 allDecs.append(D)
                 if D == self.denominator:
-                    muXSBR = "mu_XS_%s_x_BR_%s" % (P, self.denominator)
+                    muXSBR = f"mu_XS_{P}_x_BR_{self.denominator}"
                     self.modelBuilder.factory_("expr::scaling_" + P + "_" + D + '_13TeV("@0",' + muXSBR + ")")
                 else:
-                    muXSBR = "mu_XS_%s_x_BR_%s" % (P, self.denominator)
-                    muBR = "mu_BR_%s_r_BR_%s" % (D, self.denominator)
+                    muXSBR = f"mu_XS_{P}_x_BR_{self.denominator}"
+                    muBR = f"mu_BR_{D}_r_BR_{self.denominator}"
                     self.modelBuilder.factory_("expr::scaling_" + P + "_" + D + '_13TeV("@0*@1",' + muXSBR + "," + muBR + ")")
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
         for regproc in ALL_STXS_PROCS["Stage0"].keys():
             if fnmatch.fnmatch(production, regproc):
-                return "scaling_%s_%s_%s" % (
+                return "scaling_{}_{}_{}".format(
                     ALL_STXS_PROCS["Stage0"][regproc],
                     decay,
                     energy,

--- a/python/SingleTopModels.py
+++ b/python/SingleTopModels.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import ROOT
 from HiggsAnalysis.CombinedLimit.LHCHCGModels import *
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -146,10 +144,10 @@ class KappaVKappaT(LHCHCGBaseModel):
         self.modelBuilder.factory_('expr::c7_BRscal_hinv("@0", BRinv)')
 
     def getHiggsSignalYieldScale(self, production, decay, energy):
-        name = "c7_XSBRscal_%s_%s_%s" % (production, decay, energy)
+        name = f"c7_XSBRscal_{production}_{decay}_{energy}"
         if self.modelBuilder.out.function(name) == None:
             if production in ["ggH", "qqH", "ggZH", "tHq", "tHW"]:
-                XSscal = ("@0", "Scaling_%s_%s" % (production, energy))
+                XSscal = ("@0", f"Scaling_{production}_{energy}")
             elif production == "WH":
                 XSscal = ("@0*@0", "kappa_V")
             elif production == "ZH":
@@ -166,15 +164,13 @@ class KappaVKappaT(LHCHCGBaseModel):
             if decay == "hss":
                 BRscal = "hbb"
             if production in ["tHq", "tHW", "ttH"]:
-                self.modelBuilder.factory_('expr::%s("%s*@1*@2", %s, c7_BRscal_%s, r)' % (name, XSscal[0], XSscal[1], BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("{XSscal[0]}*@1*@2", {XSscal[1]}, c7_BRscal_{BRscal}, r)')
             elif production == "ggH" and (decay in self.add_bbH) and energy in ["7TeV", "8TeV", "13TeV", "14TeV"]:
-                b2g = "CMS_R_bbH_ggH_%s_%s[%g]" % (decay, energy, 0.01)
+                b2g = f"CMS_R_bbH_ggH_{decay}_{energy}[{0.01:g}]"
                 b2gs = "CMS_bbH_scaler_%s" % energy
-                self.modelBuilder.factory_(
-                    'expr::%s("(%s + @1*@1*@2*@3)*@4", %s, kappa_b, %s, %s, c7_BRscal_%s)' % (name, XSscal[0], XSscal[1], b2g, b2gs, BRscal)
-                )
+                self.modelBuilder.factory_(f'expr::{name}("({XSscal[0]} + @1*@1*@2*@3)*@4", {XSscal[1]}, kappa_b, {b2g}, {b2gs}, c7_BRscal_{BRscal})')
             else:
-                self.modelBuilder.factory_('expr::%s("%s*@1*@2", %s, c7_BRscal_%s,r)' % (name, XSscal[0], XSscal[1], BRscal))
+                self.modelBuilder.factory_(f'expr::{name}("{XSscal[0]}*@1*@2", {XSscal[1]}, c7_BRscal_{BRscal},r)')
             print("[LHC-HCG Kappas]", name, production, decay, energy, ": ", end=" ")
             self.modelBuilder.out.function(name).Print("")
         return name

--- a/python/SpinZeroHiggsCTau.py
+++ b/python/SpinZeroHiggsCTau.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import math
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -32,7 +30,7 @@ class SpinZeroHiggsCTau(PhysicsModel):
         if self.DC.isSignal[process]:
             self.my_norm = "r"
 
-            print("Process {0} will scale by {1}".format(process, self.my_norm))
+            print(f"Process {process} will scale by {self.my_norm}")
             return self.my_norm
 
         elif not self.DC.isSignal[process]:

--- a/python/SpinZeroStructure.py
+++ b/python/SpinZeroStructure.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import math
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -9,7 +7,7 @@ from HiggsAnalysis.CombinedLimit.PhysicsModel import *
 
 class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
     def __init__(self):
-        super(SpinZeroHiggsBase, self).__init__()
+        super().__init__()
 
         self.fai1Floating = True
         self.fai1POI = True
@@ -30,22 +28,22 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
         self.offshell = False
 
     def setModelBuilder(self, modelBuilder):
-        super(SpinZeroHiggsBase, self).setModelBuilder(modelBuilder)
+        super().setModelBuilder(modelBuilder)
         self.modelBuilder.doModelBOnly = False
 
     def getYieldScale(self, bin, process):
         "Split in production and decay, and call getHiggsSignalYieldScale; return 1 for backgrounds"
-        result = super(SpinZeroHiggsBase, self).getYieldScale(bin, process)
+        result = super().getYieldScale(bin, process)
         if result not in (0, 1):
-            print("Process {0} will scale by {1}".format(process, result))
+            print(f"Process {process} will scale by {result}")
         return result
 
     def processPhysicsOptions(self, physOptions):
-        processed = super(SpinZeroHiggsBase, self).processPhysicsOptions(physOptions)
+        processed = super().processPhysicsOptions(physOptions)
         for po in physOptions:
             if po.lower() == "fai1fixed" or po.lower() == "fai1notpoi":
                 if not self.fai1POI:
-                    raise ValueError("Specified fai1Fixed and/or fai1NotPOI multiple times!\n{}".format(physOptions))
+                    raise ValueError(f"Specified fai1Fixed and/or fai1NotPOI multiple times!\n{physOptions}")
                 print("CMS_zz4l_fai1 is NOT A POI")
                 self.fai1POI = False
                 if po.lower() == "fai1fixed":
@@ -55,7 +53,7 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
 
             if po.lower() == "phiai1floating" or po.lower() == "phiai1aspoi":
                 if self.phiai1Floating:
-                    raise ValueError("Specified phiai1Floating and/or phiai1AsPOI multiple times!\n{}".format(physOptions))
+                    raise ValueError(f"Specified phiai1Floating and/or phiai1AsPOI multiple times!\n{physOptions}")
                 print("Will consider phase ai1 as a floating parameter")
                 self.phiai1Floating = True
                 if po.lower() == "phiai1aspoi":
@@ -65,7 +63,7 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
 
             if po.lower() == "fai2floating" or po.lower() == "fai2aspoi":
                 if self.fai2Floating:
-                    raise ValueError("Specified fai2Floating and/or fai2AsPOI multiple times!\n{}".format(physOptions))
+                    raise ValueError(f"Specified fai2Floating and/or fai2AsPOI multiple times!\n{physOptions}")
                 print("Will float CMS_zz4l_fai2")
                 self.fai2Floating = True
                 if po.lower() == "fai2aspoi":
@@ -74,7 +72,7 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
 
             if po.lower() == "phiai2floating" or po.lower() == "phiai2aspoi":
                 if self.phiai2Floating:
-                    raise ValueError("Specified phiai2Floating and/or phiai2AsPOI multiple times!\n{}".format(physOptions))
+                    raise ValueError(f"Specified phiai2Floating and/or phiai2AsPOI multiple times!\n{physOptions}")
                 print("Will consider phase ai2 as a floating parameter")
                 self.phiai2Floating = True
                 if po.lower() == "phiai2aspoi":
@@ -98,7 +96,7 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
 
     def getPOIList(self):
         poi = []
-        poi += super(SpinZeroHiggsBase, self).getPOIList()
+        poi += super().getPOIList()
 
         if self.fai1Floating:
             if self.modelBuilder.out.var("CMS_zz4l_fai1"):
@@ -230,12 +228,12 @@ class SpinZeroHiggsBase(PhysicsModelBase_NiceSubclasses):
 
 class SpinZeroHiggs(SpinZeroHiggsBase):
     def __init__(self):
-        super(SpinZeroHiggs, self).__init__()
+        super().__init__()
         self.muFloating = True
         self.muAsPOI = False
 
     def processPhysicsOptions(self, physOptions):
-        processed = super(SpinZeroHiggs, self).processPhysicsOptions(physOptions)
+        processed = super().processPhysicsOptions(physOptions)
         for po in physOptions:
             if po.lower() == "mufixed":
                 print("Will consider the signal strength as a fixed parameter")
@@ -266,7 +264,7 @@ class SpinZeroHiggs(SpinZeroHiggsBase):
         return processed
 
     def getPOIList(self):
-        poi = super(SpinZeroHiggs, self).getPOIList()
+        poi = super().getPOIList()
         if self.muFloating:
             if self.modelBuilder.out.var("r"):
                 self.modelBuilder.out.var("r").setRange(0.0, 400.0)
@@ -295,7 +293,7 @@ class SpinZeroHiggs(SpinZeroHiggsBase):
 
 class MultiSignalSpinZeroHiggs(SpinZeroHiggsBase, CanTurnOffBkgModel, MultiSignalModel):
     def __init__(self):
-        super(MultiSignalSpinZeroHiggs, self).__init__()
+        super().__init__()
 
         self.scalemuvfseparately = True
         self.scaledifferentsqrtsseparately = False
@@ -311,10 +309,10 @@ class MultiSignalSpinZeroHiggs(SpinZeroHiggsBase, CanTurnOffBkgModel, MultiSigna
             # no po started with map --> no manual overriding --> use the defaults
             # can still override with e.g. turnoff=ZH,WH
             physOptions = ["map=.*/(gg|qq|Z|W|tt)H:1"] + physOptions
-        super(MultiSignalSpinZeroHiggs, self).setPhysicsOptions(physOptions)
+        super().setPhysicsOptions(physOptions)
 
     def processPhysicsOptions(self, physOptions):
-        processed = super(MultiSignalSpinZeroHiggs, self).processPhysicsOptions(physOptions)
+        processed = super().processPhysicsOptions(physOptions)
         for po in physOptions:
             if po.lower() == "scalemuvmuftogether":
                 self.scalemuvfseparately = False
@@ -339,23 +337,23 @@ class MultiSignalSpinZeroHiggs(SpinZeroHiggsBase, CanTurnOffBkgModel, MultiSigna
 
         if self.scaledifferentsqrtsseparately and self.scalemuvfseparately:
             if self.uservoverrf:
-                self.fixed = ["RV", "RF", "R"] + ["RF_{}TeV".format(_) for _ in self.sqrts]
-                self.floated = ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "") for _2 in self.sqrts]
+                self.fixed = ["RV", "RF", "R"] + [f"RF_{_}TeV" for _ in self.sqrts]
+                self.floated = [f"R{_1}_{_2}TeV" for _1 in ("V", "") for _2 in self.sqrts]
             else:
-                self.fixed = ["RV", "RF", "R"] + ["R_{}TeV".format(_) for _ in self.sqrts]
-                self.floated = ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "F") for _2 in self.sqrts]
+                self.fixed = ["RV", "RF", "R"] + [f"R_{_}TeV" for _ in self.sqrts]
+                self.floated = [f"R{_1}_{_2}TeV" for _1 in ("V", "F") for _2 in self.sqrts]
         elif self.scaledifferentsqrtsseparately and not self.scalemuvfseparately:
-            self.fixed = ["RV", "RF", "R"] + ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "F") for _2 in self.sqrts]
-            self.floated = ["R_{}TeV".format(_) for _ in self.sqrts]
+            self.fixed = ["RV", "RF", "R"] + [f"R{_1}_{_2}TeV" for _1 in ("V", "F") for _2 in self.sqrts]
+            self.floated = [f"R_{_}TeV" for _ in self.sqrts]
         elif not self.scaledifferentsqrtsseparately and self.scalemuvfseparately:
             if self.uservoverrf:
-                self.fixed = ["RF"] + ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "F", "") for _2 in self.sqrts]
+                self.fixed = ["RF"] + [f"R{_1}_{_2}TeV" for _1 in ("V", "F", "") for _2 in self.sqrts]
                 self.floated = ["RV", "R"]
             else:
-                self.fixed = ["R"] + ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "F", "") for _2 in self.sqrts]
+                self.fixed = ["R"] + [f"R{_1}_{_2}TeV" for _1 in ("V", "F", "") for _2 in self.sqrts]
                 self.floated = ["RV", "RF"]
         elif not self.scaledifferentsqrtsseparately and not self.scalemuvfseparately:
-            self.fixed = ["RV", "RF"] + ["R{}_{}TeV".format(_1, _2) for _1 in ("V", "F", "") for _2 in self.sqrts]
+            self.fixed = ["RV", "RF"] + [f"R{_1}_{_2}TeV" for _1 in ("V", "F", "") for _2 in self.sqrts]
             self.floated = ["R"]
         else:
             assert False, "?????"
@@ -363,31 +361,31 @@ class MultiSignalSpinZeroHiggs(SpinZeroHiggsBase, CanTurnOffBkgModel, MultiSigna
         return processed
 
     def getPOIList(self):
-        result = super(MultiSignalSpinZeroHiggs, self).getPOIList()
+        result = super().getPOIList()
 
         fixedorfloated = self.fixed + self.floated
         for variable in fixedorfloated:
             if not self.modelBuilder.out.var(variable):
-                print("{} does not exist in the workspace!  Check:\n - your datacard maker\n - your sqrts option".format(variable))
+                print(f"{variable} does not exist in the workspace!  Check:\n - your datacard maker\n - your sqrts option")
             else:
                 if "r" in variable.lower():
-                    print("Setting {} range to [1.,0.,400.]".format(variable))
+                    print(f"Setting {variable} range to [1.,0.,400.]")
                     self.modelBuilder.out.var(variable).setRange(0.0, 400.0)
                     self.modelBuilder.out.var(variable).setVal(1)
                 elif "ggsm" in variable.lower():
-                    print("Setting {} range to [1.,0.,50.]".format(variable))
+                    print(f"Setting {variable} range to [1.,0.,50.]")
                     self.modelBuilder.out.var(variable).setRange(0.0, 50.0)
                     self.modelBuilder.out.var(variable).setVal(1)
                 else:
-                    print("Setting {} value to 0".format(variable))
+                    print(f"Setting {variable} value to 0")
                     self.modelBuilder.out.var(variable).setVal(0)
         for variable in self.fixed:
             if self.modelBuilder.out.var(variable):
-                print("Fixing {}".format(variable))
+                print(f"Fixing {variable}")
                 self.modelBuilder.out.var(variable).setConstant()
         for variable in self.floated:
             if self.modelBuilder.out.var(variable):
-                print("Floating {} and assigning attribute flatParam".format(variable))
+                print(f"Floating {variable} and assigning attribute flatParam")
                 self.modelBuilder.out.var(variable).setConstant(False)
                 self.modelBuilder.out.var(variable).setAttribute("flatParam")
 

--- a/python/TagAndProbeModel.py
+++ b/python/TagAndProbeModel.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -25,7 +23,7 @@ class TagAndProbe(PhysicsModel):
                         exp_pass = self.DC.exp[b][p]
                     if re.search("fail", b):
                         exp_fail = self.DC.exp[b][p]
-        self.modelBuilder.factory_('expr::fail_scale("(%f+%f-(%f*@0))/%f", SF)' % (exp_pass, exp_fail, exp_pass, exp_fail))
+        self.modelBuilder.factory_(f'expr::fail_scale("({exp_pass:f}+{exp_fail:f}-({exp_pass:f}*@0))/{exp_fail:f}", SF)')
 
     def getYieldScale(self, bin, process):
         "Return the name of a RooAbsReal to scale this yield by, or the two special values 1 and 0 (do not scale, and set to zero)"

--- a/python/TwoHiggsModels.py
+++ b/python/TwoHiggsModels.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import re
 
 from HiggsAnalysis.CombinedLimit.PhysicsModel import *
@@ -35,7 +33,7 @@ class TwoHiggsBase(PhysicsModel):
             (production, decay, energy) = getHiggsProdDecMode(bin, process.replace("_SM", ""), self.options)
             return self.getHiggsYieldScaleSM(production, decay, energy)
         if self.DC.isSignal[process]:
-            raise RuntimeError("Found a signal process '%s' that is not among the supported ones: %s" % (process, self.modes))
+            raise RuntimeError(f"Found a signal process '{process}' that is not among the supported ones: {self.modes}")
         return 1
 
     def setPhysicsOptionsBase(self, physOptions):
@@ -89,7 +87,7 @@ class TwoHiggsBase(PhysicsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
                 if self.mHAsPOI:
                     poi += ",MH"
             else:
@@ -120,7 +118,7 @@ class TwoHiggsBase(PhysicsModel):
                     "and",
                     self.mHSMRange[1],
                 )
-                self.modelBuilder.doVar("MH_SM[%s,%s]" % (self.mHSMRange[0], self.mHSMRange[1]))
+                self.modelBuilder.doVar(f"MH_SM[{self.mHSMRange[0]},{self.mHSMRange[1]}]")
                 if self.mHSMAsPOI:
                     poi += ",MH_SM"
             else:
@@ -312,8 +310,8 @@ class TwoHiggsCvCf(TwoHiggsBase):
 
     def doParametersOfInterest(self):
         """Create POI and other parameters, and define the POI set."""
-        self.modelBuilder.doVar("CV[1,%s,%s]" % (self.cVRange[0], self.cVRange[1]))
-        self.modelBuilder.doVar("CF[1,%s,%s]" % (self.cFRange[0], self.cFRange[1]))
+        self.modelBuilder.doVar(f"CV[1,{self.cVRange[0]},{self.cVRange[1]}]")
+        self.modelBuilder.doVar(f"CF[1,{self.cFRange[0]},{self.cFRange[1]}]")
 
         self.modelBuilder.doSet("POI", "CV,CF")
 
@@ -373,23 +371,23 @@ class TwoHiggsCvCf(TwoHiggsBase):
         self.modelBuilder.factory_('expr::2HCvCf_BRscal_hvv("@0*@0/@1", CV, 2HCvCf_Gscal_tot)')
 
     def getHiggsYieldScaleSM(self, production, decay, energy):
-        name = "2HCvCf_XSBRscal_%s_%s" % (production, decay)
+        name = f"2HCvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name):
             return name
 
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
-        self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, 2HCvCf_BRscal_%s)' % (name, XSscal, BRscal))
+        self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, 2HCvCf_BRscal_{BRscal})')
         return name
 
     def getHiggsYieldScale(self, production, decay, energy):
-        name = "2HCvCf_XSBRscal_%s_%s" % (production, decay)
+        name = f"2HCvCf_XSBRscal_{production}_{decay}"
         if self.modelBuilder.out.function(name):
             return name
 
         XSscal = self.productionScaling[production]
         BRscal = self.decayScaling[decay]
-        self.modelBuilder.factory_('expr::%s("@0*@0 * @1", %s, 2HCvCf_BRscal_%s)' % (name, XSscal, BRscal))
+        self.modelBuilder.factory_(f'expr::{name}("@0*@0 * @1", {XSscal}, 2HCvCf_BRscal_{BRscal})')
         return name
 
 

--- a/python/VEVandEpsilon.py
+++ b/python/VEVandEpsilon.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import os
 
 import six
@@ -44,15 +42,15 @@ class MepsHiggs(SMLikeHiggsModel):
     def doParametersOfInterest(self):
         """Create POI out of signal strength and MH"""
         # --- Signal Strength as only POI ---
-        self.modelBuilder.doVar("M[246.22,%s,%s]" % (self.MRange[0], self.MRange[1]))
-        self.modelBuilder.doVar("eps[0,%s,%s]" % (self.epsRange[0], self.epsRange[1]))
+        self.modelBuilder.doVar(f"M[246.22,{self.MRange[0]},{self.MRange[1]}]")
+        self.modelBuilder.doVar(f"eps[0,{self.epsRange[0]},{self.epsRange[1]}]")
 
         if self.floatMass:
             if self.modelBuilder.out.var("MH"):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "M,eps,MH")
         else:
             if self.modelBuilder.out.var("MH"):
@@ -75,9 +73,9 @@ class MepsHiggs(SMLikeHiggsModel):
             "Z": (91.1876, (-0.0021, +0.0021)),
         }
 
-        for name, vals in six.iteritems(self.msbar):
+        for name, vals in self.msbar.items():
             # self.modelBuilder.doVar("M%s_MSbar[%s,%s,%s]" % (name, vals[0], vals[0]+vals[1][0], vals[0]+vals[1][1]))
-            self.modelBuilder.doVar("M%s_MSbar[%s]" % (name, vals[0]))
+            self.modelBuilder.doVar(f"M{name}_MSbar[{vals[0]}]")
 
             if name in ("W", "Z"):
                 #                # Ellis cv == v (mv^(2 e)/M^(1 + 2 e))
@@ -216,7 +214,7 @@ class ResolvedC6(SMLikeHiggsModel):
                 self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
                 self.modelBuilder.out.var("MH").setConstant(False)
             else:
-                self.modelBuilder.doVar("MH[%s,%s]" % (self.mHRange[0], self.mHRange[1]))
+                self.modelBuilder.doVar(f"MH[{self.mHRange[0]},{self.mHRange[1]}]")
             self.modelBuilder.doSet("POI", "MH,CW,CZ,Ctop,Cb,Ctau,Cmu")
         else:
             if self.modelBuilder.out.var("MH"):

--- a/python/tool_base/CombineToolBase.py
+++ b/python/tool_base/CombineToolBase.py
@@ -265,12 +265,12 @@ class CombineToolBase:
             for script in script_list:
                 full_script = os.path.abspath(script)
                 logname = full_script.replace(".sh", "_%J.log")
-                run_command(self.dry_run, "bsub -o {} {} {}".format(logname, self.bopts, full_script))
+                run_command(self.dry_run, f"bsub -o {logname} {self.bopts} {full_script}")
         if self.job_mode == "SGE":
             for script in script_list:
                 full_script = os.path.abspath(script)
                 logname = full_script.replace(".sh", "_%J.log")
-                run_command(self.dry_run, "qsub -o {} {} {}".format(logname, self.bopts, full_script))
+                run_command(self.dry_run, f"qsub -o {logname} {self.bopts} {full_script}")
         if self.job_mode == "slurm":
             script_name = "slurm_%s.sh" % self.task_name
             if self.job_dir:
@@ -348,7 +348,7 @@ class CombineToolBase:
 
                     newline = newline.replace(wsp, os.path.basename(wsp))
                     if wsp.startswith("root://"):
-                        newline = ("./copyRemoteWorkspace.sh {} ./{}; ".format(wsp, os.path.basename(wsp))) + newline
+                        newline = (f"./copyRemoteWorkspace.sh {wsp} ./{os.path.basename(wsp)}; ") + newline
                     else:
                         wsp_files.add(wsp)
                     if self.extract_lib_arg(newline.split()) is not None:

--- a/python/tool_base/EnhancedCombine.py
+++ b/python/tool_base/EnhancedCombine.py
@@ -134,7 +134,7 @@ class EnhancedCombine(CombineToolBase):
                     if header == "n" or header == "name":
                         final_arg.append(e)
                     elif len(e) and e != "!":
-                        final_arg.append("{} {}".format(argname, e))
+                        final_arg.append(f"{argname} {e}")
                     else:
                         final_arg.append("")
                 arglist.append(tuple(final_arg))
@@ -158,7 +158,7 @@ class EnhancedCombine(CombineToolBase):
                 # Figure out if the enclosing directory is a mass value
                 dirs = path.split("/")
                 if self.args.mass is None and len(dirs) >= 1 and isfloat(dirs[-1]):
-                    print("Assuming card {} uses mass value {}".format(dc, dirs[-1]))
+                    print(f"Assuming card {dc} uses mass value {dirs[-1]}")
                     dc_mass.append((path, file, dirs[-1]))
                 dc_no_mass.append((path, file))
             # If at least one mass value was inferred assume all of them are like this
@@ -221,7 +221,7 @@ class EnhancedCombine(CombineToolBase):
                     # point
                     if lower_bound == 0:
                         lower_bound += 1
-                    command.append("{}={:g},{:g}".format(par, bound_vals[par][lower_bound - 1][1], bound_vals[par][lower_bound - 1][2]))
+                    command.append(f"{par}={bound_vals[par][lower_bound - 1][1]:g},{bound_vals[par][lower_bound - 1][2]:g}")
                 new_list.append(entry + (str(":".join(command)),))
             # now remove the current mass information from subbed_vars
             # and replace it with the updated one

--- a/python/tool_base/Impacts.py
+++ b/python/tool_base/Impacts.py
@@ -150,12 +150,12 @@ class Impacts(CombineToolBase):
             initialRes = {}
             if self.args.approx is not None:
                 if self.args.approx == "hesse":
-                    fResult = ROOT.TFile("multidimfit_approxFit_{name}.root".format(name=name))
+                    fResult = ROOT.TFile(f"multidimfit_approxFit_{name}.root")
                     rfr = fResult.Get("fit_mdf")
                     fResult.Close()
                     initialRes = utils.get_roofitresult(rfr, poiList, poiList)
                 elif self.args.approx == "robust":
-                    fResult = ROOT.TFile("robustHesse_approxFit_{name}.root".format(name=name))
+                    fResult = ROOT.TFile(f"robustHesse_approxFit_{name}.root")
                     floatParams = fResult.Get("floatParsFinal")
                     rfr = fResult.Get("h_correlation")
                     rfr.SetDirectory(0)

--- a/python/tool_base/ImpactsFromScans.py
+++ b/python/tool_base/ImpactsFromScans.py
@@ -86,8 +86,8 @@ class ImpactsFromScans(CombineToolBase):
         res = {}
         for POI in POIs:
             res[POI] = {}
-            name_hi = "higgsCombine{}.{}.Hi.MultiDimFit.mH{}.root".format(self.args.name, POI, mass)
-            name_lo = "higgsCombine{}.{}.Lo.MultiDimFit.mH{}.root".format(self.args.name, POI, mass)
+            name_hi = f"higgsCombine{self.args.name}.{POI}.Hi.MultiDimFit.mH{mass}.root"
+            name_lo = f"higgsCombine{self.args.name}.{POI}.Lo.MultiDimFit.mH{mass}.root"
             res_hi = self.get_fixed_results(name_hi, POIs)
             res_lo = self.get_fixed_results(name_lo, POIs)
             for fPOI in POIs:
@@ -129,7 +129,7 @@ class ImpactsFromScans(CombineToolBase):
                 for x in bf_vals:
                     if x in p:
                         bf_val = bf_vals[x]
-                        print("Using {}={:g}".format(x, bf_vals[x]))
+                        print(f"Using {x}={bf_vals[x]:g}")
                 covv = d21 if bf_val >= d1 else d10
             if p == "mu_XS_ZH_BR_WW":
                 covv = covv * 0.89
@@ -165,9 +165,7 @@ class ImpactsFromScans(CombineToolBase):
             xres = solve(mtx, yvec)
             # print xres
             covvars.append(
-                ROOT.RooFormulaVar(
-                    "cov%i" % i, "", "{:g}*(@0-{:g})*(@0-{:g})+{:g}*(@0-{:g})+{:g}".format(xres[0], d1, d1, xres[1], d1, xres[2]), ROOT.RooArgList(xvars[i])
-                )
+                ROOT.RooFormulaVar("cov%i" % i, "", f"{xres[0]:g}*(@0-{d1:g})*(@0-{d1:g})+{xres[1]:g}*(@0-{d1:g})+{xres[2]:g}", ROOT.RooArgList(xvars[i]))
             )
             # covvars.append(ROOT.RooFormulaVar('cov%i'%i,'', '%g' % (y2), ROOT.RooArgList()))
             covvars[-1].Print()
@@ -258,10 +256,10 @@ class ImpactsFromScans(CombineToolBase):
                     for x in bf_vals:
                         if x in ip:
                             bf_val_i = bf_vals[x]
-                            print("Using {}={:g} for POI i".format(x, bf_vals[x]))
+                            print(f"Using {x}={bf_vals[x]:g} for POI i")
                         if x in jp:
                             bf_val_j = bf_vals[x]
-                            print("Using {}={:g} for POI j".format(x, bf_vals[x]))
+                            print(f"Using {x}={bf_vals[x]:g} for POI j")
 
                     val_i = cji_21 if bf_val_i >= di_1 else cji_10
                     val_j = cij_21 if bf_val_j >= dj_1 else cij_10

--- a/python/tool_base/LimitGrids.py
+++ b/python/tool_base/LimitGrids.py
@@ -88,22 +88,22 @@ class AsymptoticGrid(CombineToolBase):
         for p in points:
             file_dict[p] = []
 
-        for f in glob.glob("higgsCombine.{}.*.{}.*.AsymptoticLimits.mH*.root".format(POIs[0], POIs[1])):
+        for f in glob.glob(f"higgsCombine.{POIs[0]}.*.{POIs[1]}.*.AsymptoticLimits.mH*.root"):
             # print f
-            rgx = re.compile(r"higgsCombine\.{}\.(?P<p1>.*)\.{}\.(?P<p2>.*)\.AsymptoticLimits\.mH.*\.root".format(POIs[0], POIs[1]))
+            rgx = re.compile(rf"higgsCombine\.{POIs[0]}\.(?P<p1>.*)\.{POIs[1]}\.(?P<p2>.*)\.AsymptoticLimits\.mH.*\.root")
             matches = rgx.search(f)
             p = (matches.group("p1"), matches.group("p2"))
             if p in file_dict:
                 file_dict[p].append(f)
 
         for key, val in file_dict.items():
-            name = "{}.{}.{}.{}".format(POIs[0], key[0], POIs[1], key[1])
+            name = f"{POIs[0]}.{key[0]}.{POIs[1]}.{key[1]}"
             print(">> Point %s" % name)
             if len(val) == 0:
-                print("Going to run limit for point {}".format(key))
-                set_arg = ",".join(["{}={},{}={}".format(POIs[0], key[0], POIs[1], key[1])] + to_set)
-                freeze_arg = ",".join(["{},{}".format(POIs[0], POIs[1])] + to_freeze)
-                point_args = "-n .{} --setParameters {} --freezeParameters {}".format(name, set_arg, freeze_arg)
+                print(f"Going to run limit for point {key}")
+                set_arg = ",".join([f"{POIs[0]}={key[0]},{POIs[1]}={key[1]}"] + to_set)
+                freeze_arg = ",".join([f"{POIs[0]},{POIs[1]}"] + to_freeze)
+                point_args = f"-n .{name} --setParameters {set_arg} --freezeParameters {freeze_arg}"
                 cmd = " ".join(["combine -M AsymptoticLimits", opts, point_args] + self.passthru)
                 self.job_queue.append(cmd)
 
@@ -271,7 +271,7 @@ class HybridNewGrid(CombineToolBase):
         signif_results = {}
 
         if verbose:
-            print(">>> CLs target is a significance of {:.1f} standard deviations from {:.3f}".format(signif, crossing))
+            print(f">>> CLs target is a significance of {signif:.1f} standard deviations from {crossing:.3f}")
 
         for contour in contours:
             # Start by assuming this contour passes, we'll set it to False if it fails
@@ -281,7 +281,7 @@ class HybridNewGrid(CombineToolBase):
             if "exp" in contour:
                 quantile = ROOT.Math.normal_cdf(float(contour.replace("exp", "")))
                 if verbose:
-                    print(">>> Checking the {} contour at quantile={:f}".format(contour, quantile))
+                    print(f">>> Checking the {contour} contour at quantile={quantile:f}")
                 if hyp_res is not None:
                     # Get the stat statistic value at this quantile by rounding to the nearest b-only toy
                     testStat = btoys[int(min(floor(quantile * len(btoys) + 0.5), len(btoys) - 1))]
@@ -312,12 +312,12 @@ class HybridNewGrid(CombineToolBase):
             dist = 0.0
             if CLsErr == 0.0:
                 if verbose:
-                    print(">>>> CLs = {:g} +/- {:g} (infinite significance), will treat as passing".format(CLs, CLsErr))
+                    print(f">>>> CLs = {CLs:g} +/- {CLsErr:g} (infinite significance), will treat as passing")
                 dist = 999.0
             else:
                 dist = abs(CLs - crossing) / CLsErr
                 if verbose:
-                    print(">>>> CLs = {:g} +/- {:g}, reached {:.1f} sigma signifance".format(CLs, CLsErr, dist))
+                    print(f">>>> CLs = {CLs:g} +/- {CLsErr:g}, reached {dist:.1f} sigma signifance")
                 if dist < signif:
                     signif_results[contour] = False
             results[contour] = (CLs, CLsErr, dist, testStatObs)
@@ -405,7 +405,7 @@ class HybridNewGrid(CombineToolBase):
                 min_limit = max(0.0, min_limit - width * 0.3)
                 nsteps = from_asymptotic_settings.get("points", 100)
                 step_width = (max_limit - min_limit) / nsteps
-                grids.append([m, "{:g}:{:g}|{:g}".format(min_limit, max_limit, step_width), ""])
+                grids.append([m, f"{min_limit:g}:{max_limit:g}|{step_width:g}", ""])
                 boundlist_file = from_asymptotic_settings.get("boundlist", "")
                 if boundlist_file:
                     with open(boundlist_file) as json_file:
@@ -444,7 +444,7 @@ class HybridNewGrid(CombineToolBase):
             file_dict[p] = {}
 
         # The regex we will use to identify output files and extract POI values
-        rgx = re.compile(r"higgsCombine\.{}\.(?P<p1>.*)\.{}\.(?P<p2>.*)\.HybridNew\.mH.*\.(?P<toy>.*)\.root".format(POIs[0], POIs[1]))
+        rgx = re.compile(rf"higgsCombine\.{POIs[0]}\.(?P<p1>.*)\.{POIs[1]}\.(?P<p2>.*)\.HybridNew\.mH.*\.(?P<toy>.*)\.root")
 
         stats = {}
         if statfile and os.path.isfile(statfile):
@@ -471,7 +471,7 @@ class HybridNewGrid(CombineToolBase):
                         file_dict[p][seed] = zipname + "#" + f
 
         # Now look for files in the local directory
-        for f in glob.glob("higgsCombine.{}.*.{}.*.HybridNew.mH*.root".format(POIs[0], POIs[1])):
+        for f in glob.glob(f"higgsCombine.{POIs[0]}.*.{POIs[1]}.*.HybridNew.mH*.root"):
             matches = rgx.search(f)
             p = (matches.group("p1"), matches.group("p2"))
             seed = int(matches.group("toy"))
@@ -485,7 +485,7 @@ class HybridNewGrid(CombineToolBase):
                     # file with incomplete or failed jobs
                     if zipname and plot.TFileIsGood(f):
                         zipf.write(f)  # assume this throws if it fails
-                        print("Adding {} to {}".format(f, zipname))
+                        print(f"Adding {f} to {zipname}")
                         file_dict[p][seed] = zipname + "#" + f
                         os.remove(f)
                     else:  # otherwise just add the file to the dict in the normal way
@@ -517,7 +517,7 @@ class HybridNewGrid(CombineToolBase):
             status_changed = True
             total_points += 1
             status_key = ":".join(key)
-            name = "{}.{}.{}.{}".format(POIs[0], key[0], POIs[1], key[1])
+            name = f"{POIs[0]}.{key[0]}.{POIs[1]}.{key[1]}"
 
             # First check if we use the status json
             all_files = list(val.values())
@@ -603,19 +603,19 @@ class HybridNewGrid(CombineToolBase):
                 # Build to combine command. Here we'll take responsibility for setting the name and the
                 # model parameters, making sure the latter are frozen
                 if not feldman_cousins:
-                    set_arg = ",".join(["{}={},{}={}".format(POIs[0], key[0], POIs[1], key[1])] + to_set)
-                    freeze_arg = ",".join(["{},{}".format(POIs[0], POIs[1])] + to_freeze)
-                    point_args = "-n .{} --setParameters {} --freezeParameters {}".format(name, set_arg, freeze_arg)
+                    set_arg = ",".join([f"{POIs[0]}={key[0]},{POIs[1]}={key[1]}"] + to_set)
+                    freeze_arg = ",".join([f"{POIs[0]},{POIs[1]}"] + to_freeze)
+                    point_args = f"-n .{name} --setParameters {set_arg} --freezeParameters {freeze_arg}"
                 else:
-                    single_point_arg = ".".join(["{}={},{}={}".format(POIs[0], key[0], POIs[1], key[1])])
+                    single_point_arg = ".".join([f"{POIs[0]}={key[0]},{POIs[1]}={key[1]}"])
                     if len(to_set) > 0 and len(to_freeze) > 0:
-                        point_args = "-n .{} --singlePoint {} --setParameters {} --freezeParameters {}".format(name, single_point_arg, to_set, to_freeze)
+                        point_args = f"-n .{name} --singlePoint {single_point_arg} --setParameters {to_set} --freezeParameters {to_freeze}"
                     elif len(to_set) > 0:
-                        point_args = "-n .{} --singlePoint {} --setParameters {}".format(name, single_point_arg, to_set)
+                        point_args = f"-n .{name} --singlePoint {single_point_arg} --setParameters {to_set}"
                     elif len(to_freeze) > 0:
-                        point_args = "-n .{} --singlePoint {} --freezeParameters {}".format(name, single_point_arg, to_freeze)
+                        point_args = f"-n .{name} --singlePoint {single_point_arg} --freezeParameters {to_freeze}"
                     else:
-                        point_args = "-n .{} --singlePoint {} ".format(name, single_point_arg)
+                        point_args = f"-n .{name} --singlePoint {single_point_arg} "
 
                 if self.args.from_asymptotic:
                     mval = key[0]
@@ -630,7 +630,7 @@ class HybridNewGrid(CombineToolBase):
                         # point
                         if lower_bound == 0:
                             lower_bound += 1
-                        command.append("{}={:g},{:g}".format(par, bound_vals[par][lower_bound - 1][1], bound_vals[par][lower_bound - 1][2]))
+                        command.append(f"{par}={bound_vals[par][lower_bound - 1][1]:g},{bound_vals[par][lower_bound - 1][2]:g}")
                     if len(command) > 0:
                         point_args += " --setParameterRanges %s" % (":".join(command))
                     # print per_mass_point_args
@@ -674,7 +674,7 @@ class HybridNewGrid(CombineToolBase):
                     files_by_mass[key[0]] = list()
                 files_by_mass[key[0]].extend(list(val.values()))
             for m, files in files_by_mass.items():
-                gridfile = "higgsCombine.gridfile.{}.{}.{}.root".format(POIs[0], m, POIs[1])
+                gridfile = f"higgsCombine.gridfile.{POIs[0]}.{m}.{POIs[1]}.root"
                 self.job_queue.append("hadd -f {} {}".format(gridfile, " ".join(files)))
                 for exp in ["", "0.025", "0.160", "0.500", "0.840", "0.975"]:
                     self.job_queue.append(
@@ -683,7 +683,7 @@ class HybridNewGrid(CombineToolBase):
                                 "combine -M HybridNew --rAbsAcc 0",
                                 opts,
                                 "--grid %s" % gridfile,
-                                "-n .final.{}.{}.{}".format(POIs[0], m, POIs[1]),
+                                f"-n .final.{POIs[0]}.{m}.{POIs[1]}",
                                 "-m %s" % (m),
                                 ("--expectedFromGrid %s" % exp) if exp else "--noUpdateGrid",
                             ]
@@ -764,9 +764,9 @@ class HybridNewGrid(CombineToolBase):
         pt_r.AddText(
             "%i (%s) + %i (%s)" % (result.GetNullDistribution().GetSize(), opts["null_label"], result.GetAltDistribution().GetSize(), opts["alt_label"])
         )
-        pt_r.AddText("{:.3f} #pm {:.3f}".format(result.CLsplusb(), result.CLsplusbError()))
-        pt_r.AddText("{:.3f} #pm {:.3f}".format(result.CLb(), result.CLbError()))
-        pt_r.AddText("{:.3f} #pm {:.3f}".format(result.CLs(), result.CLsError()))
+        pt_r.AddText(f"{result.CLsplusb():.3f} #pm {result.CLsplusbError():.3f}")
+        pt_r.AddText(f"{result.CLb():.3f} #pm {result.CLbError():.3f}")
+        pt_r.AddText(f"{result.CLs():.3f} #pm {result.CLsError():.3f}")
         # if point_info is not None:
         #     for exp in ['exp-2', 'exp-1', 'exp0', 'exp+1', 'exp+2']:
         #         pt_r.AddText('%.3f #pm %.3f' % (point_info[exp][0], point_info[exp][1]))

--- a/python/tool_base/Output.py
+++ b/python/tool_base/Output.py
@@ -67,7 +67,7 @@ class PrintFit(CombineToolBase):
             res = utils.get_singles_results(self.args.input, POIs, POIs)
             for p in POIs:
                 val = res[p][p]
-                print("{} = {:.3f} -{:.3f}/+{:.3f}".format(p, val[1], val[1] - val[0], val[2] - val[1]))
+                print(f"{p} = {val[1]:.3f} -{val[1] - val[0]:.3f}/+{val[2] - val[1]:.3f}")
         elif self.args.algo == "fixed":
             res = utils.get_fixed_results(self.args.input, POIs)
             print("%-30s   bestfit :   fixed" % (""))

--- a/python/tool_base/TaylorExpand.py
+++ b/python/tool_base/TaylorExpand.py
@@ -114,11 +114,11 @@ class ExpansionTerm:
         sp = " " * indent
         extra = ""
         if self.fundamental:
-            extra = " {} = {:f}".format(list(self.FormattedPars()), self.fnval)
+            extra = f" {list(self.FormattedPars())} = {self.fnval:f}"
         if coeff is None:
-            print("{}{}{}".format(sp, self.derivatives, extra))
+            print(f"{sp}{self.derivatives}{extra}")
         else:
-            print("{}{:+.1f}*{}{}".format(sp, coeff, self.derivatives, extra))
+            print(f"{sp}{coeff:+.1f}*{self.derivatives}{extra}")
         for i in range(len(self.terms)):
             self.terms[i].Print(indent + 2, self.coeffs[i])
 
@@ -435,7 +435,7 @@ class TaylorExpand(CombineToolBase):
                 if self.args.multiple == 1:
                     set_vals = []
                     for POI, val in zip(POIs, vals):
-                        set_vals.append("{}={:f}".format(POI, val))
+                        set_vals.append(f"{POI}={val:f}")
                         if self.args.test_mode == 1:
                             self.wsp_vars[POI].setVal(val)
                     set_vals_str = ",".join(set_vals)
@@ -457,7 +457,7 @@ class TaylorExpand(CombineToolBase):
                         continue
 
                 hash_id = hashlib.sha1(set_vals_str).hexdigest()
-                filename = "higgsCombine.TaylorExpand.{}.MultiDimFit.mH{}.root".format(hash_id, mass)
+                filename = f"higgsCombine.TaylorExpand.{hash_id}.MultiDimFit.mH{mass}.root"
                 arg_str = "-M MultiDimFit -n .TaylorExpand.{} --algo fixed --redefineSignalPOIs {} --fixedPointPOIs ".format(hash_id, ",".join(POIs))
                 arg_str += set_vals_str
 

--- a/python/tool_base/utils.py
+++ b/python/tool_base/utils.py
@@ -52,10 +52,10 @@ def prefit_from_workspace(file, workspace, params, setPars=None):
             tmp = allParams.find(par)
             isrvar = tmp.IsA().InheritsFrom(ROOT.RooRealVar.Class())
             if isrvar:
-                print("Setting parameter {} to {:g}".format(par, float(val)))
+                print(f"Setting parameter {par} to {float(val):g}")
                 tmp.setVal(float(val))
             else:
-                print("Setting index {} to {:g}".format(par, float(val)))
+                print(f"Setting index {par} to {float(val):g}")
                 tmp.setIndex(int(val))
 
     for p in params:

--- a/python/util/plotting.py
+++ b/python/util/plotting.py
@@ -941,7 +941,7 @@ def ApplyGraphYOffset(graph, y_off):
 def RemoveGraphYAll(graph, val):
     for i in range(graph.GetN()):
         if graph.GetY()[i] == val:
-            print("[RemoveGraphYAll] Removing point ({:f}, {:f})".format(graph.GetX()[i], graph.GetY()[i]))
+            print(f"[RemoveGraphYAll] Removing point ({graph.GetX()[i]:f}, {graph.GetY()[i]:f})")
             graph.RemovePoint(i)
             RemoveGraphYAll(graph, val)
             break
@@ -951,7 +951,7 @@ def RemoveSmallDelta(graph, val):
     for i in range(graph.GetN()):
         diff = abs(graph.GetY()[i])
         if diff < val:
-            print("[RemoveSmallDelta] Removing point ({:f}, {:f})".format(graph.GetX()[i], graph.GetY()[i]))
+            print(f"[RemoveSmallDelta] Removing point ({graph.GetX()[i]:f}, {graph.GetY()[i]:f})")
             graph.RemovePoint(i)
             RemoveSmallDelta(graph, val)
             break
@@ -999,8 +999,8 @@ def ImproveMinimum(graph, func, doIt=False):
     search_max = fit_i + 2 if fit_i + 2 < graph.GetN() else fit_i + 1
     min_x = func.GetMinimumX(graph.GetX()[search_min], graph.GetX()[search_max])
     min_y = func.Eval(min_x)
-    print("[ImproveMinimum] Fit minimum was ({:f}, {:f})".format(fit_x, fit_y))
-    print("[ImproveMinimum] Better minimum was ({:f}, {:f})".format(min_x, min_y))
+    print(f"[ImproveMinimum] Fit minimum was ({fit_x:f}, {fit_y:f})")
+    print(f"[ImproveMinimum] Better minimum was ({min_x:f}, {min_y:f})")
     if doIt:
         for i in range(graph.GetN()):
             before = graph.GetY()[i]
@@ -1060,8 +1060,8 @@ def ReZeroTGraph(gr, doIt=False):
             min_y = gr.GetY()[i]
             min_x = gr.GetX()[i]
     if min_y < fit_y:
-        print("[ReZeroTGraph] Fit minimum was ({:f}, {:f})".format(fit_x, fit_y))
-        print("[ReZeroTGraph] Better minimum was ({:f}, {:f})".format(min_x, min_y))
+        print(f"[ReZeroTGraph] Fit minimum was ({fit_x:f}, {fit_y:f})")
+        print(f"[ReZeroTGraph] Better minimum was ({min_x:f}, {min_y:f})")
         if doIt:
             for i in range(gr.GetN()):
                 # before = gr.GetY()[i]
@@ -1119,7 +1119,7 @@ def RemoveNearMin(graph, val, spacing=None):
         if i == bf_i:
             continue
         if abs(graph.GetX()[i] - bf) < (val * spacing):
-            print("[RemoveNearMin] Removing point ({:f}, {:f}) close to minimum at {:f}".format(graph.GetX()[i], graph.GetY()[i], bf))
+            print(f"[RemoveNearMin] Removing point ({graph.GetX()[i]:f}, {graph.GetY()[i]:f}) close to minimum at {bf:f}")
             graph.RemovePoint(i)
             RemoveNearMin(graph, val, spacing)
             break

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -215,7 +215,7 @@ for ich, fname in enumerate(args):
                     import warnings
 
                     warning_message = (
-                        "\nYou probably have one or more regularization term(s) in datacard {}.\n".format(fname)
+                        f"\nYou probably have one or more regularization term(s) in datacard {fname}.\n"
                         + "A constraint term is a line that looks like the following:\n\n"
                         + "\tconstr0 constr @3*(@0-2*@1+@2) r_0,r_1,r_2,regularize[0.] delta[10.]\n\n"
                     )
@@ -259,9 +259,7 @@ for ich, fname in enumerate(args):
                     for b, v in systeffect.items():
                         othereffect[b] = v
                 else:
-                    raise RuntimeError(
-                        "File {} defines systematic {} as using pdf {}, while a previous file defines it as using {}".format(fname, lsyst, pdf, otherpdf)
-                    )
+                    raise RuntimeError(f"File {fname} defines systematic {lsyst} as using pdf {pdf}, while a previous file defines it as using {otherpdf}")
             else:
                 if pdf == "gmN" and int(pdfargs[0]) != int(otherargs[0]):
                     raise RuntimeError(
@@ -501,7 +499,7 @@ for bpf in binParFlags.keys():
     if isVetoed(bpf_new2old[bpf], options.channelVetos) or not isIncluded(bpf_new2old[bpf], options.channelIncludes):
         continue
     if len(binParFlags[bpf]) == 1:
-        print("{} autoMCStats {:g}".format(bpf, binParFlags[bpf][0]))
+        print(f"{bpf} autoMCStats {binParFlags[bpf][0]:g}")
     if len(binParFlags[bpf]) == 2:
         print("%s autoMCStats %g %i" % (bpf, binParFlags[bpf][0], binParFlags[bpf][1]))
     if len(binParFlags[bpf]) == 3:

--- a/scripts/plot1DScan.py
+++ b/scripts/plot1DScan.py
@@ -195,7 +195,7 @@ crossings = main_scan["crossings"]
 val_nom = main_scan["val"]
 val_2sig = main_scan["val_2sig"]
 
-textfit = "{} = {:.3f}{{}}^{{#plus {:.3f}}}_{{#minus {:.3f}}}".format(fixed_name, val_nom[0], val_nom[1], abs(val_nom[2]))
+textfit = f"{fixed_name} = {val_nom[0]:.3f}{{}}^{{#plus {val_nom[1]:.3f}}}_{{#minus {abs(val_nom[2]):.3f}}}"
 
 
 pt = ROOT.TPaveText(0.59, 0.82 - len(other_scans) * 0.08, 0.95, 0.91, "NDCNB")
@@ -227,7 +227,7 @@ if args.breakdown is not None:
         v_hi.append(other["val"][1])
         v_lo.append(other["val"][2])
     assert len(v_hi) == len(breakdown)
-    textfit = "{} = {:.3f}".format(fixed_name, val_nom[0])
+    textfit = f"{fixed_name} = {val_nom[0]:.3f}"
     for i, br in enumerate(breakdown):
         if i < (len(breakdown) - 1):
             if abs(v_hi[i + 1]) > abs(v_hi[i]):
@@ -243,7 +243,7 @@ if args.breakdown is not None:
         else:
             hi = v_hi[i]
             lo = v_lo[i]
-        textfit += "{{}}^{{#plus {:.3f}}}_{{#minus {:.3f}}}({})".format(hi, abs(lo), br)
+        textfit += f"{{}}^{{#plus {hi:.3f}}}_{{#minus {abs(lo):.3f}}}({br})"
     pt.AddText(textfit)
 
 
@@ -267,7 +267,7 @@ for i, other in enumerate(other_scans):
 legend.Draw()
 
 save_graph = main_scan["graph"].Clone()
-save_graph.GetXaxis().SetTitle("{} = {:.3f} {:+.3f}/{:+.3f}".format(fixed_name, val_nom[0], val_nom[2], val_nom[1]))
+save_graph.GetXaxis().SetTitle(f"{fixed_name} = {val_nom[0]:.3f} {val_nom[2]:+.3f}/{val_nom[1]:+.3f}")
 outfile = ROOT.TFile(args.output + ".root", "RECREATE")
 outfile.WriteTObject(save_graph)
 outfile.Close()

--- a/scripts/plotImpacts.py
+++ b/scripts/plotImpacts.py
@@ -151,7 +151,7 @@ else:
 # Now compute each parameters ranking according to: largest pull, strongest constraint, and largest impact
 ranking_pull = sorted([(i, abs(v["pull"])) for i, v in enumerate(params)], reverse=True, key=lambda X: X[1])
 ranking_constraint = sorted([(i, abs(v["constraint"])) for i, v in enumerate(params)], reverse=False, key=lambda X: X[1])
-ranking_impact = sorted([(i, abs(v["impact_{}".format(POI)])) for i, v in enumerate(params)], reverse=True, key=lambda X: X[1])
+ranking_impact = sorted([(i, abs(v[f"impact_{POI}"])) for i, v in enumerate(params)], reverse=True, key=lambda X: X[1])
 for i in range(len(params)):
     params[ranking_pull[i][0]]["rank_pull"] = i + 1
     params[ranking_impact[i][0]]["rank_impact"] = i + 1
@@ -235,12 +235,12 @@ def MakeSummaryPage():
     latex.DrawLatex(0.3, 0.85, "N(> 1 s.d.)")
     latex.DrawLatex(0.3, 0.8, "N(> 2 s.d.)")
     latex.DrawLatex(0.3, 0.75, "N(> 3 s.d.)")
-    latex.DrawLatex(0.33, 0.85, "{}".format(n_larger[0]))
-    latex.DrawLatex(0.33, 0.8, "{}".format(n_larger[1]))
-    latex.DrawLatex(0.33, 0.75, "{}".format(n_larger[2]))
-    latex.DrawLatex(0.42, 0.85, "#color[2]{{{:.2f}}}".format(n_entries * 2.0 * ROOT.Math.normal_cdf_c(1.0)))
-    latex.DrawLatex(0.42, 0.8, "#color[2]{{{:.2f}}}".format(n_entries * 2.0 * ROOT.Math.normal_cdf_c(2.0)))
-    latex.DrawLatex(0.42, 0.75, "#color[2]{{{:.2f}}}".format(n_entries * 2.0 * ROOT.Math.normal_cdf_c(3.0)))
+    latex.DrawLatex(0.33, 0.85, f"{n_larger[0]}")
+    latex.DrawLatex(0.33, 0.8, f"{n_larger[1]}")
+    latex.DrawLatex(0.33, 0.75, f"{n_larger[2]}")
+    latex.DrawLatex(0.42, 0.85, f"#color[2]{{{n_entries * 2.0 * ROOT.Math.normal_cdf_c(1.0):.2f}}}")
+    latex.DrawLatex(0.42, 0.8, f"#color[2]{{{n_entries * 2.0 * ROOT.Math.normal_cdf_c(2.0):.2f}}}")
+    latex.DrawLatex(0.42, 0.75, f"#color[2]{{{n_entries * 2.0 * ROOT.Math.normal_cdf_c(3.0):.2f}}}")
 
     plot.DrawCMSLogo(ROOT.gPad, "CMS", args.cms_label, 0, 0.20, 0.00, 0.00)
     s_nom, s_hi, s_lo = GetRounded(POI_fit[1], POI_fit[2] - POI_fit[1], POI_fit[1] - POI_fit[0])
@@ -320,7 +320,7 @@ def MakeSummaryPage():
     SetTitleText(latex)
     latex.DrawLatex(0.03, 0.95, "Largest impacts")
     SetFormulaText(latex)
-    latex.DrawLatex(0.97, 0.95, "#Delta{}(#pm#sigma_{{#theta}})/#sigma_{{{}}}".format(POI, POI))
+    latex.DrawLatex(0.97, 0.95, f"#Delta{POI}(#pm#sigma_{{#theta}})/#sigma_{{{POI}}}")
     DrawBoxes(ROOT.kBlue - 10)
     for i in range(nDraw):
         par = params[ranking_impact[i][0]]
@@ -361,7 +361,7 @@ def MakeSummaryPage():
             if curr_marker >= len(marker_styles):
                 curr_marker = 0
 
-    canv.Print("{}_summary.pdf".format(args.output))
+    canv.Print(f"{args.output}_summary.pdf")
 
 
 if args.summary:
@@ -453,7 +453,7 @@ for page in range(n):
             y1 = y1 + ((float(i) + 0.5) * h)
             x1 = x1 + (1 - pads[0].GetRightMargin() - x1) / 2.0
             s_nom, s_hi, s_lo = GetRounded(fit[1], fit[2] - fit[1], fit[1] - fit[0])
-            text_entries.append((x1, y1, "{}^{{#plus{}}}_{{#minus{}}}".format(s_nom, s_hi, s_lo)))
+            text_entries.append((x1, y1, f"{s_nom}^{{#plus{s_hi}}}_{{#minus{s_lo}}}"))
             redo_boxes.append(i)
         g_impacts_hi.SetPoint(i, 0, float(i) + 0.5)
         g_impacts_lo.SetPoint(i, 0, float(i) + 0.5)
@@ -518,7 +518,7 @@ for page in range(n):
     h_impacts = ROOT.TH2F("impacts", "impacts", 6, -max_impact * 1.1, max_impact * 1.1, n_params, 0, n_params)
     impt_x_title = "#Delta#hat{%s}" % (Translate(POI, translate))
     if args.relative:
-        impt_x_title = "#Delta#hat{{{}}}/#sigma_{{{}}}".format(Translate(POI, translate), Translate(POI, translate))
+        impt_x_title = f"#Delta#hat{{{Translate(POI, translate)}}}/#sigma_{{{Translate(POI, translate)}}}"
 
     plot.Set(h_impacts.GetXaxis(), LabelSize=0.03, TitleSize=0.04, Ndivisions=505, Title=impt_x_title)
     plot.Set(h_impacts.GetYaxis(), LabelSize=0, TickLength=0.0)

--- a/scripts/pruneUncerts.py
+++ b/scripts/pruneUncerts.py
@@ -120,7 +120,7 @@ def main():
 
     ## create a combined datacard from input datacards
     rnd_name = "".join(random.choice(string.ascii_uppercase + string.digits) for x in range(10))
-    os.system("combineCards.py -S {PATH}/*.txt > /tmp/{NAME}".format(PATH=args[0], NAME=rnd_name))
+    os.system(f"combineCards.py -S {args[0]}/*.txt > /tmp/{rnd_name}")
 
     pruner = DatacardPruner(
         fit_results,
@@ -132,7 +132,7 @@ def main():
         options.comment_nuisances,
     )
     ## determine list of all uncertainties from input datacards
-    uncerts = pruner.determine_uncerts("/tmp/{NAME}".format(NAME=rnd_name))
+    uncerts = pruner.determine_uncerts(f"/tmp/{rnd_name}")
     ## determine list of dropped and kept uncertainties from input datacards
     (dropped, kept, confused) = pruner.prune(uncerts)
     ## write dropped and kept uncertainties to file

--- a/scripts/text2workspace.py
+++ b/scripts/text2workspace.py
@@ -96,7 +96,7 @@ physics = getattr(mod, physModName)
 if mod == None:
     raise RuntimeError("Physics model module %s not found" % physModMod)
 if physics == None or not isinstance(physics, PhysicsModelBase):
-    raise RuntimeError("Physics model {} in module {} not found, or not inheriting from PhysicsModelBase".format(physModName, physModMod))
+    raise RuntimeError(f"Physics model {physModName} in module {physModMod} not found, or not inheriting from PhysicsModelBase")
 physics.setPhysicsOptions(options.physOpt)
 ## Attach to the tools, and run
 MB.setPhysics(physics)


### PR DESCRIPTION
That mostly means to modernize Python code to use f-strings.

This can be done now that the recommended cmssw version CMSSW_14_1_0_pre4 ships with Python 3.9, and the minimum supported Python version by ROOT is actually 3.8 since ROOT 6.32.

See:
https://github.com/asottile/pyupgrade
https://github.com/root-project/root/pull/14340