### PR TITLE
Fix vertical morphing pdfs not tracking nuisances

### DIFF
--- a/interface/VerticalInterpHistPdf.h
+++ b/interface/VerticalInterpHistPdf.h
@@ -109,6 +109,12 @@ protected:
   mutable std::vector<Morph> _morphs;  //! not to be serialized
   mutable std::vector<RooAbsReal *> _morphParams; //! not to be serialized
 
+  // RooFit calls this whenever this pdf's servers are changed, e.g. when the RooWorkspace owning it is copied.
+  // Without it, _sentry and _morphParams keep pointing at the old coefficient
+  // objects and the pdf silently stops responding to its own parameters.
+  bool redirectServersHook(const RooAbsCollection &newServerList, bool mustReplaceAll,
+                           bool nameChange, bool isRecursiveStep) override;
+
   // Prepare morphing data for a triplet of templates
   void syncMorph(Morph &out, const FastTemplate &nominal, FastTemplate &lo, FastTemplate &hi) const;
 
@@ -280,6 +286,12 @@ protected:
   // For multiplicative morphing, log(fUp/f0)+log(fDown/f0),  log(fUp/f0)-log(fDown/f0)
   // NOTE: it's the responsibility of the daughter to make sure these are initialized!!!
   std::vector<Morph> _morphs;  
