### PR TITLE
Add InterferenceModel test step to CMSSW CI workflow

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -234,4 +234,4 @@ jobs:
             source /cvmfs/cms.cern.ch/cmsset_default.sh
             cmsenv
             cd HiggsAnalysis/CombinedLimit/test
-            python test_interference.py
+            python3 test_interference.py

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -222,3 +222,16 @@ jobs:
             text2workspace.py HiggsAnalysis/CombinedLimit/data/ci/templ_datacard_largeYields.txt -o ws_template-analysis.root  --for-fits --no-wrappers --use-histsum
             combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-1,1 --X-rtd FAST_VERTICAL_MORPH
 
+      - uses: rhaschke/docker-run-action@v5
+        name: InterferenceModel test in CMSSW
+        with:
+          image: ${{ matrix.IMAGE }}
+          shell: bash
+          options: ${{env.docker_opt_ro}}
+          run: |
+            cp -r cmssw/${CMSSW_VERSION} .
+            cd /home/cmsusr/${CMSSW_VERSION}/src
+            source /cvmfs/cms.cern.ch/cmsset_default.sh
+            cmsenv
+            cd HiggsAnalysis/CombinedLimit/test
+            python test_interference.py


### PR DESCRIPTION
The conda-based CI doesn't error but there are reports that the CMSSW-based one is failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added an automated CI test that runs the InterferenceModel within a CMSSW environment to validate behavior on each run, improving reliability and early detection of regressions.
- Chores
  - Updated the CI workflow to set up the required environment and execute the new test, ensuring consistent verification across builds and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->