### PR TITLE
[ci] Migrate some more tests to the CTest suite

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -208,28 +208,6 @@ jobs:
             combine -M MultiDimFit ws_RooParametricHist.root --algo singles
 
       - uses: ./.github/actions/run-in-cvmfs
-        name: RooHistPdf
-        if: ${{ !matrix.CMSSW_VERSION || startsWith(matrix.CMSSW_VERSION, 'CMSSW_14') }}
-        with:
-          script: |
-            text2workspace.py data/ci/datacard_RooHistPdf.txt.gz -o ws_RooHistPdf.root
-            combine -M MultiDimFit ws_RooHistPdf.root --algo singles -v -2  --setParameterRanges r=-1,2.
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis with large integrals
-        with:
-          script: |
-            text2workspace.py data/ci/templ_datacard_largeYields.txt -o ws_template-analysis.root
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5
-
-      - uses: ./.github/actions/run-in-cvmfs
-        name: Template analysis with large integrals using CMSHistSum
-        with:
-          script: |
-            text2workspace.py data/ci/templ_datacard_largeYields.txt -o ws_template-analysis.root  --for-fits --no-wrappers --use-histsum
-            combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH
-
-      - uses: ./.github/actions/run-in-cvmfs
         name: InterferenceModel test in CMSSW
         if: ${{ env.CMSSW_VERSION != '' }}
         with:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,9 +147,8 @@ set(t2w ${CMAKE_BINARY_DIR}/bin/text2workspace.py)
 
 # Counting datacard
 ADD_COMBINE_TEST(counting_datacard
-  COPY_TO_BUILDDIR ${REPO}/data/tutorials/multiDim/toy-hgg-125.txt
   T2W_COMMAND
-    text2workspace.py toy-hgg-125.txt -o counting_datacard.root -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
+    text2workspace.py ${REPO}/data/tutorials/multiDim/toy-hgg-125.txt -o counting_datacard.root -m 125 -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH
   COMBINE_COMMANDS
     "combine -M MultiDimFit counting_datacard.root  --setParameterRanges r=-5,5"
 )
