### PR TITLE
Immediately safe_import CMSHistFuncWrapper

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -67,7 +67,6 @@ class ShapeBuilder(ModelBuilder):
                 ROOT.gSystem.Load(lib)
         self.wspnames = {}
         self.wsp = None
-        self.extraImports = []
         self.norm_rename_map = {}
         self._fileCache = FileCache(self.options.baseDir)
 
@@ -365,7 +364,7 @@ class ShapeBuilder(ModelBuilder):
                         "combine.channel",
                         pdfs.at(idx).getStringAttribute("combine.channel"),
                     )
-                    self.extraImports.append(wrapper)
+                    self.out.safe_import(wrapper, ROOT.RooFit.RecycleConflictNodes())
 
         if len(bbb_names) > 0:
             bbb_nuisanceargset = ROOT.RooArgSet()
@@ -433,9 +432,6 @@ class ShapeBuilder(ModelBuilder):
                     self.getObj("pdf_bin%s_bonly" % self.DC.bins[0]).clone("model_b"),
                     ROOT.RooFit.Silence(),
                 )
-        for arg in self.extraImports:
-            # print 'Importing extra arg: %s' % arg.GetName()
-            self.out.safe_import(arg, ROOT.RooFit.RecycleConflictNodes())
         if self.options.fixpars:
             pars = self.out.pdf("model_s").getParameters(self.out.obs)
             for arg in pars:


### PR DESCRIPTION
A huge part of the execution time when running ```text2workspace.py``` for template models seems to be spent in importing into the workspace instances of ```CMSHistFuncWrapper```. This import uses ```ROOT.Roofit.RecycleConflictNodes```, which traverses the dependency graph and seems to grow non-linearly with the workspace size.

Instead of importing all the instances of ```CMSHistFuncWrapper``` at the end of ```doCombination```, this PR moves the safe import right after the creation of each instance, when the workspace is less large, effectively reducing the time spent in traversing the graph and the overall runtime of ```text2workspace.py```.
I tested this on the pT datacard of HIG-20-015 (see [here](https://gitlab.cern.ch/magalli/hig-20-015/-/tree/master?ref_type=heads)) and the overall time to run the ```text2workspace.py``` command **decreased from 375.81s to 264s** (measured with ```/usr/bin/time```). In this case, the command created ~4000 of such wrappers when running t2w.

Considering that it seems to much gain for such an easy fix, I expect that there is something that I overlooked and something to break somewhere else, so let's see if the tests are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined import handling in model processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->