### PR TITLE
[ci] Remove redundant tests from the CMSSW CI

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -179,15 +179,6 @@ jobs:
             cd ..
             cd build_test
             ctest3 --output-on-failure .
-            
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Counting datacard
-        # Only run this test in CMSSW mode, because otherwise we already run this in the unit tests
-        if: ${{ env.CMSSW_VERSION != '' }}
-        with:
-          script: |
-            text2workspace.py  data/tutorials/multiDim/toy-hgg-125.txt -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
-            combine -M MultiDimFit data/tutorials/multiDim/toy-hgg-125.root  --setParameterRanges r=-5,5
 
       - uses: ./.github/actions/run-in-cvmfs
         name: Countind datacard Fixed Point from csv
@@ -196,59 +187,6 @@ jobs:
           script: |
             text2workspace.py  data/tutorials/multiDim/toy-hgg-125.txt -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
             combineTool.py -M MultiDimFit data/tutorials/multiDim/toy-hgg-125.root --fromfile data/tutorials/multiDim/fixed.csv
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Parametric analysis
-        if: ${{ env.CMSSW_VERSION != '' }}
-        with:
-          script: |
-            text2workspace.py data/tutorials/CAT23001/datacard-3-parametric-analysis.txt -o ws_parametric-analysis.root --mass 125
-            combine -M MultiDimFit ws_parametric-analysis.root  --algo singles --setParameterRanges r=-2,1
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis CMSHistFunc 
-        with:
-          script: |
-            text2workspace.py data/ci/template-analysis_shapeInterp.txt -o ws_template-analysis.root --mass 200
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis CMSHistFunc shapeN
-        with:
-          script: |
-            text2workspace.py data/ci/template-analysis_shapeNInterp.txt -o ws_template-analysis.root --mass 200
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: CMSHistFunc with channel masks
-        with:
-          script: |
-            text2workspace.py data/ci/htt_multiple_regions.txt -o ws_template-analysis_masks.root --mass 125 --channel-masks
-            combine -M MultiDimFit ws_template-analysis_masks.root --algo singles  --setParameterRanges r=-5,5 --setParameters mask_htt_tt_2_8TeV=1 
-
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis CMSHistSum
-        if: ${{ env.CMSSW_VERSION != '' }}
-        with:
-          script: |
-            text2workspace.py data/ci/template-analysis_shapeInterp.txt -o ws_template-analysis.root --mass 200 --for-fits --no-wrappers --use-histsum
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis CMSHistSum with shapeN
-        if: ${{ env.CMSSW_VERSION != '' }}
-        with:
-          script: |
-            text2workspace.py data/ci/template-analysis_shapeNInterp.txt -o ws_template-analysis.root --mass 200 --for-fits --no-wrappers --use-histsum
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: CMSHistSum with channel masks
-        with:
-          script: |
-            text2workspace.py data/ci/htt_multiple_regions.txt -o ws_template-analysis_masks.root --mass 125 --channel-masks --for-fits --no-wrappers --use-histsum
-            combine -M MultiDimFit ws_template-analysis_masks.root --algo singles  --setParameterRanges r=-5,5 --setParameters mask_htt_tt_2_8TeV=1 --X-rtd FAST_VERTICAL_MORPH 
 
       - uses: ./.github/actions/run-in-cvmfs
         name: RooMultiPdf


### PR DESCRIPTION
Many tests that were hardcoded in the YAML config of the CMSSW CI are also in the CMake tests, which are always run on all CI platforms.

While it makes sense to keep some test around also in the explicit YAML config so that the output can be inspected manually, this doesn't make sense anymore for tests that compare the output against a reference file, as no manual inspection of the output is required.

This commit removes such tests from the CMSSW CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow by removing select test steps while retaining core validation tests and general analysis workflows. Pipeline focus refined to essential testing procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->