+
+  // RooFit calls this whenever this pdf's servers are changed, e.g. when the RooWorkspace owning it is copied.
+  // Without it, _sentry and _morphParams keep pointing at the old coefficient
+  // objects and the pdf silently stops responding to its own parameters.
+  bool redirectServersHook(const RooAbsCollection &newServerList, bool mustReplaceAll,
+                           bool nameChange, bool isRecursiveStep) override;
 
   // Coefficients of the list in _coefList, already dynamic_cast'ed and in a vector
   mutable std::vector<const RooAbsReal *> _morphParams; //! not to be serialized

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -320,6 +320,24 @@ FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase(const FastVerticalI
 
 
 //_____________________________________________________________________________
+bool FastVerticalInterpHistPdfBase::redirectServersHook(const RooAbsCollection &newServerList,
+                                                        bool mustReplaceAll, bool nameChange,
+                                                        bool isRecursiveStep)
+{
+    // _coefList has already been re-pointed at the new servers,
+    // but _morphParams and _sentry still refer to the old coefficient objects. 
+    // Re-point both, and mark the cache dirty so the next evaluate() re-runs syncTotal().
+    _morphParams.resize(_coefList.getSize());
+    int i = 0;
+    for (RooAbsArg *a : _coefList) _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
+    _sentry.deps().removeAll();
+    _sentry.addVars(_coefList);
+    _sentry.setValueDirty();
+    _init = false;
+    return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+}
+
+//_____________________________________________________________________________
 FastVerticalInterpHistPdfBase::~FastVerticalInterpHistPdfBase() = default;
 
 
@@ -766,6 +784,19 @@ Bool_t FastVerticalInterpHistPdf2Base::importWorkspaceHook(RooWorkspace& ws) {
   return kFALSE;
 }
 
+bool FastVerticalInterpHistPdf2Base::redirectServersHook(const RooAbsCollection &newServerList,
+                                                        bool mustReplaceAll, bool nameChange,
+                                                        bool isRecursiveStep)
+{
+    _morphParams.resize(_coefList.getSize());
+    int i = 0;
+    for (RooAbsArg *a : _coefList) _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
+    _sentry.deps().removeAll();
+    _sentry.addVars(_coefList);
+    _sentry.setValueDirty();
+    return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+}
+
 
 //_____________________________________________________________________________
 FastVerticalInterpHistPdf2Base::~FastVerticalInterpHistPdf2Base()
@@ -778,6 +809,7 @@ FastVerticalInterpHistPdf2Base::initBase() const
 {
     if (_initBase) return;
 
+    _morphParams.clear();
     for (RooAbsArg *coef : _coefList) {
         const RooAbsReal *rrv = dynamic_cast<RooAbsReal*>(coef);
         if (!rrv) {

--- a/src/VerticalInterpHistPdf.cc
+++ b/src/VerticalInterpHistPdf.cc
@@ -318,23 +318,23 @@ FastVerticalInterpHistPdfBase::FastVerticalInterpHistPdfBase(const FastVerticalI
   _sentry.setValueDirty(); 
 }
 
-
 //_____________________________________________________________________________
 bool FastVerticalInterpHistPdfBase::redirectServersHook(const RooAbsCollection &newServerList,
-                                                        bool mustReplaceAll, bool nameChange,
-                                                        bool isRecursiveStep)
-{
-    // _coefList has already been re-pointed at the new servers,
-    // but _morphParams and _sentry still refer to the old coefficient objects. 
-    // Re-point both, and mark the cache dirty so the next evaluate() re-runs syncTotal().
-    _morphParams.resize(_coefList.getSize());
-    int i = 0;
-    for (RooAbsArg *a : _coefList) _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
-    _sentry.deps().removeAll();
-    _sentry.addVars(_coefList);
-    _sentry.setValueDirty();
-    _init = false;
-    return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+                                                        bool mustReplaceAll,
+                                                        bool nameChange,
+                                                        bool isRecursiveStep) {
+  // _coefList has already been re-pointed at the new servers,
+  // but _morphParams and _sentry still refer to the old coefficient objects.
+  // Re-point both, and mark the cache dirty so the next evaluate() re-runs syncTotal().
+  _morphParams.resize(_coefList.getSize());
+  int i = 0;
+  for (RooAbsArg *a : _coefList)
+    _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
+  _sentry.deps().removeAll();
+  _sentry.addVars(_coefList);
+  _sentry.setValueDirty();
+  _init = false;
+  return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
 }
 
 //_____________________________________________________________________________
@@ -785,18 +785,21 @@ Bool_t FastVerticalInterpHistPdf2Base::importWorkspaceHook(RooWorkspace& ws) {
 }
 
 bool FastVerticalInterpHistPdf2Base::redirectServersHook(const RooAbsCollection &newServerList,
-                                                        bool mustReplaceAll, bool nameChange,
-                                                        bool isRecursiveStep)
-{
-    _morphParams.resize(_coefList.getSize());
-    int i = 0;
-    for (RooAbsArg *a : _coefList) _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
-    _sentry.deps().removeAll();
-    _sentry.addVars(_coefList);
-    _sentry.setValueDirty();
-    return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+                                                         bool mustReplaceAll,
+                                                         bool nameChange,
+                                                         bool isRecursiveStep) {
+  // _coefList has already been re-pointed at the new servers,
+  // but _morphParams and _sentry still refer to the old coefficient objects.
+  // Re-point both, and mark the cache dirty so the next evaluate() re-runs syncTotal().
+  _morphParams.resize(_coefList.getSize());
+  int i = 0;
+  for (RooAbsArg *a : _coefList)
+    _morphParams[i++] = dynamic_cast<RooAbsReal *>(a);
+  _sentry.deps().removeAll();
+  _sentry.addVars(_coefList);
+  _sentry.setValueDirty();
+  return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
 }
-
 
 //_____________________________________________________________________________
 FastVerticalInterpHistPdf2Base::~FastVerticalInterpHistPdf2Base()


### PR DESCRIPTION
Copying a workspace and then changing a copy's parameters doesn't always work for `FastVerticalInterpHistPdf` and `FastVerticalInterpHistPdf2`. Depending on the class and how the copy was made, `_morphParams` and/or `_sentry` can
still refer to the original workspace's objects, so the copy stops responding to its own parameters. The fix adds `redirectServersHook` to both base classes to re-point these on redirect, plus one related fix in `FastVerticalInterpHistPdf2Base::initBase()` (it appended fresh coefficient pointers without clearing stale ones first).

Tested by creating two workspaces that use `FastVerticalInterpHistPdf` and `FastVerticalInterpHistPdf2`
```py
import ROOT

ROOT.gROOT.SetBatch(True)
ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit")
ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.ERROR)

x = ROOT.RooRealVar("x", "x", 0.0, 4.0)
x.setBins(4)
theta = ROOT.RooRealVar("theta", "theta", 0.0, -5.0, 5.0)


TEMPLATES = (("nom", 0.0), ("up", 0.6), ("dn", -0.2))


def th1(tag, ramp):
    h = ROOT.TH1F("h_" + tag, "", 4, 0.0, 4.0)
    for i in range(1, 5):
        h.SetBinContent(i, 1.0 + ramp * i)
    return h


hists = [th1(tag, ramp) for tag, ramp in TEMPLATES]

# --- v1  ---------------

keep = [] # RooArgList stores bare pointers and RooHistPdf does not clone its RooDataHist, so these must stay alive in python until w.import() copies them.
pdfs = ROOT.RooArgList()
for h, (tag, _) in zip(hists, TEMPLATES):
    dh = ROOT.RooDataHist("dh_" + tag, "", ROOT.RooArgList(x), h)
    p = ROOT.RooHistPdf("p_" + tag, "", ROOT.RooArgSet(x), dh)
    keep.extend([dh, p])
    pdfs.add(p)
morph_v1 = ROOT.FastVerticalInterpHistPdf("morph_v1", "", x, pdfs,
                                          ROOT.RooArgList(theta), 1.0, 1)

# --- v2  ------------------------------
tlist = ROOT.TList()
for h in hists:
    tlist.Add(h)
morph_v2 = ROOT.FastVerticalInterpHistPdf2("morph_v2", "", x, tlist,
                                           ROOT.RooArgList(theta), 1.0, 1)

w = ROOT.RooWorkspace("w")
getattr(w, "import")(morph_v1)
getattr(w, "import")(morph_v2)
w.writeToFile("demo_ws.root")

print("wrote demo_ws.root")
for name in ("morph_v1", "morph_v2"):
    print("   %-9s -> %s" % (name, w.pdf(name).ClassName()))

```

We then read the workspace, copy it, change the value of theta, and print the value of the first bin. 

Combine v11.0.0
```
pdf value in bin 1, original workspace held at theta = 0

  class                        copy         -1.0        0.0        1.0        2.0
  ------------------------------------------------------------------------------
  FastVerticalInterpHistPdf    correct       0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf2   correct       0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf    cold         0.25       0.25       0.25       0.25
  FastVerticalInterpHistPdf2   cold         0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf    warm         0.25       0.25       0.25       0.25
  FastVerticalInterpHistPdf2   warm         0.25       0.25       0.25       0.25
```

With PR-proposed fix:
```
pdf value in bin 1, original workspace held at theta = 0

  class                        copy         -1.0        0.0        1.0        2.0
  ------------------------------------------------------------------------------
  FastVerticalInterpHistPdf    correct       0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf2   correct       0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf    cold         0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf2   cold         0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf    warm         0.40       0.25       0.16       0.07
  FastVerticalInterpHistPdf2   warm         0.40       0.25       0.16       0.07
```

The evaluation script is pasted below:
```py
import os
import sys
import ROOT

ROOT.gROOT.SetBatch(True)
ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit")
ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.ERROR)

PDFS = ("morph_v1", "morph_v2")
THETAS = (-1.0, 0.0, 1.0, 2.0)


def value(ws, pdf, t):
    # pdf value in bin 1, after setting workspace's theta = t
    ws.var("theta").setVal(t)
    ws.var("x").setVal(0.5)    # 0.5 is the centre of bin 1; x in [0,4] with 4 bins
    return ws.pdf(pdf).getVal()


def reference():
    # what the morphing should give measured on non-copied workspace
    f = ROOT.TFile.Open("demo_ws.root")
    w = f.Get("w")
    out = {p: [value(w, p, t) for t in THETAS] for p in PDFS}
    f.Close()
    return out


def copied(warm):
    # scan the copied workspace's  theta, with the original workspace's theta left at 0
    # warm parameter runs evaluation of original workspace before copying
    f = ROOT.TFile.Open("demo_ws.root")
    original = f.Get("w")
    if warm:
        for p in PDFS:  # evaluate before copying
            value(original, p, 0.0)
    copy = ROOT.RooWorkspace(original)
    original.var("theta").setVal(0.0)
    for p in PDFS: # pin the copy at theta = 0 too
        value(copy, p, 0.0)
    out = {p: [value(copy, p, t) for t in THETAS] for p in PDFS}
    f.Close()
    return out


ref = reference()
classes = {}
f = ROOT.TFile.Open("demo_ws.root")
for p in PDFS:
    classes[p] = f.Get("w").pdf(p).ClassName()
f.Close()

print("combine build : %s" % os.environ.get("CMSSW_BASE", "?"))
print()
print("pdf value in bin 1, original workspace held at theta = 0")
print()
hdr = "  ".join("%9.1f" % t for t in THETAS)
print("  %-28s %-6s  %s" % ("class", "copy", hdr))
print("  " + "-" * (28 + 8 + len(hdr)))
for p in PDFS:
    print("  %-28s %-6s  %s" % (classes[p], "correct",
                                "  ".join("%9.2f" % v for v in ref[p])))
for warm in (False, True):
    got = copied(warm)
    for p in PDFS:
        print("  %-28s %-6s  %s"
              % (classes[p], "warm" if warm else "cold",
                 "  ".join("%9.2f" % v for v in got[p])))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when histogram-based probability models are copied or their parameters are redirected.
  * Ensured models continue responding correctly to updated coefficient values after workspace operations.
  * Improved parameter synchronization and recalculation following server changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->