### PR TITLE
Update the documentation of available containers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ git checkout v7.0.13
 scramv1 b clean; scramv1 b -j$(nproc --ignore=2) # always make a clean build, with n - 2 cores on the system
 ```
 
-### Oustide of CMSSW
+### Outside of CMSSW
 
 #### Standalone compilation
 
@@ -202,7 +202,7 @@ Pre-compiled versions of the tool are available as container images from the [CM
 ```sh
 docker run --name combine -it gitlab-registry.cern.ch/cms-cloud/combine-standalone:<tag>
 ```
-where you must replace `<tag>` with a particular version of the tool. At the moment the available container versions are `v9.2.1` and `v9.2.1-slim`, both build with Combine tag `v9.2.1`, and the `v9.2.1-slim` correspond to a slim version. If no tag is specified the latest version of the container will be loaded, which is `v9.2.1-slim` at the moment. The containers for `v10.X.X` versions are being developed and are not yet availble for the users.
+where you must replace `<tag>` with a particular version of the tool. Containers are available from `v9.2.1` and `v10.0.1` onwards. If no tag is specified the latest version of the container will be loaded, which is `v10.3.3` at the moment.
 
 You will now have the compiled <span style="font-variant:small-caps;">Combine</span> binary available as well as the complete package of tool.
 The container can be re-started using `docker start -i combine`.


### PR DESCRIPTION
The documentation incorrectly states that only two Combine containers are available, while we have more. Correct this.

Also fix a typo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the installation guide.
  * Updated container installation instructions with latest version details, including the default container tag v10.3.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->