@@ -169,81 +168,106 @@ COMBINE_ADD_TEST(counting_datacard_from_csv
 
 # Parametric analysis
 ADD_COMBINE_TEST(parametric_analysis
-  COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt
-                   ${REPO}/data/tutorials/CAT23001/parametric-analysis-datacard-input.root
+  COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/parametric-analysis-datacard-input.root
   T2W_COMMAND
-    text2workspace.py datacard-3-parametric-analysis.txt --mass 125
+    text2workspace.py ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt -o datacard-3-parametric-analysis.root --mass 125
   COMBINE_COMMANDS
     "combine -M MultiDimFit datacard-3-parametric-analysis.root --algo singles --setParameterRanges r=-2,1"
 )
 
-#
+# RooHistPdf
+ADD_COMBINE_TEST(histpdf
+  T2W_COMMAND
+    text2workspace.py ${REPO}/data/ci/datacard_RooHistPdf.txt.gz -o ws_RooHistPdf.root
+  COMBINE_COMMANDS
+    "combine -M MultiDimFit ws_RooHistPdf.root --algo singles -v -2  --setParameterRanges r=-1,2"
+)
+
 # Template analysis CMSHistFunc
 ADD_COMBINE_TEST(cmshistfunc
-  COPY_TO_BUILDDIR ${REPO}/data/ci/template-analysis_shapeInterp.txt
-                   ${REPO}/data/ci/htt_input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_input.root
   T2W_COMMAND
-    text2workspace.py template-analysis_shapeInterp.txt -o ws_template-analysis.root --mass 200
+    text2workspace.py ${REPO}/data/ci/template-analysis_shapeInterp.txt -o ws_template-analysis.root --mass 200
   COMBINE_COMMANDS
     "combine -M MultiDimFit ws_template-analysis.root --algo singles  --setParameterRanges r=-5,5"
 )
 
 # Template analysis CMSHistFunc with channel masks
 ADD_COMBINE_TEST(cmshistfunc_channel_masks
-  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_multiple_regions.txt
-                   ${REPO}/data/ci/htt_multiple_regions.input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_multiple_regions.input.root
   T2W_COMMAND
-    text2workspace.py htt_multiple_regions.txt  -o ws_template-analysis-channel_masks.root --mass 125 --channel-masks
+    text2workspace.py ${REPO}/data/ci/htt_multiple_regions.txt  -o ws_template-analysis-channel_masks.root --mass 125 --channel-masks
   COMBINE_COMMANDS
     "combine -M MultiDimFit ws_template-analysis-channel_masks.root --algo singles  --setParameterRanges r=-5,5 --setParameters mask_htt_tt_2_8TeV=1"
 )
 
 # Template analysis CMSHistFunc shapeN
 ADD_COMBINE_TEST(cmshistfunc_shapeN
-  COPY_TO_BUILDDIR ${REPO}/data/ci/template-analysis_shapeNInterp.txt
-                   ${REPO}/data/ci/htt_input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_input.root
   T2W_COMMAND
-    text2workspace.py template-analysis_shapeNInterp.txt -o ws_template-analysis-shapeN.root --mass 200
+    text2workspace.py ${REPO}/data/ci/template-analysis_shapeNInterp.txt -o ws_template-analysis-shapeN.root --mass 200
   COMBINE_COMMANDS
     "combine -M MultiDimFit ws_template-analysis-shapeN.root --algo singles  --setParameterRanges r=-5,5"
 )
 
 # Template analysis CMSHistSum
 ADD_COMBINE_TEST(cmshistsum
-  COPY_TO_BUILDDIR ${REPO}/data/ci/template-analysis_shapeInterp.txt
-                   ${REPO}/data/ci/htt_input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_input.root
   T2W_COMMAND
-    text2workspace.py template-analysis_shapeInterp.txt --mass 200 --for-fits --no-wrappers --use-histsum
+    text2workspace.py ${REPO}/data/ci/template-analysis_shapeInterp.txt -o cmshistsum.root --mass 200 --for-fits --no-wrappers --use-histsum
   COMBINE_COMMANDS
-    "combine -M MultiDimFit template-analysis_shapeInterp.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH"
+    "combine -M MultiDimFit cmshistsum.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH"
 )
 
 # Template analysis CMSHistSum with shapeN
 ADD_COMBINE_TEST(cmshistsum_shapeN
-  COPY_TO_BUILDDIR ${REPO}/data/ci/template-analysis_shapeNInterp.txt
-                   ${REPO}/data/ci/htt_input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_input.root
   T2W_COMMAND
-    text2workspace.py template-analysis_shapeNInterp.txt --mass 200 --for-fits --no-wrappers --use-histsum
+    text2workspace.py ${REPO}/data/ci/template-analysis_shapeNInterp.txt -o cmshistsum_shapeN.root --mass 200 --for-fits --no-wrappers --use-histsum
   COMBINE_COMMANDS
-    "combine -M MultiDimFit template-analysis_shapeNInterp.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH"
+    "combine -M MultiDimFit cmshistsum_shapeN.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH"
 )
+
+# Template analysis with large integrals
+ADD_COMBINE_TEST(template_analysis_large_integrals
+  T2W_COMMAND
+    text2workspace.py ${REPO}/data/ci/templ_datacard_largeYields.txt -o template_analysis_large_integrals.root
+  COMBINE_COMMANDS
+    "combine -M MultiDimFit template_analysis_large_integrals.root --algo singles  --setParameterRanges r=-5,5"
+)
+
+# Template analysis with large integrals using CMSHistSum
+ADD_COMBINE_TEST(template_analysis_large_integrals_cmshistsum
+  T2W_COMMAND
+    text2workspace.py ${REPO}/data/ci/templ_datacard_largeYields.txt -o template_analysis_large_integrals_cmshistsum.root  --for-fits --no-wrappers --use-histsum
+  COMBINE_COMMANDS
+    "combine -M MultiDimFit template_analysis_large_integrals_cmshistsum.root --algo singles  --setParameterRanges r=-5,5 --X-rtd FAST_VERTICAL_MORPH"
+)
+
+# RooParametricHist
+# Unfortunately, the result of this test is not deterministic, so we can't enable it yet.
+# TODO: understand why this is, enable the test here, and remove corresponding test from cvmfs-ci.yml
+# ADD_COMBINE_TEST(parametric_hist
+#   COPY_TO_BUILDDIR ${REPO}/data/ci/shapes_RooParametricHist.root
+#   T2W_COMMAND
+#   text2workspace.py -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel  --PO verbose --PO map=.*/*hcc*:r[1,-500,500] --PO map=.*/zcc:z[1,-5,5] ${REPO}/data/ci/datacard_RooParametricHist.txt -o ws_RooParametricHist.root
+#   COMBINE_COMMANDS
+#     "combine -M MultiDimFit ws_RooParametricHist.root --algo singles"
+# )
 
 # Template analysis CMSHistFunc with channel masks
 ADD_COMBINE_TEST(cmshistsum_channel_masks
-  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_multiple_regions.txt
-                   ${REPO}/data/ci/htt_multiple_regions.input.root
+  COPY_TO_BUILDDIR ${REPO}/data/ci/htt_multiple_regions.input.root
   T2W_COMMAND
-    text2workspace.py htt_multiple_regions.txt  -o ws_template-analysis-channel_masks.root --mass 125 --channel-masks -for-fits --no-wrappers --use-histsum
+    text2workspace.py ${REPO}/data/ci/htt_multiple_regions.txt  -o ws_template-analysis-channel_masks.root --mass 125 --channel-masks --for-fits --no-wrappers --use-histsum
   COMBINE_COMMANDS
     "combine -M MultiDimFit ws_template-analysis-channel_masks.root --algo singles  --setParameterRanges r=-5,5 --setParameters mask_htt_tt_2_8TeV=1 --X-rtd FAST_VERTICAL_MORPH"
 )
 
 # Template-analysis datacard -> text2workspace
 COMBINE_ADD_TEST(template_analysis-text2workspace
-    COMMAND text2workspace.py template-analysis_shape_autoMCStats.txt -o template-analysis_shape_autoMCStats.root
-    COPY_TO_BUILDDIR
-        ${REPO}/data/ci/template-analysis_shape_autoMCStats.txt
-        ${REPO}/data/ci/htt_input.root
+    COMMAND text2workspace.py ${REPO}/data/ci/template-analysis_shape_autoMCStats.txt -o template-analysis_shape_autoMCStats.root
+    COPY_TO_BUILDDIR ${REPO}/data/ci/htt_input.root
     FIXTURES_SETUP template_analysis_workspace
 )
 
@@ -272,37 +296,33 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS "python test_interferen
 
 
 COMBINE_ADD_TEST(simple-counting-experiment-text2workspace
-    COMMAND text2workspace.py simple-counting-experiment.txt
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/counting/simple-counting-experiment.txt
+    COMMAND text2workspace.py ${REPO}/data/tutorials/counting/simple-counting-experiment.txt
     # No output, so nothing to compare. We just check that it runs.
 )
 
 # Test that setting a parameter outside its range throws an error
 COMBINE_ADD_TEST(setParameters-out-of-range
-    COMMAND combine -M MultiDimFit simple-counting-experiment.txt --setParameters r=-1.05
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/counting/simple-counting-experiment.txt
+    COMMAND combine -M MultiDimFit ${REPO}/data/tutorials/counting/simple-counting-experiment.txt --setParameters r=-1.05
     PASSRC 1
     PASSREGEX "outside its range"
 )
 
 # Test that setting a parameter outside its range via regex throws an error
 COMBINE_ADD_TEST(setParameters-out-of-range-regex
-    COMMAND combine -M MultiDimFit simple-counting-experiment.txt --setParameters "rgx{r}=-1.05"
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/counting/simple-counting-experiment.txt
+    COMMAND combine -M MultiDimFit ${REPO}/data/tutorials/counting/simple-counting-experiment.txt --setParameters "rgx{r}=-1.05"
     PASSRC 1
     PASSREGEX "outside its range"
 )
 
 COMBINE_ADD_TEST(simple-shapes-TH1-text2workspace
-    COMMAND text2workspace.py simple-shapes-TH1.txt
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/shapes/simple-shapes-TH1.txt
-                     ${REPO}/data/tutorials/shapes/simple-shapes-TH1_input.root
+    COMMAND text2workspace.py ${REPO}/data/tutorials/shapes/simple-shapes-TH1.txt
+    COPY_TO_BUILDDIR ${REPO}/data/tutorials/shapes/simple-shapes-TH1_input.root
     # No output, so nothing to compare. We just check that it runs.
 )
 
 COMBINE_ADD_TEST(LHC-Higgs-coupling-models-text2workspace
-    COMMAND text2workspace.py toy-hgg-125.txt -P HiggsAnalysis.CombinedLimit.LHCHCGModels:K3 -m 125
     COPY_TO_BUILDDIR ${REPO}/data/tutorials/multiDim/toy-hgg-125.txt
+    COMMAND text2workspace.py toy-hgg-125.txt -P HiggsAnalysis.CombinedLimit.LHCHCGModels:K3 -m 125
     CHECKOUT OUTPUT LHC-Higgs-coupling-models-text2workspace.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/LHC-Higgs-coupling-models-text2workspace.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -310,9 +330,8 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(hzz4l-significance
-    COMMAND combine -M Significance hzz4l_datacard.txt
-    COPY_TO_BUILDDIR ${REPO}/test/inputs/hzz4l_datacard.txt
-                     ${REPO}/test/inputs/Workspace_m4l.root
+    COMMAND combine -M Significance ${REPO}/test/inputs/hzz4l_datacard.txt
+    COPY_TO_BUILDDIR ${REPO}/test/inputs/Workspace_m4l.root
     CHECKOUT OUTPUT hzz4l-significance.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/hzz4l-significance.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -320,9 +339,8 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(LHC-limits
-    COMMAND combine datacard-2-template-analysis.txt -M HybridNew --LHCmode LHC-limits --rMax 2.0 --clsAcc 0.01
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-2-template-analysis.txt
-                     ${REPO}/data/tutorials/CAT23001/template-analysis-datacard-input.root
+    COMMAND combine ${REPO}/data/tutorials/CAT23001/datacard-2-template-analysis.txt -M HybridNew --LHCmode LHC-limits --rMax 2.0 --clsAcc 0.01
+    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/template-analysis-datacard-input.root
     CHECKOUT OUTPUT LHC-limits.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/LHC-limits.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -330,8 +348,7 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(LHC-significance
-    COMMAND combine datacard-3-parametric-analysis.txt -M HybridNew --LHCmode LHC-significance -T 5000 --mass 125
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt
+    COMMAND combine ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt -M HybridNew --LHCmode LHC-significance -T 5000 --mass 125
     CHECKOUT OUTPUT LHC-significance.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/LHC-significance.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -339,8 +356,7 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(parametric-analysis-significance
-    COMMAND combine datacard-3-parametric-analysis.txt -M Significance --mass 125
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt
+    COMMAND combine ${REPO}/data/tutorials/CAT23001/datacard-3-parametric-analysis.txt -M Significance --mass 125
     CHECKOUT OUTPUT parametric-analysis-significance.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/parametric-analysis-significance.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -348,8 +364,7 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(MarkovChainMC
-    COMMAND combine datacard-1-counting-experiment.txt -M MarkovChainMC --tries 100
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-1-counting-experiment.txt
+    COMMAND combine ${REPO}/data/tutorials/CAT23001/datacard-1-counting-experiment.txt -M MarkovChainMC --tries 100
     CHECKOUT OUTPUT MarkovChainMC.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/MarkovChainMC.out
 )
 set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
@@ -357,8 +372,7 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(multi-signal-text2workspace
-    COMMAND text2workspace.py datacard-5-multi-signal.txt -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH -o datacard-5-multi-signal.root --mass 125
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-5-multi-signal.txt
+    COMMAND text2workspace.py ${REPO}/data/tutorials/CAT23001/datacard-5-multi-signal.txt -P HiggsAnalysis.CombinedLimit.PhysicsModel:floatingXSHiggs --PO modes=ggH,qqH -o datacard-5-multi-signal.root --mass 125
     CHECKOUT OUTPUT multi-signal-text2workspace.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/multi-signal-text2workspace.out
     FIXTURES_SETUP multi-signal-text2workspace
 )
@@ -376,8 +390,7 @@ set_property(GLOBAL APPEND PROPERTY ALL_COMBINE_COMMANDS
 )
 
 COMBINE_ADD_TEST(multi-signal-ChannelCompatibilityCheck
-    COMMAND combine datacard-5-multi-signal.txt -M ChannelCompatibilityCheck --mass 125
-    COPY_TO_BUILDDIR ${REPO}/data/tutorials/CAT23001/datacard-5-multi-signal.txt
+    COMMAND combine ${REPO}/data/tutorials/CAT23001/datacard-5-multi-signal.txt -M ChannelCompatibilityCheck --mass 125
     CHECKOUT OUTPUT multi-signal-ChannelCompatibilityCheck.out OUTREF ${CMAKE_CURRENT_SOURCE_DIR}/references/multi-signal-ChannelCompatibilityCheck.out
     FIXTURES_REQUIRED multi-signal
 )

--- a/test/references/histpdf.out
+++ b/test/references/histpdf.out
@@ -1,0 +1,5 @@
+ <<< Combine >>> 
+ <<< v10.5.0 >>>
+>>> Random number generator seed is 123456
+>>> Method used is MultiDimFit
+   r :    +0.966   -0.102/+0.113 (68%)

--- a/test/references/parametric_hist.out
+++ b/test/references/parametric_hist.out
@@ -1,0 +1,10 @@
+ <<< Combine >>> 
+ <<< v10.5.0 >>>
+>>> Random number generator seed is 123456
+>>> Method used is MultiDimFit
+Doing initial fit: 
+
+ --- MultiDimFit ---
+best fit parameter values and profile-likelihood uncertainties: 
+   r :   +67.590   -38.846/+42.603 (68%)
+   z :    +0.537   -0.177/+0.222 (68%)

--- a/test/references/template_analysis_large_integrals.out
+++ b/test/references/template_analysis_large_integrals.out
@@ -1,0 +1,10 @@
+ <<< Combine >>> 
+ <<< v10.5.0 >>>
+>>> Random number generator seed is 123456
+>>> Method used is MultiDimFit
+Set Range of Parameter r To : (-5,5)
+Doing initial fit: 
+
+ --- MultiDimFit ---
+best fit parameter values and profile-likelihood uncertainties: 
+   r :    +0.975   -0.083/+0.091 (68%)

--- a/test/references/template_analysis_large_integrals_cmshistsum.out
+++ b/test/references/template_analysis_large_integrals_cmshistsum.out
@@ -1,0 +1,10 @@
+ <<< Combine >>> 
+ <<< v10.5.0 >>>
+>>> Random number generator seed is 123456
+>>> Method used is MultiDimFit
+Set Range of Parameter r To : (-5,5)
+Doing initial fit: 
+
+ --- MultiDimFit ---
+best fit parameter values and profile-likelihood uncertainties: 
+   r :    +0.975   -0.083/+0.091 (68%)


### PR DESCRIPTION
Like this, these tests can be ran in all environments also locally and the results are automatically compared to reference files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized test suite with several new scenarios (including large-integral and histogram-based workflows) to improve validation of analysis workflows.
  * Updated test inputs to use repository-rooted data references for more consistent, portable test runs.

* **Chores**
  * Simplified CI by removing redundant pre-test execution steps.
  * Normalized shape file path formatting in datacards for cleaner, consistent references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->