### PR TITLE
Recommend to use multiprocessing when building Combine

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -99,7 +99,7 @@ jobs:
             cmsenv
             mkdir -p HiggsAnalysis
             cp -r /work/CombinedLimit HiggsAnalysis/
-            scramv1 b -j$(nproc)
+            scramv1 b -j$(nproc --ignore=2)
             echo ${PATH}
             root --version
             combine --help

--- a/.github/workflows/development-tests-ci.yml
+++ b/.github/workflows/development-tests-ci.yml
@@ -45,7 +45,7 @@ jobs:
             cmsenv
             mkdir -p HiggsAnalysis
             cp -r /work/CombinedLimit HiggsAnalysis/
-            scramv1 b -j$(nproc)
+            scramv1 b -j$(nproc --ignore=2)
             echo ${PATH}
             root --version
             combine --help

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ cd CMSSW_14_1_0_pre4/src
 cmsenv
 git -c advice.detachedHead=false clone --depth 1 --branch v10.2.1 https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-scramv1 b clean; scramv1 b # always make a clean build
+scramv1 b clean; scramv1 b -j$(nproc --ignore=2) # always make a clean build, with n - 2 cores on the system
 ```
 
 ### Combine v9
@@ -67,7 +67,7 @@ cd CMSSW_11_3_4/src
 cmsenv
 git -c advice.detachedHead=false clone --depth 1 --branch v9.2.1 https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-scramv1 b clean; scramv1 b # always make a clean build
+scramv1 b clean; scramv1 b -j$(nproc --ignore=2) # always make a clean build, with n - 2 cores on the system
 ```
 
 #### Combine v8: `CMSSW_10_2_X` release series
@@ -82,7 +82,7 @@ cmsrel CMSSW_10_2_13
 cd CMSSW_10_2_13/src
 cmsenv
 git -c advice.detachedHead=false clone --depth 1 --branch v8.2.0 https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-scramv1 b clean; scramv1 b # always make a clean build
+scramv1 b clean; scramv1 b -j$(nproc --ignore=2) # always make a clean build, with n - 2 cores on the system
 ```
 
 #### SLC6/CC7 release `CMSSW_8_1_X`
@@ -107,7 +107,7 @@ Update to a recommended tag - currently the recommended tag for CMSSW_8_1_X is *
 cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit
 git fetch origin
 git checkout v7.0.13
-scramv1 b clean; scramv1 b # always make a clean build
+scramv1 b clean; scramv1 b -j$(nproc --ignore=2) # always make a clean build, with n - 2 cores on the system
 ```
 
 ### Oustide of CMSSW (recommended for non-CMS users)
@@ -252,7 +252,7 @@ This package also comes with useful features for <span style="font-variant:small
 
 ```sh
 git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester
-scram b
+scram b -j$(nproc --ignore=2)
 ```
 
 See the [`CombineHarvester`](http://cms-analysis.github.io/CombineHarvester/) documentation for full instructions and reccomended versions. 

--- a/docs/model_building_tutorial2024/model_building_exercise.md
+++ b/docs/model_building_tutorial2024/model_building_exercise.md
@@ -8,7 +8,7 @@ After setting up <span style="font-variant:small-caps;">Combine</span>, you can 
 ```shell
 cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/
 git checkout main 
-scram b -j 8
+scram b -j$(nproc --ignore=2)
 cd $CMSSW_BASE/src/HiggsAnalysis/CombinedLimit/data/tutorials/model_building_2024/
 ```
 

--- a/docs/root_ad_development_notes.md
+++ b/docs/root_ad_development_notes.md
@@ -12,7 +12,7 @@ git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsA
 git checkout roofit_ad_ichep_2024_63206_comp
 cd ../../
 cmsenv
-scram b -j 8
+scram b -j$(nproc --ignore=2)
 ```
 ## Tested models
 Below you can find test results for several models with classes implemented in Combine. 


### PR DESCRIPTION
Closes #718.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI build processes to reserve 2 CPU cores during builds for improved system stability.

* **Documentation**
  * Updated build and installation instructions across documentation to reflect optimized parallel build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->