### PR TITLE
Replace type comparisons with `isinstance` in Python

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,5 @@
 # E741: ambiguous variable name 'l' (too pedantic! get a good font)
 # E711: sometimes needed for comparison to ROOT nullptr (better to cast to bool)
 # F401: unused import (some may have side effects, need to clean by hand)
-# E721: do not compare types (new, could be fixed relatively easily)
-ignore = F403,F405,E402,W504,E203,W503,E262,E265,E266,E501,E741,E711,F401,E721
+ignore = F403,F405,E402,W504,E203,W503,E262,E265,E266,E501,E741,E711,F401
 max-line-length = 160

--- a/python/DatacardParser.py
+++ b/python/DatacardParser.py
@@ -444,7 +444,7 @@ def parseCard(file, options):
                     raise RuntimeError("Found %d bins (%s), declared imax = %d" % (len(ret.bins), ret.bins, nbins))
                 ret.exp = {b: {} for b in ret.bins}
                 ret.isSignal = {p: None for p in ret.processes}
-                if ret.obs != [] and type(ret.obs) == list:  # still as list, must change into map with bin names
+                if ret.obs != [] and isinstance(ret.obs, list):  # still as list, must change into map with bin names
                     ret.obs = {b: ret.obs[i] for i, b in enumerate(ret.bins)}
                 for b, p, s in ret.keyline:
                     if ret.isSignal[p] is None:

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -916,7 +916,7 @@ class ModelBuilder(ModelBuilderBase):
                 alogNorms = []  # (kappaLo, kappaHi, RooAbsReal) asymm lnN
                 if scale == 1:
                     pass
-                elif type(scale) == str:
+                elif isinstance(scale, str):
                     factors.append(scale)
                 else:
                     raise RuntimeError("Physics model returned something that is neither a name, nor 0, nor 1.")
@@ -949,7 +949,7 @@ class ModelBuilder(ModelBuilderBase):
                     if pdf == "lnN" and errline[b][p] == 1.0:
                         continue
                     if pdf == "lnN" or pdf == "lnU":
-                        if type(errline[b][p]) == list:
+                        if isinstance(errline[b][p], list):
                             elow, ehigh = errline[b][p]
                             alogNorms.append((elow, ehigh, n))
                         else:

--- a/python/NuisanceModifier.py
+++ b/python/NuisanceModifier.py
@@ -34,22 +34,22 @@ def fullmatch(regex, line):
 
 
 def quadratureAdd(pdf, val1, val2, context=None):
-    if type(val1) == list and len(val1) != 2:
+    if isinstance(val1, list) and len(val1) != 2:
         raise RuntimeError(f"{val1} is a list of length != 2")
-    if type(val2) == list and len(val2) != 2:
+    if isinstance(val2, list) and len(val2) != 2:
         raise RuntimeError(f"{val2} is a list of length != 2")
 
-    if type(val1) == list and type(val2) == list:
+    if isinstance(val1, list) and isinstance(val2, list):
         return [
             quadratureAdd(pdf, val1[0], val2[0], context),
             quadratureAdd(pdf, val1[1], val2[1], context),
         ]
-    elif type(val1) == list and type(val2) == float:
+    elif isinstance(val1, list) and isinstance(val2, float):
         return [
             quadratureAdd(pdf, val1[0], 1.0 / val2, context),
             quadratureAdd(pdf, val1[1], val2, context),
         ]
