### PR TITLE
Support codegen only for ROOT 6.36+

### DIFF
--- a/interface/AsymPow.h
+++ b/interface/AsymPow.h
@@ -4,8 +4,6 @@
 #include <RooAbsReal.h>
 #include <RooRealProxy.h>
 
-#include "CombineCodegenImpl.h"
-
 //_________________________________________________
 /*
 BEGIN_HTML
@@ -29,8 +27,6 @@ class AsymPow : public RooAbsReal {
 
       TObject * clone(const char *newname) const override { return new AsymPow(*this, newname); }
 
-      COMBINE_DECLARE_TRANSLATE;
-
       RooAbsReal const &kappaLow() const { return kappaLow_.arg(); }
       RooAbsReal const &kappaHigh() const { return kappaHigh_.arg(); }
       RooAbsReal const &theta() const { return theta_.arg(); }
@@ -44,7 +40,5 @@ class AsymPow : public RooAbsReal {
 
   ClassDefOverride(AsymPow,1) // Asymmetric power	
 };
-
-COMBINE_DECLARE_CODEGEN_IMPL(AsymPow);
 
 #endif

--- a/interface/CombineCodegenImpl.h
+++ b/interface/CombineCodegenImpl.h
@@ -1,27 +1,26 @@
 #ifndef HiggsAnalysis_CombinedLimit_CombineCodegenImpl_h
 #define HiggsAnalysis_CombinedLimit_CombineCodegenImpl_h
 
-#include <ROOT/RConfig.hxx> // for ROOT_VERSION
+#include <string>
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,35,0)
-# define COMBINE_DECLARE_CODEGEN_IMPL(CLASS_NAME) \
-    namespace RooFit { namespace Experimental { void codegenImpl(CLASS_NAME &arg, CodegenContext &ctx); }}
-# define COMBINE_DECLARE_CODEGEN_INTEGRAL_IMPL(CLASS_NAME) \
-    namespace RooFit { namespace Experimental { std::string codegenIntegralImpl(CLASS_NAME &arg, int code, const char *rangeName, CodegenContext &ctx); }}
-# define COMBINE_DECLARE_TRANSLATE
-# define COMBINE_DECLARE_ANALYTICAL_INTEGRAL
-#elif ROOT_VERSION_CODE >= ROOT_VERSION(6,32,0)
-# define COMBINE_DECLARE_CODEGEN_IMPL(CLASS_NAME)
-# define COMBINE_DECLARE_CODEGEN_INTEGRAL_IMPL(CLASS_NAME)
-# define COMBINE_DECLARE_TRANSLATE \
-    void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
-# define COMBINE_DECLARE_ANALYTICAL_INTEGRAL \
-    std::string buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
-#else
-# define COMBINE_DECLARE_CODEGEN_IMPL(_)
-# define COMBINE_DECLARE_CODEGEN_INTEGRAL_IMPL(_)
-# define COMBINE_DECLARE_TRANSLATE
-# define COMBINE_DECLARE_ANALYTICAL_INTEGRAL
-#endif
+class AsymPow;
+class FastVerticalInterpHistPdf2;
+class FastVerticalInterpHistPdf2D2;
+class ProcessNormalization;
+class VerticalInterpPdf;
+
+namespace RooFit::Experimental {
+
+  class CodegenContext;
+
+  void codegenImpl(AsymPow& arg, CodegenContext& ctx);
+  void codegenImpl(FastVerticalInterpHistPdf2& arg, CodegenContext& ctx);
+  void codegenImpl(FastVerticalInterpHistPdf2D2& arg, CodegenContext& ctx);
+  void codegenImpl(ProcessNormalization& arg, CodegenContext& ctx);
+  void codegenImpl(VerticalInterpPdf& arg, CodegenContext& ctx);
+
+  std::string codegenIntegralImpl(VerticalInterpPdf& arg, int code, const char* rangeName, CodegenContext& ctx);
+
+}  // namespace RooFit::Experimental
 
 #endif

--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -4,8 +4,6 @@
 #include <RooAbsReal.h>
 #include "RooListProxy.h"
 
-#include "CombineCodegenImpl.h"
-
 //_________________________________________________
 /*
 BEGIN_HTML
@@ -29,8 +27,6 @@ class ProcessNormalization : public RooAbsReal {
       void addAsymmLogNormal(double kappaLo, double kappaHi, RooAbsReal &theta) ;
       void addOtherFactor(RooAbsReal &factor) ;
       void dump() const ;
-
-      COMBINE_DECLARE_TRANSLATE;
 
       double nominalValue() const { return nominalValue_; }
       std::vector<double> const &logKappa() const { return logKappa_; }
@@ -60,7 +56,5 @@ class ProcessNormalization : public RooAbsReal {
 
   ClassDefOverride(ProcessNormalization,1) // Process normalization interpolator 
 };
-
-COMBINE_DECLARE_CODEGEN_IMPL(ProcessNormalization);
 
 #endif

--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -11,8 +11,6 @@
 #include "SimpleCacheSentry.h"
 #include "FastTemplate_Old.h"
 
-#include "CombineCodegenImpl.h"
-
 class FastVerticalInterpHistPdf;
 class FastVerticalInterpHistPdf2Base;
 class FastVerticalInterpHistPdf2;
@@ -330,8 +328,6 @@ public:
 
   FastHisto const& cache() const { return _cache; }
 
-  COMBINE_DECLARE_TRANSLATE;
-
   FastHisto const &cacheNominal() const { return _cacheNominal; }
 
   friend class FastVerticalInterpHistPdf2V;
@@ -392,8 +388,6 @@ public:
   Double_t maxVal(Int_t code) const override ;
 
   Double_t evaluate() const override ;
-
-  COMBINE_DECLARE_TRANSLATE;
 
   FastHisto2D const &cacheNominal() const { return _cacheNominal; }
 
@@ -465,9 +459,5 @@ protected:
 private:
   ClassDefOverride(FastVerticalInterpHistPdf3D,1) // 
 };
-
-
-COMBINE_DECLARE_CODEGEN_IMPL(FastVerticalInterpHistPdf2);
-COMBINE_DECLARE_CODEGEN_IMPL(FastVerticalInterpHistPdf2D2);
 
 #endif

--- a/interface/VerticalInterpPdf.h
+++ b/interface/VerticalInterpPdf.h
@@ -9,8 +9,6 @@
 #include "RooObjCacheManager.h"
 #include "RtypesCore.h"
 
-#include "CombineCodegenImpl.h"
-
 class VerticalInterpPdf : public RooAbsPdf {
 public:
 
@@ -21,12 +19,10 @@ public:
 
   Double_t evaluate() const override ;
   Bool_t checkObservables(const RooArgSet* nset) const override ;	
-  COMBINE_DECLARE_TRANSLATE
 
   Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
   Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  COMBINE_DECLARE_ANALYTICAL_INTEGRAL
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& funcIntListFromCache() const;
@@ -70,8 +66,5 @@ protected:
 
   ClassDefOverride(VerticalInterpPdf,3) // PDF constructed from a sum of (non-pdf) functions
 };
-
-COMBINE_DECLARE_CODEGEN_IMPL(VerticalInterpPdf);
-COMBINE_DECLARE_CODEGEN_INTEGRAL_IMPL(VerticalInterpPdf);
 
 #endif

--- a/src/classes.h
+++ b/src/classes.h
@@ -61,3 +61,5 @@
 #include "HiggsAnalysis/CombinedLimit/interface/CMSExternalMorph.h"
 #include "HiggsAnalysis/CombinedLimit/interface/CMSInterferenceFunc.h"
 #include "HiggsAnalysis/CombinedLimit/interface/RooEFTScalingFunction.h"
+
+#include "HiggsAnalysis/CombinedLimit/interface/CombineCodegenImpl.h"


### PR DESCRIPTION
The interface to implement codegen was changed with ROOT 6.36, but I preserverd backwards compatibility with ROOT 6.32+ using preprocessor macros. This was important to get test coverage in the CI, because we had no CI with ROOT 6.36 one year ago. Now we have it with the LCG realeases, so the backwards compatibility is not needed anymore. Nobody is using RooFit codegen in production yet, so it's fine to support only the latest ROOT version.

Removing the preprocessor logic will make it much easier to work with the code, understand what it's doing, and extending it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code generation infrastructure to enhance maintainability and code clarity. Replaced macro-based declarations with explicit namespace-qualified function definitions for improved code organization.
  * Updated internal compilation mechanisms for mathematical function types to better structure code generation entry points.
  * All existing functionality and user-facing behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->