### PR TITLE
Fix sqrt function call in AsymptoticLimits.cc

### DIFF
--- a/src/AsymptoticLimits.cc
+++ b/src/AsymptoticLimits.cc
@@ -492,7 +492,7 @@ float AsymptoticLimits::findExpectedLimitFromCrossing(RooAbsReal &nll, RooRealVa
         r->setConstant(false);
 
         double qMuAsimov =  q_At_0-q_At_muA;
-        double N_for_expected = N+ROOT::Math::sqrt(qMuAsimov);
+        double N_for_expected = N+sqrt(qMuAsimov);
         pb_expected = ROOT::Math::normal_cdf(N_for_expected, 1.0); 
         // std::cout << "  --> this gives pb = " << pb_expected << " (N=" << N_for_expected << ")" << std::endl;
     }


### PR DESCRIPTION
Use sqrt instead of Math::sqrt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mathematical function usage for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->