### PR TITLE
Do analytical Barlow Beeston before likelihood evaluation

### DIFF
--- a/interface/CMSHistErrorPropagator.h
+++ b/interface/CMSHistErrorPropagator.h
@@ -30,7 +30,6 @@ private:
     std::vector<double> x2;
     std::vector<double> res;
     std::vector<double> gobs;
-    std::set<RooAbsArg*> dirty_prop;
     std::vector<RooRealVar*> push_res;
   };
 public:
@@ -77,7 +76,9 @@ public:
 
   friend class CMSHistV<CMSHistErrorPropagator>;
 
- protected:
+  void runBarlowBeeston() const;
+
+protected:
   RooRealProxy x_;
   RooListProxy funcs_;
   RooListProxy coeffs_;
@@ -108,8 +109,6 @@ public:
 
   void initialize() const;
   void updateCache(int eval = 1) const;
-
-  void runBarlowBeeston() const;
 
 
  private:

--- a/interface/CMSHistSum.h
+++ b/interface/CMSHistSum.h
@@ -30,7 +30,6 @@ private:
     std::vector<double> x2;
     std::vector<double> res;
     std::vector<double> gobs;
-    std::set<RooAbsArg*> dirty_prop;
     std::vector<RooRealVar*> push_res;
   };
 public:
@@ -80,7 +79,9 @@ public:
 
   void injectExternalMorph(int idx, CMSExternalMorph& morph);
 
- protected:
+  void runBarlowBeeston() const;
+
+protected:
   RooRealProxy x_;
 
   RooListProxy morphpars_;
@@ -142,9 +143,6 @@ public:
   void initialize() const;
   void updateCache() const;
   inline double smoothStepFunc(double x, int const& ip) const;
-
-
-  void runBarlowBeeston() const;
 
   void updateMorphs() const;
 

