### PR TITLE
Implement `doEval()` for ProcessNormalization class

### DIFF
--- a/interface/ProcessNormalization.h
+++ b/interface/ProcessNormalization.h
@@ -37,6 +37,9 @@ class ProcessNormalization : public RooAbsReal {
 
     protected:
         Double_t evaluate() const override;
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,32,0)
+        void doEval(RooFit::EvalContext &) const override;
+#endif
 
     private:
         void fillAsymmKappaVecs() const;


### PR DESCRIPTION
This is support RooFits vectorized likelihood evaluation without it having to fall back to `RooAbsReal::evaluate()`, which is always a performance hit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for faster, vectorized likelihood evaluation when the runtime provides the capability, improving bulk-evaluation performance.

* **Refactor**
  * Enhanced evaluation pathway to enable vectorized computation while preserving the original scalar behavior and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->