### PR TITLE
[ci] Add also ROOT 6.30 from LCG to the test matrix

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -34,6 +34,15 @@ jobs:
           - LCG_RELEASE: "LCG_102"
             LCG_ARCH: "x86_64-ubuntu2204-gcc11-opt"
             ROOT: "6.26.04"
+          # Nobody is using Combine with ROOT 6.28 because this ROOT version
+          # was not used in CMSSW. But if you want to test it in the CI, here
+          # is how it would work:
+          # - LCG_RELEASE: "LCG_104"
+          #   LCG_ARCH: "x86_64-ubuntu2204-gcc11-opt"
+          #   ROOT: "6.28.04"
+          - LCG_RELEASE: "LCG_105"
+            LCG_ARCH: "x86_64-ubuntu2204-gcc11-opt"
+            ROOT: "6.30.02"
           - LCG_RELEASE: "LCG_106"
             LCG_ARCH: "x86_64-ubuntu2204-gcc11-opt"
             ROOT: "6.32.02"


### PR DESCRIPTION
This is to test also these older ROOT versions with the more rigurous CTests that come when building Combine standalone with CMake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Expanded the continuous integration testing matrix by introducing additional release configurations with different compiler versions and architecture specifications to improve build compatibility verification across multiple platform combinations.
* Maintained all existing release configurations to ensure comprehensive build testing coverage while preparing infrastructure for potential future test scenario expansions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->