### PR TITLE
Add option to pick toy

### DIFF
--- a/bin/combine.cpp
+++ b/bin/combine.cpp
@@ -92,12 +92,15 @@ int main(int argc, char **argv) {
     ("verbose,v",  po::value<int>(&verbose)->default_value(0), "Verbosity level (-1 = very quiet; 0 = quiet, 1 = verbose, 2+ = debug)")
     ("help,h", "Produce help message")
     ;
-  combiner.statOptions().add_options()
-    ("toys,t", po::value<int>(&runToys)->default_value(0), "Number of Toy MC extractions")
-    ("pickToy", po::value<int>(&pickToy)->default_value(0), "Works with --toys option. Pick a specific toy index 1..N to calculate result")
-    ("seed,s", po::value<int>(&seed)->default_value(123456), "Toy MC random seed")
-    ("hintMethod,H",  po::value<string>(&whichHintMethod)->default_value(""), "First run this method to provide a hint on the result")
-    ;
+  combiner.statOptions().add_options()(
+      "toys,t", po::value<int>(&runToys)->default_value(0), "Number of Toy MC extractions")(
+      "pickToy",
+      po::value<int>(&pickToy)->default_value(0),
+      "Works with --toys option. Pick a specific toy index 1..N to calculate result")(
+      "seed,s", po::value<int>(&seed)->default_value(123456), "Toy MC random seed")(
+      "hintMethod,H",
+      po::value<string>(&whichHintMethod)->default_value(""),
+      "First run this method to provide a hint on the result");
   combiner.ioOptions().add_options()
     ("name,n",     po::value<string>(&name)->default_value("Test"), "Name of the job, affects the name of the output tree")
     ("mass,m",     po::value<float>(&iMass)->default_value(120.), "Mass to store in the output tree")
@@ -206,8 +209,8 @@ int main(int argc, char **argv) {
 
   TString massName = TString::Format("mH%g.", iMass);
   TString toyName  = "";  if (runToys > 0 || seed != 123456 || vm.count("saveToys")) toyName  = TString::Format("%d.", seed);
-  if (runToys > 0  ){
-    if ( ( !vm["pickToy"].defaulted() ) && ( pickToy > runToys || pickToy <= 0) ){
+  if (runToys > 0) {
+    if ((!vm["pickToy"].defaulted()) && (pickToy > runToys || pickToy <= 0)) {
       std::cerr << "ERROR - set pickToy to values 1 to (N toys) cannot use pickToy=" << pickToy << std::endl;
       assert(0);
     }

--- a/interface/Combine.h
+++ b/interface/Combine.h
@@ -16,7 +16,7 @@ class RooWorkspace;
 class RooAbsData;
 namespace RooStats { class ModelConfig; }
 
-extern Float_t t_cpu_, t_real_, g_quantileExpected_; 
+extern Float_t t_cpu_, t_real_, g_quantileExpected_;
 extern bool g_fillTree_;
 extern int pickToy_;
 //RooWorkspace *writeToysHere = 0;
@@ -53,7 +53,7 @@ public:
 
   /// Set a specific toy to run method on when using --toysFile / --toys
   static void setPickToy(int pickToy);
- 
+
   /// Stop combine from fillint the tree (some algos need control)
   static void toggleGlobalFillTree(bool flag=false);
 

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -1027,8 +1027,8 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
     algo->setNToys(nToys);
 
     for (iToy = 1; iToy <= nToys; ++iToy) {
-
-      if ( (pickToy_ !=0) && (iToy != pickToy_) ) continue;
+      if ((pickToy_ != 0) && (iToy != pickToy_))
+        continue;
 
       // Reset ranges --> for likelihood scans
       if (setPhysicsModelParameterRangeExpression_ != "") {
@@ -1151,9 +1151,7 @@ void Combine::toggleGlobalFillTree(bool flag){
    g_fillTree_ = flag;
 }
 
-void Combine::setPickToy(int pickToy){
-    pickToy_ = pickToy;
-}
+void Combine::setPickToy(int pickToy) { pickToy_ = pickToy; }
 
 void Combine::commitPoint(bool expected, float quantile) {
     Float_t saveQuantile =  g_quantileExpected_;


### PR DESCRIPTION
When running with `--toys N`, can pick a specific toy to run over with `--pickToy i`, where i = 1..N. Allows used to pick out a toy previously generated with `-M GenerateOnly`. 

Also means global observables are correctly picked up too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to select a specific toy for processing during toy MC runs.
  * The selected toy is applied when toy runs are enabled; default behavior is unchanged when not set.

* **Bug Fixes**
  * Validation added to ensure the chosen toy index is within the valid range; errors abort invalid requests.

* **Documentation**
  * Updated help/docs to reflect the new option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->