### PR TITLE
Fix: make signature of setData in CachingSimNLL and CachingAddNLL ref…

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -120,7 +120,7 @@ class CachingAddNLL : public RooAbsReal {
         Double_t evaluate() const override ;
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
-        void setData(const RooAbsData &data) ;
+        bool setData(RooAbsData &data, bool cloneData = true) override;
         double  sumWeights() const { return sumWeights_; }
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
@@ -167,7 +167,7 @@ class CachingSimNLL  : public RooAbsReal {
         Double_t evaluate() const override ;
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
-        void setData(const RooAbsData &data) ;
+        bool setData(RooAbsData &data, bool cloneData = true) override;
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
         RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
 #else


### PR DESCRIPTION
…lect the one it inherits from in RooAbsReal https://github.com/root-project/root/blob/master/roofit/roofitcore/inc/RooAbsReal.h#L373.
After a fix that will be implemented on the Roofit side, it will make https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/1216 obsolete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Data-assignment API now returns a boolean status to signal success/failure instead of being void.
  * Added an optional cloning parameter to control whether input data is cloned during assignment.
  * Signatures now accept non-const data references to allow in-place handling and clearer ownership semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->