### PR TITLE
ci(docs): automatically set new tags as latest and default version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,12 @@ jobs:
         git config user.email ci-bot@example.com
 
         if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-          # Tag push: deploy the tag version
+          # Tag push: deploy the tag version with 'latest' alias and set as default
           TAG_VERSION=${GITHUB_REF#refs/tags/}
           echo "Deploying docs for tag $TAG_VERSION"
-          mike deploy --push $TAG_VERSION
+          mike deploy --push --update-aliases $TAG_VERSION latest
+          echo "Setting $TAG_VERSION as default version"
+          mike set-default --push $TAG_VERSION
         else
           # Main branch push: deploy to 'main'
           echo "Deploying docs for main branch"


### PR DESCRIPTION
When a new version tag is pushed:
- Deploy with 'latest' alias (moves alias from old to new version)
- Set as default version (updates root redirect)

This eliminates manual steps after each release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved documentation deployment workflow: tagged pushes now deploy the tag version, update an additional "latest" alias, and set the tag as the default deployment; main-branch deployment remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->