### PR TITLE
add note about ranges to stat routines tutorial

### DIFF
--- a/docs/tutorial_stat_routines/stat_routines.md
+++ b/docs/tutorial_stat_routines/stat_routines.md
@@ -204,9 +204,10 @@ combine -M MultiDimFit datacard.txt --rMin -10 --rMax 10 --algo fixed --fixedPoi
 Test out a few values of `r` and see if they all give you the same result. 
 What happens for `r` less than about -1? Can you explain why? (hint: look at the values in the datacard)
 
+**Note**: if you are running the toys generation and fitting commands separately, remember to always set the range to include the value you are setting. If you don't, Roofit will clip the value of `r` to the nearest boundary, and you could see unexpected results.
+
 **Advanced**: if you run the command above for a set of points in the range [-2, 6] (the same one used in the scan before), you can build the line of critical values for $t_{\mu}$ and check where the crossing of the observed likelihood scan is in order to find the confidence interval. Try to do that and compare it to the one we derived earlier using Wilks' theorem.
 If you need help, take a look at the code in `plot_scan_with_quantile_solution.py`.
-
 
 ## Significance Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clarifying cautionary notes to the statistical routines tutorial reminding users to ensure parameter ranges include the true values when running toy generation and fitting separately, preventing unintended parameter clipping and ensuring correct fit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->