-    elif type(val2) == list and type(val1) == float:
+    elif isinstance(val2, list) and isinstance(val1, float):
         return [
             quadratureAdd(pdf, 1.0 / val1, val2[0], context),
             quadratureAdd(pdf, val1, val2[1], context),
@@ -261,7 +261,7 @@ def doRenameNuisance(datacard, args):
                 allzeroes = True
                 for a in errline0.keys():
                     for b in errline0[a].keys():
-                        if type(errline0[a][b]) != int and type(errline0[a][b]) != float:
+                        if not isinstance(errline0[a][b], int) and not isinstance(errline0[a][b], float):
                             allzeroes = allzeroes and False
                         # elif errline0[a][b] != 0.0 and errline0[a][b] != 0: allzeroes = allzeroes and False
                         elif abs(errline0[a][b]) > 1e-6:
@@ -428,7 +428,7 @@ def doFlipNuisance(datacard, args):
                         if process == "*" or fullmatch(cprocess, p):
                             foundProc = True
                             if errline[b][p] not in [0.0, 1.0]:
-                                if type(errline[b][p]) is list:
+                                if isinstance(errline[b][p], list):
                                     if errline[b][p][0] < 1:
                                         if "p2n" in opts:
                                             errline[b][p][0] = 1.0 / errline[b][p][0]

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -146,7 +146,7 @@ class ShapeBuilder(ModelBuilder):
                         else:
                             raise RuntimeError(f"packAsymPows: can't work with a coefficient of kind {coeff.ClassName()} for {b} {p}")
                         for X in extranorm:
-                            if type(X) == tuple:
+                            if isinstance(X, tuple):
                                 (klo, khi, syst) = X
                                 coeff.addAsymmLogNormal(klo, khi, self.out.var(syst))
                             else:

--- a/python/util/plotting.py
+++ b/python/util/plotting.py
@@ -882,7 +882,7 @@ def GraphDivide(num, den):
     res = num.Clone()
     for i in range(num.GetN()):
         res.GetY()[i] = res.GetY()[i] / den.Eval(res.GetX()[i])
-    if type(res) is R.TGraphAsymmErrors:
+    if isinstance(res, R.TGraphAsymmErrors):
         for i in range(num.GetN()):
             res.GetEYhigh()[i] = res.GetEYhigh()[i] / den.Eval(res.GetX()[i])
             res.GetEYlow()[i] = res.GetEYlow()[i] / den.Eval(res.GetX()[i])

--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -228,7 +228,7 @@ for ich, fname in enumerate(args):
                             constraint_terms.append(line)
                     warnings.warn(warning_message, RuntimeWarning)
                     break
-                if type(errline[b][p]) == list:
+                if isinstance(errline[b][p], list):
                     r = "{}/{}".format(
                         FloatToString(errline[b][p][0]),
                         FloatToString(errline[b][p][1]),

--- a/test/datacardDump.py
+++ b/test/datacardDump.py
@@ -117,7 +117,7 @@ for b in DC.bins:
                 exps[p][1].append(1 / sqrt(pdfargs[0] + 1))
             elif pdf == "gmM":
                 exps[p][1].append(errline[b][p])
-            elif type(errline[b][p]) == list:
+            elif isinstance(errline[b][p], list):
                 kmax = max(
                     errline[b][p][0],
                     errline[b][p][1],

--- a/test/findRedundantSystematics.py
+++ b/test/findRedundantSystematics.py
@@ -43,12 +43,11 @@ def asymDivide(something):
     if len(something) != 2:
         raise TypeError("asymDivision requires a pair.")
 
-    (a, b) = something
-    theType = (type(a), type(b))
+    a, b = something
 
-    if theType == (FloatType, ListType) or theType == (ListType, FloatType):
+    if (isinstance(a, FloatType) and isinstance(b, ListType)) or (isinstance(a, ListType) and isinstance(b, FloatType)):
         return asymDivideMixed(something)
-    elif theType == (ListType, ListType):
+    elif isinstance(a, ListType) and isinstance(b, ListType):
         if len(a) != len(b):
             raise TypeError("For pairs of lists, they must have the same length.")
         return asymDivideLists(something)
@@ -86,7 +85,7 @@ def asymDivideMixed(elementAndList):
     (x, yz) = elementAndList
     orderKept = True
 
-    if type(x) == ListType:
+    if isinstance(x, ListType):
         (x, yz) = (yz, x)
         orderKept = False
 

--- a/test/printWorkspaceNormalisations.py
+++ b/test/printWorkspaceNormalisations.py
@@ -187,8 +187,7 @@ if use_cms_histsum:
             prop = prop_it.Next()
             prop_name = prop.GetName()
             if chan == prop_name.split("_bin")[-1]:
-                types = [ROOT.CMSHistSum, ROOT.CMSHistErrorPropagator]
-                if type(prop) in types:
+                if isinstance(prop, (ROOT.CMSHistSum, ROOT.CMSHistErrorPropagator)):
                     chan_CMSHistSum_norms[chan] = dict(prop.getProcessNorms())
 
 

--- a/test/systematicsAnalyzer.py
+++ b/test/systematicsAnalyzer.py
@@ -311,7 +311,7 @@ for lsyst, nofloat, pdf, pdfargs, errline in DC.systs:
                 addTo(check_list, lsyst, [p, b])
 
             else:
-                vals.extend(errline[b][p] if type(errline[b][p]) == list else [errline[b][p]])
+                vals.extend(errline[b][p] if isinstance(errline[b][p], list) else [errline[b][p]])
                 numKeysFound += 1
                 types.append(pdf)
                 processes[p] = True

--- a/test/validation/TestClasses.py
+++ b/test/validation/TestClasses.py
@@ -270,7 +270,7 @@ class SingleDatacardWithExpectedTest(SingleDatacardTest):
 
     def readOutput(self, dir):
         out = _readRootFileWithExpected("%s/higgsCombine%s.%s.mH%s.root" % (dir, self._name, self._method, self._mass))
-        if type(out) == dict:
+        if isinstance(out, dict):
             return out
         dn = os.path.basename(self._datacard)
         resmap = dict([(dn + x, y) for (x, y) in out])
@@ -351,7 +351,7 @@ class MultiDatacardWithExpectedTest(MultiDatacardTest):
         ret = {"results": {}}
         for dc, mass in self._datacards:
             thisres = _readRootFileWithExpected("%s/higgsCombine%s.%s.mH%s.root" % (dir, self._name, self._method, mass))
-            if type(thisres) == dict:
+            if isinstance(thisres, dict):
                 ret["results"][os.path.basename(dc)] = thisres
             else:
                 for postfix, res in thisres:
@@ -412,7 +412,7 @@ class WorkspaceWithExpectedTest(MultiDatacardTest):
             )
         else:
             out = _readRootFileWithExpected("%s/higgsCombine%s.%s.mH%s.root" % (dir, self._name, self._method, self._mass))
-        if type(out) == dict:
+        if isinstance(out, dict):
             return out
         dn = os.path.basename(self._cmb_card)
         resmap = dict([(dn + x, y) for (x, y) in out])


### PR DESCRIPTION
Closes #857.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved runtime type handling across the codebase for more robust and consistent behavior with Python type subclasses, reducing edge-case errors.

* **Chores**
  * Linting configuration tightened to report a previously-ignored check (E721), enforcing stricter type-checking practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->