### PR TITLE
Drop systematic lines that do not affect any channel/process when cal…

### DIFF
--- a/scripts/combineCards.py
+++ b/scripts/combineCards.py
@@ -393,20 +393,13 @@ if process_errors:
     raise RuntimeError("ERROR: mismatch between process signal labels:\n%s" % ("\n".join(process_errors)))
 
 # Remove systematics that don't affect any process/channel in the combination
-removed_systs = {
-    name for name, (pdf, pdfargs, effect, nofloat) in systlines.items()
-    if not any(effect.get(b, {}).get(p, "-") != "-" for b, p, s in keyline)
-}
+removed_systs = {name for name, (pdf, pdfargs, effect, nofloat) in systlines.items() if not any(effect.get(b, {}).get(p, "-") != "-" for b, p, s in keyline)}
 for name in removed_systs:
     del systlines[name]
 
 # Remove pruned systematics from groups - leave all other group members untouched
 if removed_systs:
-    groups = {
-        gname: nuisanceNames - removed_systs
-        for gname, nuisanceNames in groups.items()
-        if nuisanceNames - removed_systs
-    }
+    groups = {gname: nuisanceNames - removed_systs for gname, nuisanceNames in groups.items() if nuisanceNames - removed_systs}
 
 print("Combination of", "  ".join(args))
 print("imax %d number of bins" % len(bins))


### PR DESCRIPTION
…ling combineCards.py with --include-channel

As stated in the title, combineCards.py doesn't drop systematics that do not affect any channel/process when keeping only a subset of them (i.e. using ```--include-channel```. This makes the output datacard noisy if one wants to run a simple test with a subset of channels.

I tried this with the [Higgs observation model](https://repository.cern/records/c2948-e8875) and the following command:
```
combineCards.py --ic=hgg_7TeV_inc_cat0_7TeV --ic=httem_8TeV_5 125.5/comb_hgg.txt 125.5/comb_htt.txt > 125.5/comb_hgg_htt_pruned_fewsysts_new.txt
```
Running a simple fit on the output datacard
```
combine 125.5/comb_hgg_htt_pruned_fewsysts_new.txt --mass 125.5 -M MultiDimFit -v 3 > ex_new.txt
```
gives the same results before and after the change, as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatically detects and removes systematics that do not affect any process or channel, producing cleaner analysis outputs, reducing clutter in reports, and improving overall processing efficiency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->