### PR TITLE
Drop ROOT 6.22 github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8"]
-        root: ["6.22"]  
+        python: ["3.10"]
+        root: ["6.26.4"]  
         include:
-          # python 3.10 root 6.26
-          - python: "3.10"
-            root: "6.26.4"
           - python: "3.10"
             root: "6.32.2"  
           - python: "3.12"
@@ -63,7 +60,7 @@ jobs:
     - name: Install build environment
       shell: bash -l {0}
       run: |
-        mamba install -c conda-forge python==${{ matrix.python }} pip pandas root==${{ matrix.root }} gsl tbb vdt "libstdcxx<15" boost-cpp pcre eigen
+        mamba install -c conda-forge python==${{ matrix.python }} pip pandas root==${{ matrix.root }} gsl tbb vdt boost-cpp pcre eigen
         cd HiggsAnalysis/CombinedLimit
         bash set_conda_env_vars.sh
     - name: Build


### PR DESCRIPTION
To try to fix CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI build environment package list updated to include a constrained system runtime library (libstdc++ < 15) during dependency installation, improving compatibility with native binaries.
  * Enhances reliability of automated builds and reduces failures from incompatible or missing runtime components.
  * No changes to application behavior, public APIs, or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->