### PR TITLE
[ci] Run ctests from the correct directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,4 @@ jobs:
         combine --help > /dev/null
         text2workspace.py --help > /dev/null
         ulimit -s unlimited;
-        ctest --test-dir build --output-on-failure
+        ctest --test-dir build/test --output-on-failure

--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: >-
           source /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE}/${LCG_ARCH}/setup.sh;
           ulimit -s unlimited;
-          ctest --test-dir build --output-on-failure -j$(nproc);
+          ctest --test-dir build/test --output-on-failure -j$(nproc);
 
       # AlmaLinux 9 job
       - uses: ./.github/actions/run-in-cvmfs

--- a/test/CombineTestMacros.cmake
+++ b/test/CombineTestMacros.cmake
@@ -42,9 +42,6 @@ function(COMBINE_ADD_TEST test)
       find_program(_exe ${_prg})
       if(_exe)                                         # if the command is found in the system, use it
         set(_cmd ${_exe} ${ARG_COMMAND})
-      elseif(NOT IS_ABSOLUTE ${_prg})                  # if not absolute, assume is found in current binary dir
-        set(_prg ${CMAKE_CURRENT_BINARY_DIR}/${_prg})
-        set(_cmd ${_prg} ${ARG_COMMAND})
       else()                                           # take as it is
         set(_cmd ${_prg} ${ARG_COMMAND})
       endif()


### PR DESCRIPTION
This fixes the problem that no tests were found for the LCG and conda builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI and CVMFS workflows to discover tests in the `build/test` directory instead of the broader `build` directory.
  * Updated test macro to adjust how program paths are resolved during test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->