### PR TITLE
Rearrange left/right DCB tail integral evaluation for numerical stability when n1 or n2 is very close to 1

### DIFF
--- a/src/RooDoubleCBFast.cc
+++ b/src/RooDoubleCBFast.cc
@@ -138,15 +138,15 @@ using namespace RooFit;
      double n1invalpha1 = n1*my_inv(fabs(alpha1));
       if(fabs(n1-1.0)>1.e-5) {
 	double invn1m1 = my_inv(n1-1.);
-	double leftpow = gbrmath::fast_pow(n1invalpha1,-n1*invn1m1);
+	double leftpow = gbrmath::fast_pow(n1invalpha1, n1);
 	double left0 = width*my_exp(-0.5*alpha1*alpha1)*invn1m1;
 	double left1, left2;
 	
 	if (xmax>(mean-alpha1*width)) left1 = n1invalpha1;
-	else left1 = gbrmath::fast_pow( leftpow*(n1invalpha1 - alpha1 - thigh), 1.-n1);
+	else left1 = leftpow * gbrmath::fast_pow(n1invalpha1 - alpha1 - thigh, 1. - n1);
 	
 	if (tmin<-1000.) left2 = 0.;
-	else left2 = gbrmath::fast_pow( leftpow*(n1invalpha1 - alpha1 - tmin ), 1.-n1);
+	else left2 = leftpow * gbrmath::fast_pow(n1invalpha1 - alpha1 - tmin, 1. - n1);
 	
 	left = left0*(left1-left2);
 	
@@ -175,15 +175,15 @@ using namespace RooFit;
       double n2invalpha2 = n2*my_inv(fabs(alpha2)); 
       if(fabs(n2-1.0)>1.e-5) {
 	double invn2m2 = my_inv(n2-1.);
-	double rightpow = gbrmath::fast_pow(n2invalpha2,-n2*invn2m2);
+	double rightpow = gbrmath::fast_pow(n2invalpha2, n2);
 	double right0 = width*my_exp(-0.5*alpha2*alpha2)*invn2m2;
 	double right1, right2;
 	
 	if (xmin<(mean+alpha2*width)) right1 = n2invalpha2;
-	else right1 = gbrmath::fast_pow( rightpow*(n2invalpha2 - alpha2 + tlow), 1.-n2);
+	else right1 = rightpow * gbrmath::fast_pow(n2invalpha2 - alpha2 + tlow, 1. - n2);
 	
 	if (tmax>1000.) right2 = 0.;
-	else right2 = gbrmath::fast_pow( rightpow*(n2invalpha2 - alpha2 + tmax), 1.-n2);
+	else right2 = rightpow * gbrmath::fast_pow(n2invalpha2 - alpha2 + tmax, 1. - n2);
 	
 	right = right0*(right1-right2);	
 	


### PR DESCRIPTION
When using RooDoubleCBFast, we noticed that the raw, unnormalized integral (which is returned by `RooDoubleCBFast::analyticalIntegral`) of the left (right) power-law tail blows up/is unstable when `n1` (`n2`) is very close to 1 -- but not close enough that the integral is given by the logarithm in the code.

In the [attached slides](https://github.com/user-attachments/files/28147691/Numerical.instability.in.RooDoubleCBFast__analyticalIntegral.-1.pdf) , I show that the current threshold in the code where the log is used for the integral, `(n1 - 1) < 1e-5` (same for `n2`), **does not need to be changed** to fix this issue. It turns out that the fix is simply to rearrange the evaluation of [line 186](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/v10.6.0/src/RooDoubleCBFast.cc#L186) for the right tail and [line 149](https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/v10.6.0/src/RooDoubleCBFast.cc#L149) for the left tail to be done in an algebraically equivalent, but more numerically stable way. This is done in the commit.

See the [attached slides](https://github.com/user-attachments/files/28147691/Numerical.instability.in.RooDoubleCBFast__analyticalIntegral.-1.pdf) for:
- example of DCB fit where the right tail integral blows up
- explanation of the issue
- [minimal working example](https://pastebin.com/nvsd0hg9) that demonstrates the raw, unnormalized integral of the tail blowing up