### PR TITLE
[ci] Enable RooMultiPdf test on CMSSW 16

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -195,7 +195,7 @@ jobs:
 
       - uses: ./.github/actions/run-in-cvmfs
         name: RooMultiPdf
-        if: ${{ !matrix.CMSSW_VERSION || startsWith(matrix.CMSSW_VERSION, 'CMSSW_14') }}
+        if: ${{ !matrix.CMSSW_VERSION || !startsWith(matrix.CMSSW_VERSION, 'CMSSW_11') }}
         with:
           script: |
             text2workspace.py data/ci/datacard_RooMultiPdf.txt.gz  -o ws_RooMultiPdf.root


### PR DESCRIPTION
The RooMultiPdf test doesn't work on older CMSSW versions, and was therefore whitelisted only for CMSSW 14 in commit bab435dfb3fe38c.

But now that CMSSW 16 was also added to the CI, this logic needs to be changed to make sure this test also runs on CMSSW 16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow conditions for a build step so it now runs when the CMSSW version is empty or is not CMSSW_11, broadening eligibility and ensuring the step is skipped only for CMSSW_11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->