### PR TITLE
avoid cancelling other jobs in CI if one fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
   build:
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.8"]
         root: ["6.22"]  
@@ -46,6 +47,8 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})
+    steps:
+      - run: echo "Building with Python ${{ matrix.python }} and ROOT ${{ matrix.root }}"
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Compile (py${{ matrix.python }}, root${{ matrix.root }})
-    steps:
-      - run: echo "Building with Python ${{ matrix.python }} and ROOT ${{ matrix.root }}"
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
With python 3.8 + root 6.22, at the moment, all other builds are prevented from running. This change avoids this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to run all matrix configurations even if individual jobs fail, ensuring full validation across environments.
  * Improves build reliability and provides more complete test coverage during continuous integration.
  * No changes to user-facing functionality or behavior; this update only affects build orchestration and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->