### PR TITLE
Avoid RooAbsReal comparison with `!=` in ShapeTools

### DIFF
--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -130,7 +130,7 @@ class ShapeBuilder(ModelBuilder):
                 )
                 if self.options.optimizeExistingTemplates:
                     pdf1 = self.optimizeExistingTemplates(pdf)
-                    if pdf1 != pdf:
+                    if pdf1 is not pdf:
                         self.out.dont_delete.append(pdf1)
                         pdf = pdf1
                 extranorm = self.getExtraNorm(b, p)
@@ -1402,7 +1402,7 @@ class ShapeBuilder(ModelBuilder):
             newservers = []
             for a in arg.servers():
                 aopt = self.optimizeMHDependency(a, wsp, MH, indent=indent + "   ")
-                if aopt != a:
+                if aopt is not a:
                     newservers.append((a, aopt))
             if newservers:
                 print(


### PR DESCRIPTION
The comparison operators for RooAbsReal and derived classes are cursed in Python, as explained in
https://github.com/root-project/root/issues/21347.

These is a comparison like this in ShapeTools to check if a given pdf was replaced by a different object. So in this case, the intent is identity comparison (by-address), so this should be made explicit by using `is not`. By changing this, the code will be correct no matter how ROOT decides how to get out of the dilemma with the comparison operators.

This fixes the Higgs discovery likelihood workspace creation with ROOT master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-detection so only genuinely new objects are treated as updated. This reduces unnecessary deletions and reprocessing during template/model optimization, resulting in more stable updates and fewer spurious refreshes or side effects when identical-value objects are encountered. Users should see smoother, more predictable behavior during optimization and model updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->