--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -129,6 +129,7 @@ class CachingAddNLL : public RooAbsReal {
         void updateZeroPoint() { clearZeroPoint(); setZeroPoint(); }
         void propagateData();
         void setAnalyticBarlowBeeston(bool flag);
+        void runAnalyticBarlowBeeston();
         /// note: setIncludeZeroWeights(true) won't have effect unless you also re-call setData
         virtual void  setIncludeZeroWeights(bool includeZeroWeights) ;
         RooSetProxy & params() { return params_; }

--- a/src/CMSHistErrorPropagator.cc
+++ b/src/CMSHistErrorPropagator.cc
@@ -99,7 +99,6 @@ void CMSHistErrorPropagator::initialize() const {
   initialized_ = true;
 }
 
-
 void CMSHistErrorPropagator::updateCache(int eval) const {
   initialize();
 
@@ -153,7 +152,6 @@ void CMSHistErrorPropagator::updateCache(int eval) const {
 
 
   if (!binsentry_.good() || eval != last_eval_) {
-    runBarlowBeeston();
     // bintypes might have size == 0 if we never ran setupBinPars()
     for (unsigned j = 0; j < bintypes_.size(); ++j) {
       cache_[j] = valsum_[j];
@@ -192,9 +190,7 @@ void CMSHistErrorPropagator::updateCache(int eval) const {
 }
 
 void CMSHistErrorPropagator::runBarlowBeeston() const {
-  if (!bb_.init) return;
-  RooAbsArg::setDirtyInhibit(true);
-
+  updateCache();
   const unsigned n = bb_.use.size();
   for (unsigned j = 0; j < n; ++j) {
     bb_.dat[j] = data_[bb_.use[j]];
@@ -214,10 +210,6 @@ void CMSHistErrorPropagator::runBarlowBeeston() const {
   }
   for (unsigned j = 0; j < n; ++j) {
     if (toterr_[bb_.use[j]] > 0.) bb_.push_res[j]->setVal(bb_.res[j]);
-  }
-  RooAbsArg::setDirtyInhibit(false);
-  for (RooAbsArg *arg : bb_.dirty_prop) {
-    arg->setValueDirty();
   }
 }
 
@@ -240,7 +232,6 @@ void CMSHistErrorPropagator::setAnalyticBarlowBeeston(bool flag) const {
     bb_.x2.clear();
     bb_.res.clear();
     bb_.gobs.clear();
-    bb_.dirty_prop.clear();
     bb_.push_res.clear();
     bb_.init = false;
   }
@@ -254,7 +245,6 @@ void CMSHistErrorPropagator::setAnalyticBarlowBeeston(bool flag) const {
             // std::cout << "Skipping " << this << " " << this->GetName() << "\n";
           } else {
             // std::cout << "Adding " << arg << " " << arg->GetName() << "\n";
-            bb_.dirty_prop.insert(arg);
             auto as_gauss = dynamic_cast<RooGaussian*>(arg);
             if (as_gauss) {
               auto gobs = dynamic_cast<RooAbsReal*>(as_gauss->findServer(TString(vbinpars_[j][0]->GetName())+"_In"));

--- a/src/CMSHistSum.cc
+++ b/src/CMSHistSum.cc
@@ -336,7 +336,6 @@ inline double CMSHistSum::smoothStepFunc(double x, int const& ip) const {
   return 0.125 * xnorm * (xnorm2 * (3. * xnorm2 - 10.) + 15);
 }
 
-
 void CMSHistSum::updateCache() const {
   initialize();
 
@@ -379,10 +378,6 @@ void CMSHistSum::updateCache() const {
 
 
   if (!binsentry_.good()) {
-    #if HFVERBOSE > 0
-      std::cout << "Calling runBarlowBeeston\n";
-    #endif
-    runBarlowBeeston();
     // bintypes might have size == 0 if we never ran setupBinPars()
     #if HFVERBOSE > 0
       std::cout << "Assigning bin shifts\n";
@@ -418,9 +413,7 @@ void CMSHistSum::updateCache() const {
 }
 
 void CMSHistSum::runBarlowBeeston() const {
-  if (!bb_.init) return;
-  RooAbsArg::setDirtyInhibit(true);
-
+  updateCache();
   const unsigned n = bb_.use.size();
   for (unsigned j = 0; j < n; ++j) {
     bb_.dat[j] = data_[bb_.use[j]];
@@ -440,10 +433,6 @@ void CMSHistSum::runBarlowBeeston() const {
   }
   for (unsigned j = 0; j < n; ++j) {
     if (toterr_[bb_.use[j]] > 0.) bb_.push_res[j]->setVal(bb_.res[j]);
-  }
-  RooAbsArg::setDirtyInhibit(false);
-  for (RooAbsArg *arg : bb_.dirty_prop) {
-    arg->setValueDirty();
   }
 }
 
@@ -466,7 +455,6 @@ void CMSHistSum::setAnalyticBarlowBeeston(bool flag) const {
     bb_.x2.clear();
     bb_.res.clear();
     bb_.gobs.clear();
-    bb_.dirty_prop.clear();
     bb_.push_res.clear();
     bb_.init = false;
   }
@@ -480,7 +468,6 @@ void CMSHistSum::setAnalyticBarlowBeeston(bool flag) const {
             // std::cout << "Skipping " << this << " " << this->GetName() << "\n";
           } else {
             // std::cout << "Adding " << arg << " " << arg->GetName() << "\n";
-            bb_.dirty_prop.insert(arg);
             auto as_gauss = dynamic_cast<RooGaussian*>(arg);
             if (as_gauss) {
               auto gobs = dynamic_cast<RooAbsReal*>(as_gauss->findServer(TString(vbinpars_[j][0]->GetName())+"_In"));


### PR DESCRIPTION
Doing the analytical Barlow Beeston before evaluating the likelihood has
two big advantages, instead of doing it while evaluating the
CMSHistSum/CMSHistErrorPropagator:

1. We don't have to hack the dirty state propagation. This was
   necessary before, because it is not allowed to change a RooRealVar
   server during the evaluation of the client. Also, the hack relies on
   the implementation details of the CachingSimNLL (evaluating main pdf
   before constraints), so it's also a problem for using RooFit regular
   NLL code path.

2. If the analytical minimization and the likelihood evaluation
   factorize, we don't need to worry how to differentiate through the
   analytical minimization and the likelihood evaluation together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional early analytic Barlow–Beeston evaluation before model evaluation.
  * Explicit support for CMS histogram-based PDFs in caching and evaluation.

* **Refactor**
  * Bulk handling of histogram PDFs and streamlined cache/evaluation flow.
  * Simplified dirty-state management: removed implicit triggers and redundant dirty-flag bookkeeping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->