### PR TITLE
Use unique canvas names in impact plots

### DIFF
--- a/scripts/plotImpacts.py
+++ b/scripts/plotImpacts.py
@@ -368,7 +368,8 @@ if args.summary:
     MakeSummaryPage()
 
 for page in range(n):
-    canv = ROOT.TCanvas(args.output, args.output)
+    canv_name = "%s_page%i" % (args.output, page)
+    canv = ROOT.TCanvas(canv_name, canv_name)
     n_params = len(data["params"][show * page : show * (page + 1)])
     pdata = data["params"][show * page : show * (page + 1)]
     print(">> Doing page %i, have %i parameters" % (page, n_params))
@@ -595,4 +596,4 @@ for page in range(n):
         extra = "("
     if page == n - 1:
         extra = ")"
-    canv.Print(".pdf%s" % extra)
+    canv.Print("%s.pdf%s" % (args.output, extra))


### PR DESCRIPTION
Fixes #1125 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Each page and the summary now use uniquely named canvases, preventing conflicts and overwrites when generating multi-page plots.
  * PDF export now correctly uses the specified output name and appends page-related suffixes, avoiding incorrect or empty filenames.
  * Standardized canvas finalization ensures all pages are reliably written to the output PDF, improving consistency and stability during plot generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->