### PR TITLE
Run the likelihood scan for RooMultiPdf in the cvmfs workflow 

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -50,6 +50,7 @@ jobs:
           shell: bash
           options: ${{env.docker_opt_rw}}
           run: | 
+            mkdir -p ${{ github.workspace }}/artifacts
             cd /home/cmsusr/
             source /cvmfs/cms.cern.ch/cmsset_default.sh
             scram project ${CMSSW_VERSION}
@@ -164,12 +165,13 @@ jobs:
             combine -M MultiDimFit -m 125.38  --setParameters pdf_index_ggh=2 --freezeParameters MH --cminDefaultMinimizerStrategy 0 --X-rtd FAST_VERTICAL_MORPH --X-rtd MINIMIZER_freezeDisassociatedParams --X-rtd MINIMIZER_multiMin_maskChannels=2 --algo singles ws_RooMultiPdf.root
             combine -M MultiDimFit -m 125.38 -n RooMultiPdfGrid --freezeParameters MH --cminDefaultMinimizerStrategy 0 --X-rtd FAST_VERTICAL_MORPH --X-rtd MINIMIZER_freezeDisassociatedParams --X-rtd MINIMIZER_multiMin_maskChannels=2 --algo grid ws_RooMultiPdf.root --setParameterRanges r=-1,2 --points 80 -P r
             plot1DScan.py higgsCombineRooMultiPdfGrid.MultiDimFit.mH125.38.root -o scan_RooMultiPdf 
-            mv scan_RooMultiPdf.pdf /work/scan_RooMultiPdf.pdf
+            cp scan_RooMultiPdf.pdf ${{ github.workspace }}/artifacts/.
+            
       - name: Upload scan_RooMultiPdf.pdf
         uses: actions/upload-artifact@v4
         with:
           name: Scan for RooMultiPdf 
-          path: scan_RooMultiPdf.pdf
+          path: ${{ github.workspace }}/artifacts/scan_RooMultiPdf.pdf
 
       - uses: rhaschke/docker-run-action@v5
         name: RooParametricHist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds a grid-based RooMultiPdf scan and produces a 1D scan plot for review.
  - Publishes the generated scan plot as a downloadable artifact.

- **Chores**
  - Updates the CI workflow to create an artifacts area, run the additional grid scan, generate the plot, and upload the plot artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->