### PR TITLE
Remove unneeded `getObservables` and `getParameters` overrides

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -120,12 +120,6 @@ class CachingAddNLL : public RooAbsReal {
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
-        virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
-        RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
-#else
-        bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
-#endif
         double  sumWeights() const { return sumWeights_; }
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
@@ -170,7 +164,6 @@ class CachingSimNLL  : public RooAbsReal {
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
         void setData(const RooAbsData &data) ;
-        virtual RooArgSet* getObservables(const RooArgSet* depList, Bool_t valueOnly = kTRUE) const ;
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
         RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
 #else

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -830,35 +830,6 @@ void cacheutils::CachingAddNLL::setAnalyticBarlowBeeston(bool flag) {
     }
 }
 
-RooArgSet* 
-cacheutils::CachingAddNLL::getObservables(const RooArgSet* depList, Bool_t valueOnly) const 
-{
-    return new RooArgSet();
-}
-
-// ROOT 6.26 changed the signature of getParameters to avoid heap allocation,
-// and especially returning an owning pointer that people tend to forget to
-// delete.
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
-RooArgSet* 
-cacheutils::CachingAddNLL::getParameters(const RooArgSet* depList, Bool_t stripDisconnected) const 
-{
-    RooArgSet *ret = new RooArgSet(params_);
-    ret->add(catParams_);
-    return ret;
-}
-#else
-bool cacheutils::CachingAddNLL::getParameters(const RooArgSet* depList,
-                                              RooArgSet& outputSet,
-                                              bool stripDisconnected) const
-{
-    outputSet.add(params_);
-    outputSet.add(catParams_);
-    return true;
-}
-#endif
-
-
 cacheutils::CachingSimNLL::CachingSimNLL(RooSimultaneous *pdf, RooAbsData *data, const RooArgSet *nuis) :
     pdfOriginal_(pdf),
     dataOriginal_(data),
@@ -1270,12 +1241,6 @@ void cacheutils::CachingSimNLL::setAnalyticBarlowBeeston(bool flag) {
 
         }
     }
-}
-
-RooArgSet* 
-cacheutils::CachingSimNLL::getObservables(const RooArgSet* depList, Bool_t valueOnly) const 
-{
-    return new RooArgSet();
 }
 
 // ROOT 6.26 changed the signature of getParameters to avoid heap allocation,


### PR DESCRIPTION
It makes things a bit easier if custom classes don't re-implement these special functions, in order to not surprise other RooFit functions.

The `getObservables()` function doesn't need to be re-implemented, because the caching NLL classes don't register the observables as proxies to begin with, so even the standard `getObservables()` function will return and empty set.

The `getParameters()` function for the CachingAddNLL also doesn't do anything different from the standard RooFit implementation, which is just to add all real-values and categorical parameters.

What we need to keep for now is the special implementation of `CachingSimNLL::getParameters()`, because this is important for combines channel masking. I hope in the future, we can also remove this once channel masking is easily possible in RooFit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the API of NLL caching components by removing legacy public accessors for retrieving observables and parameters.
  * Reduces surface area and eliminates unused paths, improving maintainability.

* **Impact**
  * This is a breaking change: projects that relied on these accessors will need to update their integrations.
  * Expect compile-time errors where the removed methods were referenced; adjust code to use supported workflows for accessing observables and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->