### PR TITLE
Replace `RooRealVar::removeRange()` usage

### DIFF
--- a/docs/model_building_tutorial2024/model_building_exercise.md
+++ b/docs/model_building_tutorial2024/model_building_exercise.md
@@ -350,7 +350,8 @@ class PhysicsModel(PhysicsModelBase):
         # --- Higgs Mass as other parameter ----
         if self.options.mass != 0:
             if self.modelBuilder.out.var("MH"):
-                self.modelBuilder.out.var("MH").removeRange()
+                self.modelBuilder.out.var("MH").removeMin()
+                self.modelBuilder.out.var("MH").removeMax()
                 self.modelBuilder.out.var("MH").setVal(self.options.mass)
             else:
                 self.modelBuilder.doVar("MH[%g]" % self.options.mass)

--- a/python/DegenerateMatrixRank.py
+++ b/python/DegenerateMatrixRank.py
@@ -54,6 +54,7 @@ class AllMuiLambdaHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_(f'expr::lambdatmu_{decay}("@0*@1",lambdat,mu_{decay})')
         self.modelBuilder.doSet("POI", ",".join(poi))
         if self.modelBuilder.out.var("MH"):
+            var = self.modelBuilder.out.var("MH")
             if len(self.mHRange):
                 print(
                     "MH will be left floating within",
@@ -61,15 +62,16 @@ class AllMuiLambdaHiggs(SMLikeHiggsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
-                self.modelBuilder.out.var("MH").setConstant(False)
+                var.setRange(float(self.mHRange[0]), float(self.mHRange[1]))
+                var.setConstant(False)
                 poi.append("MH")
                 self.modelBuilder.doSet("POI", ",".join(poi))
                 # self.modelBuilder.doSet('POI','poi,MH')
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(
@@ -160,6 +162,7 @@ class AllMuiLambdasHiggs(SMLikeHiggsModel):
             self.modelBuilder.factory_(f'expr::lambdat_{decay}mu_{decay}("@0*@1",lambdat_{decay},mu_{decay})')
         self.modelBuilder.doSet("POI", ",".join(poi))
         if self.modelBuilder.out.var("MH"):
+            var = self.modelBuilder.out.var("MH")
             if len(self.mHRange):
                 print(
                     "MH will be left floating within",
@@ -167,15 +170,16 @@ class AllMuiLambdasHiggs(SMLikeHiggsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
-                self.modelBuilder.out.var("MH").setConstant(False)
+                var.setRange(float(self.mHRange[0]), float(self.mHRange[1]))
+                var.setConstant(False)
                 poi.append("MH")
                 self.modelBuilder.doSet("POI", ",".join(poi))
                 # self.modelBuilder.doSet('POI','poi,MH')
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(

--- a/python/HiggsJPC.py
+++ b/python/HiggsJPC.py
@@ -142,6 +142,7 @@ class TwoHypotesisHiggs(PhysicsModel):
             self.modelBuilder.factory_('expr::not_x("(1-@0)", x)')
             self.sigNorms = {True: "x", False: "not_x"}
         if self.modelBuilder.out.var("MH"):
+            var = self.modelBuilder.out.var("MH")
             if len(self.mHRange):
                 print(
                     "MH will be left floating within",
@@ -149,13 +150,14 @@ class TwoHypotesisHiggs(PhysicsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
-                self.modelBuilder.out.var("MH").setConstant(False)
+                var.setRange(float(self.mHRange[0]), float(self.mHRange[1]))
+                var.setConstant(False)
                 poi += ",MH"
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(

--- a/python/ModelTools.py
+++ b/python/ModelTools.py
@@ -261,7 +261,8 @@ class ModelBuilder(ModelBuilderBase):
 
                 self.doVar(f"{rp}[{float(param_val)},{param_range}]")
                 if removeRange:
-                    self.out.var(rp).removeRange()
+                    self.out.var(rp).removeMin()
+                    self.out.var(rp).removeMax()
                 self.out.var(rp).setConstant(False)
                 if setConst:
                     self.out.var(rp).setConstant(True)
@@ -334,7 +335,8 @@ class ModelBuilder(ModelBuilderBase):
 
                 self.doVar(f"{argu}[{argv},{param_range}]")
                 if removeRange:
-                    self.out.var(argu).removeRange()
+                    self.out.var(argu).removeMin()
+                    self.out.var(argu).removeMax()
                 self.out.var(argu).setConstant(False)
                 self.out.var(argu).setAttribute("flatParam")
 

--- a/python/PhysicsModel.py
+++ b/python/PhysicsModel.py
@@ -101,8 +101,10 @@ class PhysicsModel(PhysicsModelBase):
         # --- Higgs Mass as other parameter ----
         if self.options.mass != 0:
             if self.modelBuilder.out.var("MH"):
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var = self.modelBuilder.out.var("MH")
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
             else:
                 self.modelBuilder.doVar("MH[%g]" % self.options.mass)
 
@@ -249,8 +251,10 @@ class HiggsMassRangeModel(PhysicsModelBase_NiceSubclasses):
                 poiNames += ["MH"]
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var = self.modelBuilder.out.var("MH")
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(
@@ -511,8 +515,10 @@ class FloatingXSHiggs(SMLikeHiggsModel):
                 poi += ",MH"
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var = self.modelBuilder.out.var("MH")
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(
@@ -629,8 +635,10 @@ class FloatingBRHiggs(SMLikeHiggsModel):
                 poi += ",MH"
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var = self.modelBuilder.out.var("MH")
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(
@@ -786,6 +794,7 @@ class FloatingXSBRHiggs(SMLikeHiggsModel):
         """Create POI and other parameters, and define the POI set."""
         # --- Higgs Mass as other parameter ----
         if self.modelBuilder.out.var("MH"):
+            var = self.modelBuilder.out.var("MH")
             if len(self.mHRange):
                 print(
                     "MH will be left floating within",
@@ -793,13 +802,14 @@ class FloatingXSBRHiggs(SMLikeHiggsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
-                self.modelBuilder.out.var("MH").setConstant(False)
+                var.setRange(float(self.mHRange[0]), float(self.mHRange[1]))
+                var.setConstant(False)
                 self.poiNames += ["MH"]
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(

--- a/python/ShapeTools.py
+++ b/python/ShapeTools.py
@@ -481,7 +481,8 @@ class ShapeBuilder(ModelBuilder):
                         self.out.var("CMS_fakeObs").setBins(1)
                         self.doSet("CMS_fakeObsSet", "CMS_fakeObs")
                         self.doVar("CMS_fakeWeight[0,1]")
-                        self.out.var("CMS_fakeWeight").removeRange()
+                        self.out.var("CMS_fakeWeight").removeMin()
+                        self.out.var("CMS_fakeWeight").removeMax()
                         shapeObs["CMS_fakeObsSet"] = self.out.set("CMS_fakeObsSet")
                     if p == self.options.dataname:
                         self.pdfModes[b] = "binned"

--- a/python/TagAndProbeModel.py
+++ b/python/TagAndProbeModel.py
@@ -10,8 +10,10 @@ class TagAndProbe(PhysicsModel):
         self.modelBuilder.doSet("POI", "SF")
         if self.options.mass != 0:
             if self.modelBuilder.out.var("MH"):
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var = self.modelBuilder.out.var("MH")
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
             else:
                 self.modelBuilder.doVar("MH[%g]" % self.options.mass)
         exp_pass = 1

--- a/python/TwoHiggsModels.py
+++ b/python/TwoHiggsModels.py
@@ -64,6 +64,7 @@ class TwoHiggsBase(PhysicsModel):
         poi = ""
         ## Searched-for higgs
         if self.modelBuilder.out.var("MH"):
+            var = self.modelBuilder.out.var("MH")
             if len(self.mHRange):
                 print(
                     "MH will be left floating within",
@@ -71,14 +72,15 @@ class TwoHiggsBase(PhysicsModel):
                     "and",
                     self.mHRange[1],
                 )
-                self.modelBuilder.out.var("MH").setRange(float(self.mHRange[0]), float(self.mHRange[1]))
-                self.modelBuilder.out.var("MH").setConstant(False)
+                var.setRange(float(self.mHRange[0]), float(self.mHRange[1]))
+                var.setConstant(False)
                 if self.mHAsPOI:
                     poi += ",MH"
             else:
                 print("MH will be assumed to be", self.options.mass)
-                self.modelBuilder.out.var("MH").removeRange()
-                self.modelBuilder.out.var("MH").setVal(self.options.mass)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.options.mass)
         else:
             if len(self.mHRange):
                 print(
@@ -95,6 +97,7 @@ class TwoHiggsBase(PhysicsModel):
                 self.modelBuilder.doVar("MH[%g]" % self.options.mass)
         ## Already-found higgs
         if self.modelBuilder.out.var("MH_SM"):
+            var = self.modelBuilder.out.var("MH_SM")
             if len(self.mHSMRange):
                 print(
                     "MH_SM will be left floating within",
@@ -102,14 +105,15 @@ class TwoHiggsBase(PhysicsModel):
                     "and",
                     self.mHSMRange[1],
                 )
-                self.modelBuilder.out.var("MH_SM").setRange(float(self.mHSMRange[0]), float(self.mHSMRange[1]))
-                self.modelBuilder.out.var("MH_SM").setConstant(False)
+                var.setRange(float(self.mHSMRange[0]), float(self.mHSMRange[1]))
+                var.setConstant(False)
                 if self.mHSMAsPOI:
                     poi += ",MH_SM"
             else:
                 print("MH_SM will be assumed to be", self.mHSM)
-                self.modelBuilder.out.var("MH_SM").removeRange()
-                self.modelBuilder.out.var("MH_SM").setVal(self.mHSM)
+                var.removeMin()
+                var.removeMax()
+                var.setVal(self.mHSM)
         else:
             if len(self.mHSMRange):
                 print(

--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -507,7 +507,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (w->var("MH")) mass_ = w->var("MH")->getVal();
     }
     // look for parameters ranged [-1e+30, 1e+30], corresponding to the old definition of unlimited parameters, 
-    // since ROOT v6.30 have to removeRange() to keep them unlimited
+    // since ROOT v6.30 have to removeMin() and removeMax() to keep them unlimited
     utils::check_inf_parameters(w->allVars(), verbose);
 
   } else {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -874,7 +874,8 @@ void utils::setModelParameterRanges( const std::string & setPhysicsModelParamete
       if (tmpParameter) {
         cout << "Leave Parameter " << SetParameterRangeExpression[0] 
              << " freely floating, with no range\n";
-        tmpParameter->removeRange();
+        tmpParameter->removeMin();
+        tmpParameter->removeMax();
       } else {
         std::cout << "Warning: Did not find a parameter with name " << SetParameterRangeExpression[0] << endl;
       }
@@ -930,11 +931,10 @@ void utils::check_inf_parameters(const RooArgSet & params, int verbosity) {
                 std::cout << "Found a parameter named "<< p->GetName()
                           << " infinite in ROOT versions < 6.30, going to update the ranges to take into account the new definition of infinity in ROOT v6.30" << endl;
             }
-            if (p->getRange().first <= -infinity_root626 && p->getRange().second >= +infinity_root626) {
-              p->removeRange();
-            } else if (p->getRange().second >= +infinity_root626) {
+            if (p->getRange().second >= +infinity_root626) {
               p->removeMax();
-            } else {
+            }
+            if (p->getRange().first <= -infinity_root626) {
               p->removeMin();
             }
         }


### PR DESCRIPTION
ROOT has deprecated the `RooRealVar::removeRange()` method, because the name was confusing:

https://github.com/root-project/root/pull/21548

Instead, one should explicitly call `removeMin()` and `removeMax()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter bound handling across physics models and utility functions for better ROOT v6.30 compatibility.
  * Fixed parameter constraint removal logic to correctly handle unlimited parameter ranges in Higgs mass parameters and dummy variables.

* **Documentation**
  * Updated tutorial documentation to reflect improved parameter bound handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->