### PR TITLE
Correct `nullptr` check of RooAbsArg in ShapeTools.py 

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -749,7 +749,7 @@ class ShapeBuilder(ModelBuilder):
                 if not syst:
                     normname = "%s_norm" % (oname)
                     norm = self.wsp.arg(normname)
-                    if norm == None:
+                    if not norm:
                         if normname in list(self.norm_rename_map.keys()):
                             norm = self.wsp.arg(self.norm_rename_map[normname])
                     if norm:


### PR DESCRIPTION
ROOT 6.38 deprecated the comparison of C++ `nullptr` with Pythons `None` for type safety. The right way to check for `nullptr` is to check the truthy-ness of the object. Note that `arg is None` does not work, becaues a C++ object in PyROOT is never identical to Pythons `None`, so this comparison will always be false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of normalization arguments to ensure consistent behavior with empty or missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->