### PR TITLE
Fix rootmap path when building with `MODIFY_ROOTMAP`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(MODIFY_ROOTMAP)
         # edit the generated rootmap in-situ before installation
 
         # Define the path to the generated file
-        set(GENERATED_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/lib${LIBNAME}.rootmap")
+        set(GENERATED_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${LIBNAME}.rootmap")
 
         # Define the custom command to search and replace in-place
         add_custom_command(


### PR DESCRIPTION
This follows up on the latest CMake updates and is relevant for building in the StatAnalysis release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to align rootmap file paths with library output directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->