### PR TITLE
Fix split delimiter for float nuisances

### DIFF
--- a/src/Combine.cc
+++ b/src/Combine.cc
@@ -634,7 +634,7 @@ void Combine::run(TString hlfFile, const std::string &dataset, double &limit, do
       if (floatNuisances_=="all") {
           toFloat.add(*nuisances);
       } else {
-          std::vector<std::string> nuisToFloat = Utils::split(floatNuisances_, "n");
+          std::vector<std::string> nuisToFloat = Utils::split(floatNuisances_, ",");
           for (int k=0; k<(int)nuisToFloat.size(); k++) {
               if (nuisToFloat[k]=="") continue;
               else if(nuisToFloat[k]=="all") {


### PR DESCRIPTION
Bug in the floatNuisances parsing logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of float parameters to correctly recognize comma-delimited nuisance parameters instead of improperly splitting on character "n".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->