### PR TITLE
Fix: make signature of setData in CachingSimNLL and CachingAddNLL ref…

### DIFF
--- a/interface/CachingNLL.h
+++ b/interface/CachingNLL.h
@@ -120,7 +120,7 @@ class CachingAddNLL : public RooAbsReal {
         Double_t evaluate() const override ;
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
-        void setData(const RooAbsData &data) ;
+        bool setData(RooAbsData &data, bool cloneData = true) override;
         double  sumWeights() const { return sumWeights_; }
         const RooAbsPdf *pdf() const { return pdf_; }
         void setZeroPoint() ;
@@ -167,7 +167,7 @@ class CachingSimNLL  : public RooAbsReal {
         Double_t evaluate() const override ;
         Bool_t isDerived() const override { return kTRUE; }
         Double_t defaultErrorLevel() const override { return 0.5; }
-        void setData(const RooAbsData &data) ;
+        bool setData(RooAbsData &data, bool cloneData = true) override;
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
         RooArgSet* getParameters(const RooArgSet* depList, Bool_t stripDisconnected = kTRUE) const override;
 #else

--- a/src/CachingNLL.cc
+++ b/src/CachingNLL.cc
@@ -388,7 +388,7 @@ cacheutils::CachingAddNLL::CachingAddNLL(const CachingAddNLL &other, const char 
     catParams_("catParams","RooCategory parameters",this),
     includeZeroWeights_(other.includeZeroWeights_)
 {
-    setData(*other.data_);
+    setData(const_cast<RooAbsData &>(*other.data_));
     setup_();
     propagateData();
     constantZeroPoint_ = -evaluate();
@@ -742,8 +742,8 @@ cacheutils::CachingAddNLL::clearConstantZeroPoint()
     setValueDirty();
 }
 
-void 
-cacheutils::CachingAddNLL::setData(const RooAbsData &data) 
+bool
+cacheutils::CachingAddNLL::setData(RooAbsData &data, bool cloneData)
 {
     //std::cout << "Setting data for pdf " << pdf_->GetName() << std::endl;
     //utils::printRAD(&data);
@@ -792,6 +792,7 @@ cacheutils::CachingAddNLL::setData(const RooAbsData &data)
         }
     }
     propagateData();
+    return true;
 }
 
 void cacheutils::CachingAddNLL::propagateData() {
@@ -1085,8 +1086,8 @@ cacheutils::CachingSimNLL::evaluate() const
     return ret.sum();
 }
 
-void 
-cacheutils::CachingSimNLL::setData(const RooAbsData &data) 
+bool
+cacheutils::CachingSimNLL::setData(RooAbsData &data, bool cloneData)
 {
     dataOriginal_ = &data;
     //std::cout << "combined data has " << data.numEntries() << " dataset entries (sumw " << data.sumEntries() << ", weighted " << data.isWeighted() << ")" << std::endl;
@@ -1107,6 +1108,7 @@ cacheutils::CachingSimNLL::setData(const RooAbsData &data)
         //             " and " << (data ? data->numEntries() : -1) << " dataset entries (sumw " << data->sumEntries() << ", weighted " << data->isWeighted() << ")" << std::endl;
         canll->setData(*data);
     }
+    return true;
 }
 
 void cacheutils::CachingSimNLL::splitWithWeights(const RooAbsData &data, const RooAbsCategory& splitCat, Bool_t createEmptyDataSets) {


### PR DESCRIPTION
…lect the one it inherits from in RooAbsReal

Replace https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/1219 after formatting mess.

After a fix that will be implemented on the Roofit side, it will make https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/pull/1216 obsolete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data handling in caching classes with improved error reporting capabilities. Data operations now return success/failure status and provide additional control over data management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->