### PR TITLE
Don't use `std::vector` iterators in CachingNLL.cc

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -88,7 +88,6 @@ class CachingPdf : public CachingPdfBase {
         const RooAbsData *lastData_ = 0;
         ValuesCache cache_;
         std::vector<uint8_t> nonZeroW_;
-        unsigned int         nonZeroWEntries_;
         bool                 includeZeroWeights_ = false;
         virtual void newData_(const RooAbsData &data) ;
         virtual void realFill_(const RooAbsData &data, std::vector<Double_t> &values) ;


### PR DESCRIPTION
Vector iterators have no advantage over random acces, because random access is just as fast. They just make the code less readable.

This addresses problems like reported in #514, where formerly used iterators cause unused-variable warnings.

Closes #514.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code structure standardized for consistency and maintainability; iteration and resource-handling patterns were modernized.
  * A deprecated internal counter was removed and per-item state handling was simplified.

---

Note: No user-facing behavior, APIs, or public interfaces were changed; this release contains internal maintenance only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->