### PR TITLE
Disable USE_VDT also for dev3/latest after it started failing when ru…

### DIFF
--- a/.github/workflows/cvmfs-ci.yml
+++ b/.github/workflows/cvmfs-ci.yml
@@ -85,9 +85,9 @@ jobs:
         env:
           LCG_RELEASE: ${{ matrix.LCG_RELEASE }}
           LCG_ARCH: ${{ matrix.LCG_ARCH }}
-          # VDT doesn't seem to be available in LCG_102.
+          # VDT doesn't seem to be available in LCG_102 and dev3/latest.
           # But also it's very good to also test builds with USE_VDT=OFF.
-          USE_VDT: ${{ matrix.LCG_RELEASE != 'LCG_102' && 'TRUE' || 'FALSE' }}
+          USE_VDT: ${{ (matrix.LCG_RELEASE != 'LCG_102' && matrix.LCG_RELEASE != 'dev3/latest') && 'TRUE' || 'FALSE' }}
         run: >-
           source /cvmfs/sft.cern.ch/lcg/views/${LCG_RELEASE}/${LCG_ARCH}/setup.sh;
           root --version;


### PR DESCRIPTION
…nning CMake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration so `dev3/latest` LCG builds run with VDT disabled.
  * Clarified the related build configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->